### PR TITLE
Add alternative way to call PutVariable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,3 +60,6 @@ export * as ExportImportUtils from './ops/utils/ExportImportUtils';
 // lib should be stateless, an aplication should own its state
 export * as state from './shared/State';
 export * as constants from './storage/StaticStorage';
+// as an escape hatch for those using the FRODO library
+// to call APIs directly
+export * as BaseApiRaw from './api/BaseApi';


### PR DESCRIPTION
A possible fix for #272 - assuming that frodo-cli adopts the new function.

This allows the `expressionType` to be provided.

I've also opened up some escape hatches which were not possible when we were trying to create an alternative `putVariable` away from changing the core code. It makes sense that client code should be able to call these APIs in a similar but different way and get the benefit of all the Axios client building etc.