### PR TITLE
fixes #397 - Service accounts now use the proper scopes when created …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   \#397: Service accounts now use the proper scopes when created using the `frodo conn save` command
+
 ## [2.0.0-74] - 2024-03-23
 
 ### Fixed

--- a/src/ops/ConnectionProfileOps.ts
+++ b/src/ops/ConnectionProfileOps.ts
@@ -496,6 +496,7 @@ export async function saveConnectionProfile({
       );
     }
     if (
+      state.getUseBearerTokenForAmApis() &&
       state.getBearerTokenMeta() &&
       state.getBearerTokenMeta().scope !== profile.svcacctScope
     ) {


### PR DESCRIPTION
…using the `frodo conn save` command