### PR TITLE
Add ability to delete scripts

### DIFF
--- a/src/ops/ScriptOps.test.ts
+++ b/src/ops/ScriptOps.test.ts
@@ -469,4 +469,41 @@ describe('ScriptOps', () => {
       expect(outcome).toBeTruthy();
     });
   });
+
+  describe('deleteScript()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ScriptOps.deleteScript).toBeDefined();
+    });
+
+    test(`1: delete script by id`, async () => {
+      expect.assertions(1);
+      const outcome = await ScriptOps.deleteScript({scriptId: script1.id, state});
+      expect(outcome).toBeTruthy();
+    });
+  });
+
+  describe('deleteScriptByName()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ScriptOps.deleteScriptByName).toBeDefined();
+    });
+
+    test(`1: delete script by name`, async () => {
+      expect.assertions(1);
+      const outcome = await ScriptOps.deleteScriptByName({scriptName: script2.name, state});
+      expect(outcome).toBeTruthy();
+    });
+  });
+
+  describe('deleteScripts()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ScriptOps.deleteScripts).toBeDefined();
+    });
+
+    //TODO: Generate mock for this test (skip for meantime)
+    test.skip(`1: delete all scripts`, async () => {
+      expect.assertions(1);
+      const outcome = await ScriptOps.deleteScripts({state});
+      expect(outcome).toBeTruthy();
+    });
+  });
 });

