### PR TITLE
Command Refactor: Update Mock Naming

### DIFF
--- a/src/utils/SetupPollyForFrodoLib.ts
+++ b/src/utils/SetupPollyForFrodoLib.ts
@@ -184,7 +184,32 @@ function getFrodoCommand({ state }: { state: State }) {
         '/' +
         getFrodoArgsId({ start: 2, state });
     } else {
-      cmd = process.argv[2] + '/' + getFrodoArgsId({ start: 3, state });
+      cmd = process.argv[2] + '/';
+      let i = 3;
+      if (cmd === 'info/') {
+        cmd += getFrodoArgsId({ start: 3, state });
+      } else {
+        if (
+          process.argv[i] === 'export' ||
+          process.argv[i] === 'import' ||
+          process.argv[i] === 'list' ||
+          process.argv[i] === 'delete' ||
+          process.argv[i] === 'count' ||
+          process.argv[i] === 'describe' ||
+          process.argv[i] === 'enable' ||
+          process.argv[i] === 'disable'
+        ) {
+          cmd += process.argv[i++] + '/';
+        }
+        let firstParamIndex = process.argv.findIndex((a) => a.startsWith('-'));
+        firstParamIndex =
+          firstParamIndex === -1 ? process.argv.length : firstParamIndex;
+        cmd += process.argv.slice(i, firstParamIndex).join('-');
+        if (!cmd.endsWith('/')) {
+          cmd += '/';
+        }
+        cmd += getFrodoArgsId({ start: firstParamIndex, state });
+      }
     }
   } catch (error) {
     printMessage({


### PR DESCRIPTION
This PR is to get the tests passing for the Commander Refactor PR on frodo-cli. After the refactor in frodo-cli, e2e tests in frodo-cli were failing due to mock naming no longer working as it once did, so I updated the naming code so that the tests will pass without having to update the mocks or snapshots again. However, this fix should be only temporary since it was made to just get the tests passing. Eventually we will want to change this, either back to how it was before or change how we handle the naming entirely depending on how we want it to work, but either way we will have to likely re-update many if not all the mocks.