### PR TITLE
Export LogApi as LogRaw

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * as NodeRaw from './api/NodeApi';
 // one place where the cli needs to execute an oauth flow.
 export * as OAuth2OIDCApi from './api/OAuth2OIDCApi';
 export * as SecretsRaw from './api/cloud/SecretsApi';
+export * as LogRaw from './api/cloud/LogApi';
 export * as SocialIdentityProvidersRaw from './api/SocialIdentityProvidersApi';
 export * as StartupRaw from './api/cloud/StartupApi';
 export * as TreeRaw from './api/TreeApi';


### PR DESCRIPTION
This pull request simply add a new export to allow access to the log API.
It's needed in our case to be able to ingest logs directly from a JS program without having to reparse frodo-cli logs output.