--- a/src/ops/ScriptOps.ts
+++ b/src/ops/ScriptOps.ts
@@ -2,6 +2,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 import {
   deleteScript as _deleteScript,
+  deleteScriptByName as _deleteScriptByName,
+  deleteScripts as _deleteScripts,
   getScript as _getScript,
   getScriptByName as _getScriptByName,
   getScripts as _getScripts,
@@ -77,6 +79,17 @@ export type Script = {
    * @returns {Promise<ScriptSkeleton>} promise that resolves to a script object
    */
   deleteScript(scriptId: string): Promise<ScriptSkeleton>;
+  /**
+   * Delete script by name
+   * @param {String} scriptId script name
+   * @returns {Promise<ScriptSkeleton>} a promise that resolves to a script object
+   */
+  deleteScriptByName(scriptName: string): Promise<ScriptSkeleton>;
+  /**
+   * Delete all non-default scripts
+   * @returns {Promise<ScriptSkeleton[]>>} a promise that resolves to an array of script objects
+   */
+  deleteScripts(): Promise<ScriptSkeleton[]>;
   /**
    * Export all scripts
    * @returns {Promise<ScriptExportInterface>} a promise that resolved to a ScriptExportInterface object
@@ -189,6 +202,12 @@ export default (state: State): Script => {
     },
     async deleteScript(scriptId: string): Promise<ScriptSkeleton> {
       return deleteScript({ scriptId, state });
+    },
+    async deleteScriptByName(scriptName: string): Promise<ScriptSkeleton> {
+      return deleteScriptByName({ scriptName, state });
+    },
+    async deleteScripts(): Promise<ScriptSkeleton[]> {
+      return deleteScripts({ state });
     },
     async exportScript(scriptId: string): Promise<ScriptExportInterface> {
       return exportScript({ scriptId, state });
@@ -391,6 +410,33 @@ export async function deleteScript({
   state: State;
 }): Promise<ScriptSkeleton> {
   return _deleteScript({ scriptId, state });
+}
+
+/**
+ * Delete script by name
+ * @param {String} scriptId script name
+ * @returns {Promise<ScriptSkeleton>} a promise that resolves to a script object
+ */
+export async function deleteScriptByName({
+  scriptName,
+  state,
+}: {
+  scriptName: string;
+  state: State;
+}): Promise<ScriptSkeleton> {
+  return _deleteScriptByName({ scriptName, state });
+}
+
+/**
+ * Delete all non-default scripts
+ * @returns {Promise<ScriptSkeleton[]>>} a promise that resolves to an array of script objects
+ */
+export async function deleteScripts({
+  state,
+}: {
+  state: State;
+}): Promise<ScriptSkeleton[]> {
+  return _deleteScripts({ state });
 }
 
 /**

--- a/src/test/mock-recordings/ScriptOps_3024995978/deleteScriptByName_571993320/1-delete-script-by-name_2688005936/recording.har
+++ b/src/test/mock-recordings/ScriptOps_3024995978/deleteScriptByName_571993320/1-delete-script-by-name_2688005936/recording.har
@@ -1,0 +1,297 @@
+{
+  "log": {
+    "_recordingName": "ScriptOps/deleteScriptByName()/1: delete script by name",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "a8164adca1e0bf44ebac017fc5d0f3eb",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-27"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ee96d45c-53fa-47c1-826f-a7fa93acec65"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer eyJ0eXAiOiJKV1QiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiZGlyIn0..rJeuF3EnnVbE69gg9OUdsg.krFoGTo0Ijtz5pHSZ0MU-r0KhlOwLP6yi-ggAJUxhT03J_rcka8ckxc8KrDH3eqBY43rJJFw10-e03yaLQw31sm9oo8qmna3wpQjuUHhrD2iWGDfA0SXDeRNwg-jz47IbfKaKMb2g664qKZrrGt_XAv1jS6mMoa6drnlud5KDkC65Ad80SicDFB6J1HeG2qyR98yf15b-p9_Ruq1dUNYvHk3WPq6qDL2no3I0q-R5V8Y7F6SppivopRDgHt_Dhhba_CS-txICMub5LB4XqXRmakMPVEXzyoZjbUFSkRDhdyPjvk5NJps5e6jiCHzaMqFbYg6HtM4gupPL0byaeNjGiZD69wgIlF27YSfbJx6WG0gvBLwOqXMY5oXYif2i1koibIwvLAxCgLRrsAE4KeYw1S1Ftu__GMA0F7YQ-QVso1nJm5wBwgzW-OjrqMZq9_ntpqpuubnWsDQ6sB8Toajv1Gjg_7pXupzEfTqg6FfkgqG-I3q0VsM2BesKuJswsrfJum76ENksV_zf4s1FLV-o0LNwWsQzRBW-Pz66iQKqciBpJS4D3zvIcsR5siDfyRqfgfrVaaX1z6dg5pQ7eAr_s5kQ1q336e74ts6qYx_RM46HEpYlbQ5_g2D7dBxu-6U_2L1A7efbN8DcnJHvc-0ZpXDC2-wkEHfpmwbt61wKypzwJSC3rgnCTHNfzyMBGvtuf5vA0gr2df8SbFjIyO5a2w4fiCApPjduvTC5z65omop5hbg4D8CtjADLatrNybmV-xaWkgb0WeqRXkLIJ_nzvJ9v83XEiyW_Coy-WDgPirrbOK6MnvsOe37LS1RUByc-30T4lKPR_m72ugU0THBKFEzYgQND0-tmyXEJFScxMYOMxKDcp2hNx2Tz1AjG1jR_hIeGIeIgavk8ww2uYLSRcfM9smb7VBp2XCMq2tEWEK5j_0D7jMgrLXonpFfGVU3dXOS0g2p52pID1pcF29xokNS52Hulw8VBrItd4Jhcup_FKqrXKNubdVo4KF8WXd3vgW_FPu5y3stY0YCur1VaCplkRiFaBX9ddHhLKtGFM8.pVbT9DpYjlNT4zaT0Hz-7Q"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1627,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "name eq \"FrodoTestScript2\""
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts?_queryFilter=name%20eq%20%22FrodoTestScript2%22"
+        },
+        "response": {
+          "bodySize": 1106,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1106,
+            "text": "{\"result\":[{\"_id\":\"b7259916-71ed-4675-8c5a-de86a80e4aed\",\"name\":\"FrodoTestScript2\",\"description\":\"Check if username has already been collected.\",\"script\":\"LyogQ2hlY2sgVXNlcm5hbWUKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogQ2hlY2sgaWYgdXNlcm5hbWUgaGFzIGFscmVhZHkgYmVlbiBjb2xsZWN0ZWQuCiAqIFJldHVybiAia25vd24iIGlmIHllcywgInVua25vd24iIG90aGVyd2lzZS4KICogCiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuCiAqIAogKiBUaGUgU2NyaXB0ZWQgRGVjaXNpb24gTm9kZSBuZWVkcyB0aGUgZm9sbG93aW5nIG91dGNvbWVzIGRlZmluZWQ6CiAqIC0ga25vd24KICogLSB1bmtub3duCiAqLwooZnVuY3Rpb24gKCkgewogICAgaWYgKG51bGwgIT0gc2hhcmVkU3RhdGUuZ2V0KCJ1c2VybmFtZSIpKSB7CiAgICAgICAgb3V0Y29tZSA9ICJrbm93biI7CiAgICB9CiAgICBlbHNlIHsKICAgICAgICBvdXRjb21lID0gInVua25vd24iOwogICAgfQp9KCkpOw==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "script-src 'self' 'unsafe-eval' 'unsafe-inline'; frame-ancestors 'self'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.1, resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1106"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 10 Aug 2023 18:20:28 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ee96d45c-53fa-47c1-826f-a7fa93acec65"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 774,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-08-10T18:20:29.202Z",
+        "time": 82,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 82
+        }
+      },
+      {
+        "_id": "eed272dd3e29e95492bb70aa4a91fd23",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-27"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ee96d45c-53fa-47c1-826f-a7fa93acec65"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer eyJ0eXAiOiJKV1QiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiZGlyIn0..rJeuF3EnnVbE69gg9OUdsg.krFoGTo0Ijtz5pHSZ0MU-r0KhlOwLP6yi-ggAJUxhT03J_rcka8ckxc8KrDH3eqBY43rJJFw10-e03yaLQw31sm9oo8qmna3wpQjuUHhrD2iWGDfA0SXDeRNwg-jz47IbfKaKMb2g664qKZrrGt_XAv1jS6mMoa6drnlud5KDkC65Ad80SicDFB6J1HeG2qyR98yf15b-p9_Ruq1dUNYvHk3WPq6qDL2no3I0q-R5V8Y7F6SppivopRDgHt_Dhhba_CS-txICMub5LB4XqXRmakMPVEXzyoZjbUFSkRDhdyPjvk5NJps5e6jiCHzaMqFbYg6HtM4gupPL0byaeNjGiZD69wgIlF27YSfbJx6WG0gvBLwOqXMY5oXYif2i1koibIwvLAxCgLRrsAE4KeYw1S1Ftu__GMA0F7YQ-QVso1nJm5wBwgzW-OjrqMZq9_ntpqpuubnWsDQ6sB8Toajv1Gjg_7pXupzEfTqg6FfkgqG-I3q0VsM2BesKuJswsrfJum76ENksV_zf4s1FLV-o0LNwWsQzRBW-Pz66iQKqciBpJS4D3zvIcsR5siDfyRqfgfrVaaX1z6dg5pQ7eAr_s5kQ1q336e74ts6qYx_RM46HEpYlbQ5_g2D7dBxu-6U_2L1A7efbN8DcnJHvc-0ZpXDC2-wkEHfpmwbt61wKypzwJSC3rgnCTHNfzyMBGvtuf5vA0gr2df8SbFjIyO5a2w4fiCApPjduvTC5z65omop5hbg4D8CtjADLatrNybmV-xaWkgb0WeqRXkLIJ_nzvJ9v83XEiyW_Coy-WDgPirrbOK6MnvsOe37LS1RUByc-30T4lKPR_m72ugU0THBKFEzYgQND0-tmyXEJFScxMYOMxKDcp2hNx2Tz1AjG1jR_hIeGIeIgavk8ww2uYLSRcfM9smb7VBp2XCMq2tEWEK5j_0D7jMgrLXonpFfGVU3dXOS0g2p52pID1pcF29xokNS52Hulw8VBrItd4Jhcup_FKqrXKNubdVo4KF8WXd3vgW_FPu5y3stY0YCur1VaCplkRiFaBX9ddHhLKtGFM8.pVbT9DpYjlNT4zaT0Hz-7Q"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1619,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/b7259916-71ed-4675-8c5a-de86a80e4aed"
+        },
+        "response": {
+          "bodySize": 46,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 46,
+            "text": "{\"_id\":\"b7259916-71ed-4675-8c5a-de86a80e4aed\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "script-src 'self' 'unsafe-eval' 'unsafe-inline'; frame-ancestors 'self'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "46"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 10 Aug 2023 18:20:28 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ee96d45c-53fa-47c1-826f-a7fa93acec65"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 745,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-08-10T18:20:29.291Z",
+        "time": 69,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 69
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/ScriptOps_3024995978/deleteScript_3257550726/1-delete-script-by-id_2302622086/recording.har
+++ b/src/test/mock-recordings/ScriptOps_3024995978/deleteScript_3257550726/1-delete-script-by-id_2302622086/recording.har
@@ -1,0 +1,153 @@
+{
+  "log": {
+    "_recordingName": "ScriptOps/deleteScript()/1: delete script by id",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "0d12c9b8f93a5a6c1387aed86b41fb71",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-27"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ee96d45c-53fa-47c1-826f-a7fa93acec65"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer eyJ0eXAiOiJKV1QiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiZGlyIn0..rJeuF3EnnVbE69gg9OUdsg.krFoGTo0Ijtz5pHSZ0MU-r0KhlOwLP6yi-ggAJUxhT03J_rcka8ckxc8KrDH3eqBY43rJJFw10-e03yaLQw31sm9oo8qmna3wpQjuUHhrD2iWGDfA0SXDeRNwg-jz47IbfKaKMb2g664qKZrrGt_XAv1jS6mMoa6drnlud5KDkC65Ad80SicDFB6J1HeG2qyR98yf15b-p9_Ruq1dUNYvHk3WPq6qDL2no3I0q-R5V8Y7F6SppivopRDgHt_Dhhba_CS-txICMub5LB4XqXRmakMPVEXzyoZjbUFSkRDhdyPjvk5NJps5e6jiCHzaMqFbYg6HtM4gupPL0byaeNjGiZD69wgIlF27YSfbJx6WG0gvBLwOqXMY5oXYif2i1koibIwvLAxCgLRrsAE4KeYw1S1Ftu__GMA0F7YQ-QVso1nJm5wBwgzW-OjrqMZq9_ntpqpuubnWsDQ6sB8Toajv1Gjg_7pXupzEfTqg6FfkgqG-I3q0VsM2BesKuJswsrfJum76ENksV_zf4s1FLV-o0LNwWsQzRBW-Pz66iQKqciBpJS4D3zvIcsR5siDfyRqfgfrVaaX1z6dg5pQ7eAr_s5kQ1q336e74ts6qYx_RM46HEpYlbQ5_g2D7dBxu-6U_2L1A7efbN8DcnJHvc-0ZpXDC2-wkEHfpmwbt61wKypzwJSC3rgnCTHNfzyMBGvtuf5vA0gr2df8SbFjIyO5a2w4fiCApPjduvTC5z65omop5hbg4D8CtjADLatrNybmV-xaWkgb0WeqRXkLIJ_nzvJ9v83XEiyW_Coy-WDgPirrbOK6MnvsOe37LS1RUByc-30T4lKPR_m72ugU0THBKFEzYgQND0-tmyXEJFScxMYOMxKDcp2hNx2Tz1AjG1jR_hIeGIeIgavk8ww2uYLSRcfM9smb7VBp2XCMq2tEWEK5j_0D7jMgrLXonpFfGVU3dXOS0g2p52pID1pcF29xokNS52Hulw8VBrItd4Jhcup_FKqrXKNubdVo4KF8WXd3vgW_FPu5y3stY0YCur1VaCplkRiFaBX9ddHhLKtGFM8.pVbT9DpYjlNT4zaT0Hz-7Q"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1619,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/c9cb4b1e-1cd3-4e5b-8f56-140f83ba9f6d"
+        },
+        "response": {
+          "bodySize": 46,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 46,
+            "text": "{\"_id\":\"c9cb4b1e-1cd3-4e5b-8f56-140f83ba9f6d\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "script-src 'self' 'unsafe-eval' 'unsafe-inline'; frame-ancestors 'self'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "46"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 10 Aug 2023 18:20:28 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ee96d45c-53fa-47c1-826f-a7fa93acec65"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 745,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-08-10T18:20:29.121Z",
+        "time": 67,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 67
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
Adds the ability to delete scripts. Since default scripts cannot be deleted, they get skipped when deleting all scripts. Also, tests for deleting all scripts currently have no mocks for them since creating mocks for them may end up deleting important scripts, so they are being skipped for now. This PR is needed for the PR in frodo-cli named "Add ability to delete scripts".