### PR TITLE
Improve MappingOps

### DIFF
--- a/src/ops/MappingOps.test.ts
+++ b/src/ops/MappingOps.test.ts
@@ -1,0 +1,415 @@
+/**
+ * To record and update snapshots, you must perform 3 steps in order:
+ *
+ * 1. Record API responses
+ *
+ *    To record API responses, you must call the test:record script and
+ *    override all the connection state required to connect to the
+ *    env to record from:
+ *
+ *    ATTENTION: For the recording to succeed, you MUST make sure to use a
+ *               user account, not a service account.
+ *
+ *        FRODO_DEBUG=1 FRODO_HOST=frodo-dev npm run test:record MappingOps
+ *
+ *    The above command assumes that you have a connection profile for
+ *    'frodo-dev' on your development machine.
+ *
+ * 2. Update snapshots
+ *
+ *    After recording API responses, you must manually update/create snapshots
+ *    by running:
+ *
+ *        FRODO_DEBUG=1 npm run test:update MappingOps
+ *
+ * 3. Test your changes
+ *
+ *    If 1 and 2 didn't produce any errors, you are ready to run the tests in
+ *    replay mode and make sure they all succeed as well:
+ *
+ *        FRODO_DEBUG=1 npm run test:only MappingOps
+ *
+ * Note: FRODO_DEBUG=1 is optional and enables debug logging for some output
+ * in case things don't function as expected
+ */
+import { autoSetupPolly, filterRecording } from "../utils/AutoSetupPolly";
+import * as MappingOps from "./MappingOps";
+import {state} from "../lib/FrodoLib";
+import { MappingSkeleton} from "./MappingOps";
+
+const ctx = autoSetupPolly();
+
+async function stageMapping(
+  mapping: MappingSkeleton,
+  create = true
+) {
+  // delete if exists, then create
+  try {
+    await MappingOps.readMapping({
+      mappingId: mapping._id,
+      state
+    });
+    await MappingOps.deleteMapping({
+      mappingId: mapping._id,
+      state,
+    });
+  } catch (error) {
+    // ignore
+  } finally {
+    if (create) {
+      await MappingOps.createMapping({
+        mappingId: mapping._id,
+        mappingData: mapping,
+        state
+      });
+    }
+  }
+}
+
+function makeSimpleTestMapping(i: number, type: string): MappingSkeleton {
+  return {
+    _id: `${type}/mapping${i}`,
+    name: `mapping${i}`,
+    displayName: `mapping${i}`,
+    linkQualifiers: [],
+    consentRequired: false,
+    policies: [],
+    properties: [],
+    source: 'managed/bravo_user',
+    target: 'managed/bravo_user',
+    syncAfter: [],
+  };
+}
+
+const SYNC = 'sync';
+const MAPPING = 'mapping';
+
+describe('MappingOps', () => {
+
+  // Mappings for read/export tests
+  const mapping1: MappingSkeleton = {
+    _id: 'sync/mapping1',
+    name: 'mapping1',
+    displayName: 'mapping1',
+    linkQualifiers: [],
+    consentRequired: false,
+    policies: [],
+    properties: [],
+    source: 'system/connector1/bravo_user',
+    target: 'system/connector1/bravo_user',
+    syncAfter: [],
+  };
+  const mapping2: MappingSkeleton = makeSimpleTestMapping(2, MAPPING);
+  // Mappings for create tests
+  const mapping3: MappingSkeleton = makeSimpleTestMapping(3, SYNC);
+  const mapping4: MappingSkeleton = makeSimpleTestMapping(4, MAPPING);
+  // Mappings for import tests
+  const mapping5: MappingSkeleton = makeSimpleTestMapping(5, SYNC);
+  const mapping6: MappingSkeleton = makeSimpleTestMapping(6, MAPPING);
+  // Mappings for import first tests
+  const mapping7: MappingSkeleton = makeSimpleTestMapping(7, SYNC);
+  const mapping8: MappingSkeleton = makeSimpleTestMapping(8, MAPPING);
+  // Mappings for import all tests
+  const mapping9: MappingSkeleton = makeSimpleTestMapping(9, SYNC);
+  const mapping10: MappingSkeleton = makeSimpleTestMapping(10, MAPPING);
+  // Mappings for update tests
+  const mapping11: MappingSkeleton = makeSimpleTestMapping(11, SYNC);
+  const mapping12: MappingSkeleton = makeSimpleTestMapping(12, MAPPING);
+
+  // in recording mode, setup test data before recording
+  beforeAll(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      await stageMapping(mapping1);
+      await stageMapping(mapping2);
+      await stageMapping(mapping3, false);
+      await stageMapping(mapping4, false);
+      await stageMapping(mapping5, false);
+      await stageMapping(mapping6, false);
+      await stageMapping(mapping7, false);
+      await stageMapping(mapping8, false);
+      await stageMapping(mapping9, false);
+      await stageMapping(mapping10, false);
+      await stageMapping(mapping11);
+      await stageMapping(mapping12);
+    }
+  });
+  // in recording mode, remove test data after recording
+  afterAll(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      await stageMapping(mapping1, false);
+      await stageMapping(mapping2, false);
+      await stageMapping(mapping3, false);
+      await stageMapping(mapping4, false);
+      await stageMapping(mapping5, false);
+      await stageMapping(mapping6, false);
+      await stageMapping(mapping7, false);
+      await stageMapping(mapping8, false);
+      await stageMapping(mapping9, false);
+      await stageMapping(mapping10, false);
+      await stageMapping(mapping11);
+      await stageMapping(mapping12);
+    }
+  });
+
+  beforeEach(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      ctx.polly.server.any().on('beforePersist', (_req, recording) => {
+        filterRecording(recording);
+      });
+    }
+  });
+
+  describe('createMappingExportTemplate()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.createMappingExportTemplate).toBeDefined();
+    });
+
+    test('1: Create Mapping Export Template', async () => {
+      const response = MappingOps.createMappingExportTemplate({ state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+  });
+
+  describe('readSyncMappings()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.readSyncMappings).toBeDefined();
+    });
+
+    test('1: Read sync mappings', async () => {
+      const response = await MappingOps.readSyncMappings({ state });
+      expect(response).toMatchSnapshot();
+    });
+  });
+
+  describe('readNewMappings()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.readNewMappings).toBeDefined();
+    });
+
+    test('1: Read new mappings', async () => {
+      const response = await MappingOps.readNewMappings({ state });
+      expect(response).toMatchSnapshot();
+    });
+  });
+
+  describe('readMappings()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.readMappings).toBeDefined();
+    });
+
+    test('1: Read mappings', async () => {
+      const response = await MappingOps.readMappings({ state });
+      expect(response).toMatchSnapshot();
+    });
+  });
+
+  describe('readMapping()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.readMapping).toBeDefined();
+    });
+
+    test('1: Should read sync mapping', async () => {
+      expect(await MappingOps.readMapping({
+        mappingId: mapping1._id,
+        state
+      })).toMatchSnapshot();
+    });
+
+    test('2: Should read regular mapping', async () => {
+      expect(await MappingOps.readMapping({
+        mappingId: mapping2._id,
+        state
+      })).toMatchSnapshot();
+    });
+  });
+
+  describe('createMapping()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.createMapping).toBeDefined();
+    });
+
+    test('1: Should create sync mapping', async () => {
+      expect(await MappingOps.createMapping({
+        mappingId: mapping3._id,
+        mappingData: mapping3,
+        state
+      })).toMatchSnapshot();
+    });
+
+    test('2: Should create regular mapping', async () => {
+      expect(await MappingOps.createMapping({
+        mappingId: mapping4._id,
+        mappingData: mapping4,
+        state
+      })).toMatchSnapshot();
+    });
+  });
+
+  describe('updateMapping()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.updateMapping).toBeDefined();
+    });
+
+    test('1: Should update sync mapping', async () => {
+      expect(await MappingOps.updateMapping({
+        mappingId: mapping11._id,
+        mappingData: {...mapping11, consentRequired: true, },
+        state
+      })).toMatchSnapshot();
+    });
+
+    test('2: Should update regular mapping', async () => {
+      expect(await MappingOps.updateMapping({
+        mappingId: mapping12._id,
+        mappingData: {...mapping12, consentRequired: true, },
+        state
+      })).toMatchSnapshot();
+    });
+  });
+
+  describe('exportMapping()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.exportMapping).toBeDefined();
+    });
+
+    test('1: Should export sync mapping', async () => {
+      expect(await MappingOps.exportMapping({
+        mappingId: mapping1._id,
+        options: {
+          useStringArrays: false,
+          deps: false,
+          connectorId: 'connector1',
+          moType: undefined
+        },
+        state
+      })).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+
+    test('2: Should export regular mapping', async () => {
+      expect(await MappingOps.exportMapping({
+        mappingId: mapping2._id,
+        options: {
+          useStringArrays: true,
+          deps: true,
+          connectorId: undefined,
+          moType: 'bravo_user'
+        },
+        state
+      })).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+  });
+
+  describe('exportMappings()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.exportMappings).toBeDefined();
+    });
+
+    test('1: Export mappings', async () => {
+      const response = await MappingOps.exportMappings({ state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+  });
+
+  describe('importMapping()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.importMapping).toBeDefined();
+    });
+
+    test('1: Should import sync mapping', async () => {
+      const importData = MappingOps.createMappingExportTemplate({ state });
+      importData.sync.mappings.push(mapping5);
+      expect(await MappingOps.importMapping({
+        mappingId: mapping5._id,
+        importData,
+        options: {
+          deps: false,
+        },
+        state
+      })).toMatchSnapshot();
+    });
+
+    test('2: Should import regular mapping', async () => {
+      const importData = MappingOps.createMappingExportTemplate({ state });
+      importData.mapping[mapping6._id] = mapping6;
+      expect(await MappingOps.importMapping({
+        mappingId: mapping6._id,
+        importData,
+        options: {
+          deps: false,
+        },
+        state
+      })).toMatchSnapshot();
+    });
+  });
+
+  describe('importFirstMapping()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.importFirstMapping).toBeDefined();
+    });
+
+    test('1: Should import first sync mapping', async () => {
+      const importData = MappingOps.createMappingExportTemplate({ state });
+      importData.sync.mappings.push(mapping7);
+      importData.mapping[mapping8._id] = mapping8;
+      expect(await MappingOps.importFirstMapping({
+        importData,
+        state
+      })).toMatchSnapshot();
+    });
+
+    test('2: Should import first regular mapping', async () => {
+      const importData = MappingOps.createMappingExportTemplate({ state });
+      importData.mapping[mapping8._id] = mapping8;
+      importData.mapping[mapping7._id] = mapping7;
+      expect(await MappingOps.importFirstMapping({
+        importData,
+        state
+      })).toMatchSnapshot();
+    });
+  });
+
+  describe('importMappings()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.importMappings).toBeDefined();
+    });
+
+    test('1: Should import mappings', async () => {
+      const importData = MappingOps.createMappingExportTemplate({ state });
+      importData.sync.mappings.push(mapping9);
+      importData.mapping[mapping10._id] = mapping10;
+      expect(await MappingOps.importMappings({
+        importData,
+        state
+      })).toMatchSnapshot();
+    });
+  });
+
+  describe('updateLegacyMappings()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.updateLegacyMappings).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('deleteMappings()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.deleteMappings).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('deleteMapping()', () => {
+    test('0: Method is implemented', async () => {
+      expect(MappingOps.deleteMapping).toBeDefined();
+    });
+    //TODO: create tests
+  });
+});

--- a/src/test/mock-recordings/MappingOps_3366551771/createMapping_1413000946/1-Should-create-sync-mapping_362966460/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/createMapping_1413000946/1-Should-create-sync-mapping_362966460/recording.har
@@ -1,0 +1,445 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/createMapping()/1: Should create sync mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10199,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10199,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:49 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10199"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:49.897Z",
+        "time": 55,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 55
+        }
+      },
+      {
+        "_id": "66a323d6617f3858cb7b08568782385e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "_id sw 'mapping'"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config?_queryFilter=_id%20sw%20%27mapping%27"
+        },
+        "response": {
+          "bodySize": 3263,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 3263,
+            "text": "{\"result\":[{\"_id\":\"mapping/managedAlpha_assignment_managedBravo_assignment\",\"consentRequired\":false,\"displayName\":\"managedAlpha_assignment_managedBravo_assignment\",\"icon\":null,\"name\":\"managedAlpha_assignment_managedBravo_assignment\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/alpha_assignment\",\"target\":\"managed/bravo_assignment\"},{\"_id\":\"mapping/managedBravo_group_managedBravo_group\",\"consentRequired\":false,\"displayName\":\"managedBravo_group_managedBravo_group\",\"icon\":null,\"name\":\"managedBravo_group_managedBravo_group\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_group\",\"target\":\"managed/bravo_group\"},{\"_id\":\"mapping/managedBravo_user_managedBravo_user0\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user0\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user0\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedAlpha_assignment_managedBravo_assignment\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping2\",\"name\":\"mapping2\",\"displayName\":\"mapping2\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}],\"resultCount\":5,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":5,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:49 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "3263"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:49.960Z",
+        "time": 53,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 53
+        }
+      },
+      {
+        "_id": "96ac3875febd8e3d62bb79f0c3b6234c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 10601,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "10601"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1578,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10614,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10614,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10614"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.089Z",
+        "time": 68,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 68
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/createMapping_1413000946/2-Should-create-regular-mapping_2900617850/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/createMapping_1413000946/2-Should-create-regular-mapping_2900617850/recording.har
@@ -1,0 +1,449 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/createMapping()/2: Should create regular mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10614,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10614,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10614"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.175Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "66a323d6617f3858cb7b08568782385e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "_id sw 'mapping'"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config?_queryFilter=_id%20sw%20%27mapping%27"
+        },
+        "response": {
+          "bodySize": 3263,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 3263,
+            "text": "{\"result\":[{\"_id\":\"mapping/managedAlpha_assignment_managedBravo_assignment\",\"consentRequired\":false,\"displayName\":\"managedAlpha_assignment_managedBravo_assignment\",\"icon\":null,\"name\":\"managedAlpha_assignment_managedBravo_assignment\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/alpha_assignment\",\"target\":\"managed/bravo_assignment\"},{\"_id\":\"mapping/managedBravo_group_managedBravo_group\",\"consentRequired\":false,\"displayName\":\"managedBravo_group_managedBravo_group\",\"icon\":null,\"name\":\"managedBravo_group_managedBravo_group\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_group\",\"target\":\"managed/bravo_group\"},{\"_id\":\"mapping/managedBravo_user_managedBravo_user0\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user0\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user0\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedAlpha_assignment_managedBravo_assignment\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping2\",\"name\":\"mapping2\",\"displayName\":\"mapping2\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}],\"resultCount\":5,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":5,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "3263"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.241Z",
+        "time": 55,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 55
+        }
+      },
+      {
+        "_id": "a586f1a70bd38ee6875063ac46d88f17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 218,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "218"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"mapping/mapping4\",\"name\":\"mapping4\",\"displayName\":\"mapping4\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping4"
+        },
+        "response": {
+          "bodySize": 218,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 218,
+            "text": "{\"_id\":\"mapping/mapping4\",\"name\":\"mapping4\",\"displayName\":\"mapping4\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping/mapping4"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "218"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 756,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping/mapping4",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.302Z",
+        "time": 72,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 72
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/exportMapping_1688159820/1-Should-export-sync-mapping_2606094890/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/exportMapping_1688159820/1-Should-export-sync-mapping_2606094890/recording.har
@@ -1,0 +1,297 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/exportMapping()/1: Should export sync mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10625,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10625,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10625"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.621Z",
+        "time": 52,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 52
+        }
+      },
+      {
+        "_id": "66a323d6617f3858cb7b08568782385e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "_id sw 'mapping'"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config?_queryFilter=_id%20sw%20%27mapping%27"
+        },
+        "response": {
+          "bodySize": 3481,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 3481,
+            "text": "{\"result\":[{\"_id\":\"mapping/managedAlpha_assignment_managedBravo_assignment\",\"consentRequired\":false,\"displayName\":\"managedAlpha_assignment_managedBravo_assignment\",\"icon\":null,\"name\":\"managedAlpha_assignment_managedBravo_assignment\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/alpha_assignment\",\"target\":\"managed/bravo_assignment\"},{\"_id\":\"mapping/managedBravo_group_managedBravo_group\",\"consentRequired\":false,\"displayName\":\"managedBravo_group_managedBravo_group\",\"icon\":null,\"name\":\"managedBravo_group_managedBravo_group\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_group\",\"target\":\"managed/bravo_group\"},{\"_id\":\"mapping/managedBravo_user_managedBravo_user0\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user0\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user0\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedAlpha_assignment_managedBravo_assignment\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping2\",\"name\":\"mapping2\",\"displayName\":\"mapping2\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping4\",\"name\":\"mapping4\",\"displayName\":\"mapping4\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}],\"resultCount\":6,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":6,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "3481"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.680Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/exportMapping_1688159820/2-Should-export-regular-mapping_3459238032/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/exportMapping_1688159820/2-Should-export-regular-mapping_3459238032/recording.har
@@ -1,0 +1,297 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/exportMapping()/2: Should export regular mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10625,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10625,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10625"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.753Z",
+        "time": 52,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 52
+        }
+      },
+      {
+        "_id": "66a323d6617f3858cb7b08568782385e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "_id sw 'mapping'"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config?_queryFilter=_id%20sw%20%27mapping%27"
+        },
+        "response": {
+          "bodySize": 3481,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 3481,
+            "text": "{\"result\":[{\"_id\":\"mapping/managedAlpha_assignment_managedBravo_assignment\",\"consentRequired\":false,\"displayName\":\"managedAlpha_assignment_managedBravo_assignment\",\"icon\":null,\"name\":\"managedAlpha_assignment_managedBravo_assignment\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/alpha_assignment\",\"target\":\"managed/bravo_assignment\"},{\"_id\":\"mapping/managedBravo_group_managedBravo_group\",\"consentRequired\":false,\"displayName\":\"managedBravo_group_managedBravo_group\",\"icon\":null,\"name\":\"managedBravo_group_managedBravo_group\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_group\",\"target\":\"managed/bravo_group\"},{\"_id\":\"mapping/managedBravo_user_managedBravo_user0\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user0\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user0\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedAlpha_assignment_managedBravo_assignment\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping2\",\"name\":\"mapping2\",\"displayName\":\"mapping2\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping4\",\"name\":\"mapping4\",\"displayName\":\"mapping4\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}],\"resultCount\":6,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":6,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "3481"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.811Z",
+        "time": 52,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 52
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/exportMappings_152450367/1-Export-mappings_3821212435/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/exportMappings_152450367/1-Export-mappings_3821212435/recording.har
@@ -1,0 +1,297 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/exportMappings()/1: Export mappings",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10625,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10625,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10625"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.877Z",
+        "time": 52,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 52
+        }
+      },
+      {
+        "_id": "66a323d6617f3858cb7b08568782385e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "_id sw 'mapping'"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config?_queryFilter=_id%20sw%20%27mapping%27"
+        },
+        "response": {
+          "bodySize": 3481,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 3481,
+            "text": "{\"result\":[{\"_id\":\"mapping/managedAlpha_assignment_managedBravo_assignment\",\"consentRequired\":false,\"displayName\":\"managedAlpha_assignment_managedBravo_assignment\",\"icon\":null,\"name\":\"managedAlpha_assignment_managedBravo_assignment\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/alpha_assignment\",\"target\":\"managed/bravo_assignment\"},{\"_id\":\"mapping/managedBravo_group_managedBravo_group\",\"consentRequired\":false,\"displayName\":\"managedBravo_group_managedBravo_group\",\"icon\":null,\"name\":\"managedBravo_group_managedBravo_group\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_group\",\"target\":\"managed/bravo_group\"},{\"_id\":\"mapping/managedBravo_user_managedBravo_user0\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user0\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user0\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedAlpha_assignment_managedBravo_assignment\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping2\",\"name\":\"mapping2\",\"displayName\":\"mapping2\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping4\",\"name\":\"mapping4\",\"displayName\":\"mapping4\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}],\"resultCount\":6,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":6,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "3481"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.936Z",
+        "time": 54,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 54
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/importFirstMapping_2247299519/1-Should-import-first-sync-mapping_1225222253/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/importFirstMapping_2247299519/1-Should-import-first-sync-mapping_1225222253/recording.har
@@ -1,0 +1,301 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/importFirstMapping()/1: Should import first sync mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 11040,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 11040,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]},{\"_id\":\"sync/mapping5\",\"name\":\"mapping5\",\"displayName\":\"mapping5\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:51 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "11040"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:51.229Z",
+        "time": 52,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 52
+        }
+      },
+      {
+        "_id": "59d1a56281573e5f084242abe5d36bc7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 11465,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "11465"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1578,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]},{\"_id\":\"sync/mapping5\",\"name\":\"mapping5\",\"displayName\":\"mapping5\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\",\"mapping3\"]},{\"_id\":\"sync/mapping7\",\"name\":\"mapping7\",\"displayName\":\"mapping7\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 11478,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 11478,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]},{\"_id\":\"sync/mapping5\",\"name\":\"mapping5\",\"displayName\":\"mapping5\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\",\"mapping3\"]},{\"_id\":\"sync/mapping7\",\"name\":\"mapping7\",\"displayName\":\"mapping7\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:51 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "11478"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:51.291Z",
+        "time": 68,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 68
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/importFirstMapping_2247299519/2-Should-import-first-regular-mapping_4255154261/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/importFirstMapping_2247299519/2-Should-import-first-regular-mapping_4255154261/recording.har
@@ -1,0 +1,166 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/importFirstMapping()/2: Should import first regular mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "656adf4884b7d4be5eaaf78c11c5fb3f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 218,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "218"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"mapping/mapping8\",\"name\":\"mapping8\",\"displayName\":\"mapping8\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping8"
+        },
+        "response": {
+          "bodySize": 218,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 218,
+            "text": "{\"_id\":\"mapping/mapping8\",\"name\":\"mapping8\",\"displayName\":\"mapping8\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:51 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping/mapping8"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "218"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 756,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping/mapping8",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2024-07-09T22:19:51.375Z",
+        "time": 66,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 66
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/importMapping_3055407301/1-Should-import-sync-mapping_3001153107/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/importMapping_3055407301/1-Should-import-sync-mapping_3001153107/recording.har
@@ -1,0 +1,301 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/importMapping()/1: Should import sync mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10625,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10625,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:51 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10625"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:51.012Z",
+        "time": 53,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 53
+        }
+      },
+      {
+        "_id": "25012b82b49b5f165ca505e9c0d341d8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 11027,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "11027"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1578,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]},{\"_id\":\"sync/mapping5\",\"name\":\"mapping5\",\"displayName\":\"mapping5\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 11040,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 11040,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]},{\"_id\":\"sync/mapping5\",\"name\":\"mapping5\",\"displayName\":\"mapping5\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:51 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "11040"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:51.078Z",
+        "time": 67,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 67
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/importMapping_3055407301/2-Should-import-regular-mapping_3946016515/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/importMapping_3055407301/2-Should-import-regular-mapping_3946016515/recording.har
@@ -1,0 +1,166 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/importMapping()/2: Should import regular mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "5321b547a56e7b1cb314658cc3acaa20",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 218,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "218"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"mapping/mapping6\",\"name\":\"mapping6\",\"displayName\":\"mapping6\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping6"
+        },
+        "response": {
+          "bodySize": 218,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 218,
+            "text": "{\"_id\":\"mapping/mapping6\",\"name\":\"mapping6\",\"displayName\":\"mapping6\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:51 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping/mapping6"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "218"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 756,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping/mapping6",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2024-07-09T22:19:51.163Z",
+        "time": 55,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 55
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/importMappings_2899875224/1-Should-import-mappings_139037249/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/importMappings_2899875224/1-Should-import-mappings_139037249/recording.har
@@ -1,0 +1,453 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/importMappings()/1: Should import mappings",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "fa0c600734fce1803d84998d726f357b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 221,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "221"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1589,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"mapping/mapping10\",\"name\":\"mapping10\",\"displayName\":\"mapping10\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping10"
+        },
+        "response": {
+          "bodySize": 221,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 221,
+            "text": "{\"_id\":\"mapping/mapping10\",\"name\":\"mapping10\",\"displayName\":\"mapping10\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:51 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping/mapping10"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "221"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 757,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping/mapping10",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2024-07-09T22:19:51.454Z",
+        "time": 53,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 53
+        }
+      },
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 11478,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 11478,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]},{\"_id\":\"sync/mapping5\",\"name\":\"mapping5\",\"displayName\":\"mapping5\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\",\"mapping3\"]},{\"_id\":\"sync/mapping7\",\"name\":\"mapping7\",\"displayName\":\"mapping7\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:51 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "11478"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:51.513Z",
+        "time": 55,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 55
+        }
+      },
+      {
+        "_id": "b1b083b1de4d095c4df924a685dd5fe1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 11914,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "11914"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1578,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]},{\"_id\":\"sync/mapping5\",\"name\":\"mapping5\",\"displayName\":\"mapping5\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\",\"mapping3\"]},{\"_id\":\"sync/mapping7\",\"name\":\"mapping7\",\"displayName\":\"mapping7\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\",\"mapping3\",\"mapping5\"]},{\"_id\":\"sync/mapping9\",\"name\":\"mapping9\",\"displayName\":\"mapping9\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 11927,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 11927,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]},{\"_id\":\"sync/mapping5\",\"name\":\"mapping5\",\"displayName\":\"mapping5\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\",\"mapping3\"]},{\"_id\":\"sync/mapping7\",\"name\":\"mapping7\",\"displayName\":\"mapping7\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\",\"mapping3\",\"mapping5\"]},{\"_id\":\"sync/mapping9\",\"name\":\"mapping9\",\"displayName\":\"mapping9\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:51 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "11927"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:51.576Z",
+        "time": 97,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 97
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/readMapping_1845989114/1-Should-read-sync-mapping_986556536/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/readMapping_1845989114/1-Should-read-sync-mapping_986556536/recording.har
@@ -1,0 +1,297 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/readMapping()/1: Should read sync mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10199,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10199,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:49 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10199"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:49.621Z",
+        "time": 54,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 54
+        }
+      },
+      {
+        "_id": "66a323d6617f3858cb7b08568782385e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "_id sw 'mapping'"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config?_queryFilter=_id%20sw%20%27mapping%27"
+        },
+        "response": {
+          "bodySize": 3263,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 3263,
+            "text": "{\"result\":[{\"_id\":\"mapping/managedAlpha_assignment_managedBravo_assignment\",\"consentRequired\":false,\"displayName\":\"managedAlpha_assignment_managedBravo_assignment\",\"icon\":null,\"name\":\"managedAlpha_assignment_managedBravo_assignment\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/alpha_assignment\",\"target\":\"managed/bravo_assignment\"},{\"_id\":\"mapping/managedBravo_group_managedBravo_group\",\"consentRequired\":false,\"displayName\":\"managedBravo_group_managedBravo_group\",\"icon\":null,\"name\":\"managedBravo_group_managedBravo_group\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_group\",\"target\":\"managed/bravo_group\"},{\"_id\":\"mapping/managedBravo_user_managedBravo_user0\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user0\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user0\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedAlpha_assignment_managedBravo_assignment\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping2\",\"name\":\"mapping2\",\"displayName\":\"mapping2\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}],\"resultCount\":5,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":5,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:49 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "3263"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:49.683Z",
+        "time": 54,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 54
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/readMapping_1845989114/2-Should-read-regular-mapping_1727060002/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/readMapping_1845989114/2-Should-read-regular-mapping_1727060002/recording.har
@@ -1,0 +1,297 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/readMapping()/2: Should read regular mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10199,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10199,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:49 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10199"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:49.750Z",
+        "time": 56,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 56
+        }
+      },
+      {
+        "_id": "66a323d6617f3858cb7b08568782385e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "_id sw 'mapping'"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config?_queryFilter=_id%20sw%20%27mapping%27"
+        },
+        "response": {
+          "bodySize": 3263,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 3263,
+            "text": "{\"result\":[{\"_id\":\"mapping/managedAlpha_assignment_managedBravo_assignment\",\"consentRequired\":false,\"displayName\":\"managedAlpha_assignment_managedBravo_assignment\",\"icon\":null,\"name\":\"managedAlpha_assignment_managedBravo_assignment\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/alpha_assignment\",\"target\":\"managed/bravo_assignment\"},{\"_id\":\"mapping/managedBravo_group_managedBravo_group\",\"consentRequired\":false,\"displayName\":\"managedBravo_group_managedBravo_group\",\"icon\":null,\"name\":\"managedBravo_group_managedBravo_group\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_group\",\"target\":\"managed/bravo_group\"},{\"_id\":\"mapping/managedBravo_user_managedBravo_user0\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user0\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user0\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedAlpha_assignment_managedBravo_assignment\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping2\",\"name\":\"mapping2\",\"displayName\":\"mapping2\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}],\"resultCount\":5,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":5,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:49 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "3263"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:49.813Z",
+        "time": 63,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 63
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/readMappings_514945269/1-Read-mappings_1770243469/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/readMappings_514945269/1-Read-mappings_1770243469/recording.har
@@ -1,0 +1,297 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/readMappings()/1: Read mappings",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10199,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10199,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:49 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10199"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:49.479Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      },
+      {
+        "_id": "66a323d6617f3858cb7b08568782385e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "_id sw 'mapping'"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config?_queryFilter=_id%20sw%20%27mapping%27"
+        },
+        "response": {
+          "bodySize": 3263,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 3263,
+            "text": "{\"result\":[{\"_id\":\"mapping/managedAlpha_assignment_managedBravo_assignment\",\"consentRequired\":false,\"displayName\":\"managedAlpha_assignment_managedBravo_assignment\",\"icon\":null,\"name\":\"managedAlpha_assignment_managedBravo_assignment\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/alpha_assignment\",\"target\":\"managed/bravo_assignment\"},{\"_id\":\"mapping/managedBravo_group_managedBravo_group\",\"consentRequired\":false,\"displayName\":\"managedBravo_group_managedBravo_group\",\"icon\":null,\"name\":\"managedBravo_group_managedBravo_group\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_group\",\"target\":\"managed/bravo_group\"},{\"_id\":\"mapping/managedBravo_user_managedBravo_user0\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user0\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user0\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedAlpha_assignment_managedBravo_assignment\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping2\",\"name\":\"mapping2\",\"displayName\":\"mapping2\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}],\"resultCount\":5,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":5,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:49 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "3263"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:49.546Z",
+        "time": 57,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 57
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/readNewMappings_573958649/1-Read-new-mappings_3354676971/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/readNewMappings_573958649/1-Read-new-mappings_3354676971/recording.har
@@ -1,0 +1,158 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/readNewMappings()/1: Read new mappings",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "66a323d6617f3858cb7b08568782385e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1588,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "_id sw 'mapping'"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config?_queryFilter=_id%20sw%20%27mapping%27"
+        },
+        "response": {
+          "bodySize": 3263,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 3263,
+            "text": "{\"result\":[{\"_id\":\"mapping/managedAlpha_assignment_managedBravo_assignment\",\"consentRequired\":false,\"displayName\":\"managedAlpha_assignment_managedBravo_assignment\",\"icon\":null,\"name\":\"managedAlpha_assignment_managedBravo_assignment\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/alpha_assignment\",\"target\":\"managed/bravo_assignment\"},{\"_id\":\"mapping/managedBravo_group_managedBravo_group\",\"consentRequired\":false,\"displayName\":\"managedBravo_group_managedBravo_group\",\"icon\":null,\"name\":\"managedBravo_group_managedBravo_group\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_group\",\"target\":\"managed/bravo_group\"},{\"_id\":\"mapping/managedBravo_user_managedBravo_user0\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user0\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user0\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedAlpha_assignment_managedBravo_assignment\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"mapping/mapping2\",\"name\":\"mapping2\",\"displayName\":\"mapping2\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}],\"resultCount\":5,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":5,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:49 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "3263"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:49.401Z",
+        "time": 63,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 63
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/readSyncMappings_1273677778/1-Read-sync-mappings_2817996588/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/readSyncMappings_1273677778/1-Read-sync-mappings_2817996588/recording.har
@@ -1,0 +1,153 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/readSyncMappings()/1: Read sync mappings",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10199,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10199,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:49 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10199"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:49.158Z",
+        "time": 74,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 74
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/updateMapping_157008805/1-Should-update-sync-mapping_1292898731/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/updateMapping_157008805/1-Should-update-sync-mapping_1292898731/recording.har
@@ -1,0 +1,301 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/updateMapping()/1: Should update sync mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "6e9b2f10aede12892b2cd5ccd64a725a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1555,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10614,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10614,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\"]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10614"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.387Z",
+        "time": 56,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 56
+        }
+      },
+      {
+        "_id": "c5c88d9078b530d8ba2f537ec352a07f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 10612,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "10612"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1578,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]}]}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/sync"
+        },
+        "response": {
+          "bodySize": 10625,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 10625,
+            "text": "{\"_id\":\"sync\",\"mappings\":[{\"_id\":\"sync/managedBravo_user_managedBravo_user\",\"consentRequired\":false,\"displayName\":\"managedBravo_user_managedBravo_user\",\"icon\":null,\"name\":\"managedBravo_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedAlpha_application_managedBravo_application\",\"consentRequired\":true,\"displayName\":\"Test Application Mapping\",\"icon\":null,\"name\":\"managedAlpha_application_managedBravo_application\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"source\":\"authoritative\",\"target\":\"_id\"}],\"source\":\"managed/alpha_application\",\"sourceQuery\":{\"_queryFilter\":\"(eq \\\"\\\" or eq \\\"\\\")\"},\"syncAfter\":[\"managedBravo_user_managedBravo_user\"],\"target\":\"managed/bravo_application\",\"targetQuery\":{\"_queryFilter\":\"!(eq \\\"\\\")\"}},{\"_id\":\"sync/managedAlpha_user_managedBravo_user\",\"consentRequired\":true,\"displayName\":\"Test Mapping for Frodo\",\"icon\":null,\"name\":\"managedAlpha_user_managedBravo_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"console.log(\\\"Hello World!\\\");\",\"type\":\"text/javascript\"},\"default\":[\"Default value string\"],\"source\":\"accountStatus\",\"target\":\"applications\",\"transform\":{\"globals\":{},\"source\":\"console.log(\\\"hello\\\");\",\"type\":\"text/javascript\"}}],\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\"],\"target\":\"managed/bravo_user\"},{\"_id\":\"sync/managedBravo_user_managedAlpha_user\",\"consentRequired\":false,\"displayName\":\"Frodo test mapping\",\"icon\":null,\"name\":\"managedBravo_user_managedAlpha_user\",\"policies\":[{\"action\":\"ASYNC\",\"situation\":\"ABSENT\"},{\"action\":\"ASYNC\",\"situation\":\"ALL_GONE\"},{\"action\":\"ASYNC\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"ASYNC\",\"situation\":\"CONFIRMED\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND\"},{\"action\":\"ASYNC\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"ASYNC\",\"situation\":\"LINK_ONLY\"},{\"action\":\"ASYNC\",\"situation\":\"MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"SOURCE_MISSING\"},{\"action\":\"ASYNC\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"ASYNC\",\"situation\":\"UNASSIGNED\"},{\"action\":\"ASYNC\",\"situation\":\"UNQUALIFIED\"}],\"properties\":[],\"source\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\"],\"target\":\"managed/alpha_user\"},{\"_id\":\"sync/AlphaUser2GoogleApps\",\"consentRequired\":false,\"correlationQuery\":[{\"expressionTree\":{\"all\":[\"__NAME__\"]},\"file\":\"ui/correlateTreeToQueryFilter.js\",\"linkQualifier\":\"default\",\"mapping\":\"AlphaUser2GoogleApps\",\"type\":\"text/javascript\"}],\"displayName\":\"AlphaUser2GoogleApps\",\"enableSync\":{\"$bool\":\"&{esv.gac.enable.mapping}\"},\"icon\":null,\"name\":\"AlphaUser2GoogleApps\",\"onCreate\":{\"globals\":{},\"source\":\"target.orgUnitPath = \\\"/NewAccounts\\\";\",\"type\":\"text/javascript\"},\"onUpdate\":{\"globals\":{},\"source\":\"//testing1234\\ntarget.givenName = oldTarget.givenName;\\ntarget.familyName = oldTarget.familyName;\\ntarget.__NAME__ = oldTarget.__NAME__;\",\"type\":\"text/javascript\"},\"policies\":[{\"action\":\"EXCEPTION\",\"situation\":\"AMBIGUOUS\"},{\"action\":\"UNLINK\",\"situation\":\"SOURCE_MISSING\"},{\"action\":{\"globals\":{},\"source\":\"// Timing Constants\\nvar ATTEMPT = 6; // Number of attempts to find the Google user.\\nvar SLEEP_TIME = 500; // Milliseconds between retries.\\nvar SYSTEM_ENDPOINT = \\\"system/GoogleApps/__ACCOUNT__\\\";\\nvar MAPPING_NAME = \\\"AlphaUser2GoogleApps\\\";\\nvar GOOGLE_DOMAIN = identityServer.getProperty(\\\"esv.gac.domain\\\");\\nvar googleEmail = source.userName + \\\"@\\\" + GOOGLE_DOMAIN;\\nvar frUserGUID = source._id;\\nvar resultingAction = \\\"ASYNC\\\";\\n\\n// Get the Google GUID\\nvar linkQueryParams = {'_queryFilter': 'firstId eq \\\"' + frUserGUID + '\\\" and linkType eq \\\"' + MAPPING_NAME + '\\\"'};\\nvar linkResults = openidm.query(\\\"repo/link/\\\", linkQueryParams, null);\\nvar googleGUID;\\n\\nif (linkResults.resultCount === 1) {\\n  googleGUID = linkResults.result[0].secondId;\\n}\\n\\nvar queryResults; // Resulting query from looking for the Google user.\\nvar params = {'_queryFilter': '__UID__ eq \\\"' + googleGUID + '\\\"'};\\n\\nfor (var i = 1; i <= ATTEMPT; i++) {\\n    queryResults = openidm.query(SYSTEM_ENDPOINT, params);\\n    if (queryResults.result && queryResults.result.length > 0) {\\n        logger.info(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in \\\" + i + \\\" attempts. Query result: \\\" + JSON.stringify(queryResults));\\n        resultingAction = \\\"UPDATE\\\";\\n        break;\\n    }\\n    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.\\n}\\n\\nif (!queryResults.result || queryResults.resultCount === 0) {\\n    logger.warn(\\\"idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - \\\" + googleEmail + \\\" not found after \\\" + ATTEMPT + \\\" attempts.\\\");\\n    resultingAction = \\\"UNLINK\\\";\\n}\\nresultingAction;\\n\",\"type\":\"text/javascript\"},\"situation\":\"MISSING\"},{\"action\":\"EXCEPTION\",\"situation\":\"FOUND_ALREADY_LINKED\"},{\"action\":\"IGNORE\",\"situation\":\"UNQUALIFIED\"},{\"action\":\"IGNORE\",\"situation\":\"UNASSIGNED\"},{\"action\":\"UNLINK\",\"situation\":\"LINK_ONLY\"},{\"action\":\"IGNORE\",\"situation\":\"TARGET_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"SOURCE_IGNORED\"},{\"action\":\"IGNORE\",\"situation\":\"ALL_GONE\"},{\"action\":\"UPDATE\",\"situation\":\"CONFIRMED\"},{\"action\":\"LINK\",\"situation\":\"FOUND\"},{\"action\":\"CREATE\",\"situation\":\"ABSENT\"}],\"properties\":[{\"condition\":{\"globals\":{},\"source\":\"object.custom_password_encrypted != null\",\"type\":\"text/javascript\"},\"source\":\"custom_password_encrypted\",\"target\":\"__PASSWORD__\",\"transform\":{\"globals\":{},\"source\":\"openidm.decrypt(source);\",\"type\":\"text/javascript\"}},{\"source\":\"cn\",\"target\":\"__NAME__\",\"transform\":{\"globals\":{},\"source\":\"source + \\\"@\\\" + identityServer.getProperty(\\\"esv.gac.domain\\\");\",\"type\":\"text/javascript\"}},{\"source\":\"givenName\",\"target\":\"givenName\"},{\"source\":\"\",\"target\":\"familyName\",\"transform\":{\"globals\":{},\"source\":\"if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {\\n  source.sn + \\\" (Student)\\\"\\n} else {\\n  source.sn\\n}\",\"type\":\"text/javascript\"}}],\"queuedSync\":{\"enabled\":true,\"maxQueueSize\":20000,\"maxRetries\":5,\"pageSize\":100,\"pollingInterval\":1000,\"postRetryAction\":\"logged-ignore\",\"retryDelay\":1000},\"source\":\"managed/alpha_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\"],\"target\":\"system/GoogleApps/__ACCOUNT__\",\"validSource\":{\"globals\":{},\"source\":\"var isGoogleEligible = true;\\n//var logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\" cn: \\\" + source.cn + \\\") -\\\";\\nvar logMsg = \\\"idmlog: ---AplhaUser2GAC (username: \\\" + source.userName + \\\" - userType: \\\" + source.frIndexedInteger1 + \\\") -\\\";\\n\\n//Get Applicable userTypes (no Parent accounts)\\nif (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" Account type not eligible.\\\";\\n}\\n\\n//Make sure the account has a valid encrypted password.\\nif (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" No encrypted password yet.\\\";\\n}\\n\\n//Check that CN exists and has no space.\\nif (source.cn && source.cn.includes(' ')) {\\n\\tisGoogleEligible = false;\\n\\tlogMsg = logMsg + \\\" CN with a space is not allowed.\\\";\\n}\\n\\nif (!isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Not sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n} \\n\\nif (isGoogleEligible) {\\n\\tlogMsg = logMsg + \\\" Sent to Google.\\\"\\n\\tlogger.info(logMsg);\\n}\\n\\nisGoogleEligible;\\n\",\"type\":\"text/javascript\"}},{\"_id\":\"sync/mapping1\",\"name\":\"mapping1\",\"displayName\":\"mapping1\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"system/connector1/bravo_user\",\"target\":\"system/connector1/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\"]},{\"_id\":\"sync/mapping11\",\"name\":\"mapping11\",\"displayName\":\"mapping11\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]},{\"_id\":\"sync/mapping3\",\"name\":\"mapping3\",\"displayName\":\"mapping3\",\"linkQualifiers\":[],\"consentRequired\":false,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[\"managedBravo_user_managedBravo_user\",\"managedAlpha_application_managedBravo_application\",\"managedAlpha_user_managedBravo_user\",\"managedBravo_user_managedAlpha_user\",\"AlphaUser2GoogleApps\",\"mapping1\",\"mapping11\"]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "10625"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 666,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.457Z",
+        "time": 74,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 74
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/MappingOps_3366551771/updateMapping_157008805/2-Should-update-regular-mapping_1119570695/recording.har
+++ b/src/test/mock-recordings/MappingOps_3366551771/updateMapping_157008805/2-Should-update-regular-mapping_1119570695/recording.har
@@ -1,0 +1,162 @@
+{
+  "log": {
+    "_recordingName": "MappingOps/updateMapping()/2: Should update regular mapping",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "cd483e4c771c345f4217cc711e609bf6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 220,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-91"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "220"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1589,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/mapping/mapping12"
+        },
+        "response": {
+          "bodySize": 220,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 220,
+            "text": "{\"_id\":\"mapping/mapping12\",\"name\":\"mapping12\",\"displayName\":\"mapping12\",\"linkQualifiers\":[],\"consentRequired\":true,\"policies\":[],\"properties\":[],\"source\":\"managed/bravo_user\",\"target\":\"managed/bravo_user\",\"syncAfter\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 09 Jul 2024 22:19:50 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "220"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-601a2e61-7255-4fc6-b6c9-9a2135901e20"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-07-09T22:19:50.548Z",
+        "time": 60,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 60
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/snapshots/ops/MappingOps.test.js.snap
+++ b/src/test/snapshots/ops/MappingOps.test.js.snap
@@ -1,0 +1,2657 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MappingOps createMapping() 1: Should create sync mapping 1`] = `
+{
+  "_id": "sync/mapping3",
+  "consentRequired": false,
+  "displayName": "mapping3",
+  "linkQualifiers": [],
+  "name": "mapping3",
+  "policies": [],
+  "properties": [],
+  "source": "managed/bravo_user",
+  "syncAfter": [],
+  "target": "managed/bravo_user",
+}
+`;
+
+exports[`MappingOps createMapping() 2: Should create regular mapping 1`] = `
+{
+  "_id": "mapping/mapping4",
+  "consentRequired": false,
+  "displayName": "mapping4",
+  "linkQualifiers": [],
+  "name": "mapping4",
+  "policies": [],
+  "properties": [],
+  "source": "managed/bravo_user",
+  "syncAfter": [],
+  "target": "managed/bravo_user",
+}
+`;
+
+exports[`MappingOps createMappingExportTemplate() 1: Create Mapping Export Template 1`] = `
+{
+  "mapping": {},
+  "meta": Any<Object>,
+  "sync": {
+    "id": "sync",
+    "mappings": [],
+  },
+}
+`;
+
+exports[`MappingOps exportMapping() 1: Should export sync mapping 1`] = `
+{
+  "mapping": {},
+  "meta": Any<Object>,
+  "sync": {
+    "id": "sync",
+    "mappings": [
+      {
+        "_id": "sync/mapping1",
+        "consentRequired": false,
+        "displayName": "mapping1",
+        "linkQualifiers": [],
+        "name": "mapping1",
+        "policies": [],
+        "properties": [],
+        "source": "system/connector1/bravo_user",
+        "syncAfter": [
+          "managedBravo_user_managedBravo_user",
+          "managedAlpha_application_managedBravo_application",
+          "managedAlpha_user_managedBravo_user",
+          "managedBravo_user_managedAlpha_user",
+          "AlphaUser2GoogleApps",
+        ],
+        "target": "system/connector1/bravo_user",
+      },
+    ],
+  },
+}
+`;
+
+exports[`MappingOps exportMapping() 2: Should export regular mapping 1`] = `
+{
+  "mapping": {
+    "mapping/mapping2": {
+      "_id": "mapping/mapping2",
+      "consentRequired": false,
+      "displayName": "mapping2",
+      "linkQualifiers": [],
+      "name": "mapping2",
+      "policies": [],
+      "properties": [],
+      "source": "managed/bravo_user",
+      "syncAfter": [],
+      "target": "managed/bravo_user",
+    },
+  },
+  "meta": Any<Object>,
+  "sync": {
+    "id": "sync",
+    "mappings": [],
+  },
+}
+`;
+
+exports[`MappingOps exportMappings() 1: Export mappings 1`] = `
+{
+  "mapping": {
+    "mapping/managedAlpha_assignment_managedBravo_assignment": {
+      "_id": "mapping/managedAlpha_assignment_managedBravo_assignment",
+      "consentRequired": false,
+      "displayName": "managedAlpha_assignment_managedBravo_assignment",
+      "icon": null,
+      "name": "managedAlpha_assignment_managedBravo_assignment",
+      "policies": [
+        {
+          "action": "ASYNC",
+          "situation": "ABSENT",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "ALL_GONE",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "AMBIGUOUS",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "CONFIRMED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "FOUND",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "FOUND_ALREADY_LINKED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "LINK_ONLY",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "MISSING",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "SOURCE_IGNORED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "SOURCE_MISSING",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "TARGET_IGNORED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "UNASSIGNED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "UNQUALIFIED",
+        },
+      ],
+      "properties": [],
+      "source": "managed/alpha_assignment",
+      "target": "managed/bravo_assignment",
+    },
+    "mapping/managedBravo_group_managedBravo_group": {
+      "_id": "mapping/managedBravo_group_managedBravo_group",
+      "consentRequired": false,
+      "displayName": "managedBravo_group_managedBravo_group",
+      "icon": null,
+      "name": "managedBravo_group_managedBravo_group",
+      "policies": [
+        {
+          "action": "ASYNC",
+          "situation": "ABSENT",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "ALL_GONE",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "AMBIGUOUS",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "CONFIRMED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "FOUND",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "FOUND_ALREADY_LINKED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "LINK_ONLY",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "MISSING",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "SOURCE_IGNORED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "SOURCE_MISSING",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "TARGET_IGNORED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "UNASSIGNED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "UNQUALIFIED",
+        },
+      ],
+      "properties": [],
+      "source": "managed/bravo_group",
+      "target": "managed/bravo_group",
+    },
+    "mapping/managedBravo_user_managedBravo_user0": {
+      "_id": "mapping/managedBravo_user_managedBravo_user0",
+      "consentRequired": false,
+      "displayName": "managedBravo_user_managedBravo_user0",
+      "icon": null,
+      "name": "managedBravo_user_managedBravo_user0",
+      "policies": [
+        {
+          "action": "ASYNC",
+          "situation": "ABSENT",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "ALL_GONE",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "AMBIGUOUS",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "CONFIRMED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "FOUND",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "FOUND_ALREADY_LINKED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "LINK_ONLY",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "MISSING",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "SOURCE_IGNORED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "SOURCE_MISSING",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "TARGET_IGNORED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "UNASSIGNED",
+        },
+        {
+          "action": "ASYNC",
+          "situation": "UNQUALIFIED",
+        },
+      ],
+      "properties": [],
+      "source": "managed/bravo_user",
+      "syncAfter": [
+        "managedAlpha_assignment_managedBravo_assignment",
+      ],
+      "target": "managed/bravo_user",
+    },
+    "mapping/mapping12": {
+      "_id": "mapping/mapping12",
+      "consentRequired": true,
+      "displayName": "mapping12",
+      "linkQualifiers": [],
+      "name": "mapping12",
+      "policies": [],
+      "properties": [],
+      "source": "managed/bravo_user",
+      "syncAfter": [],
+      "target": "managed/bravo_user",
+    },
+    "mapping/mapping2": {
+      "_id": "mapping/mapping2",
+      "consentRequired": false,
+      "displayName": "mapping2",
+      "linkQualifiers": [],
+      "name": "mapping2",
+      "policies": [],
+      "properties": [],
+      "source": "managed/bravo_user",
+      "syncAfter": [],
+      "target": "managed/bravo_user",
+    },
+    "mapping/mapping4": {
+      "_id": "mapping/mapping4",
+      "consentRequired": false,
+      "displayName": "mapping4",
+      "linkQualifiers": [],
+      "name": "mapping4",
+      "policies": [],
+      "properties": [],
+      "source": "managed/bravo_user",
+      "syncAfter": [],
+      "target": "managed/bravo_user",
+    },
+  },
+  "meta": Any<Object>,
+  "sync": {
+    "id": "sync",
+    "mappings": [
+      {
+        "_id": "sync/managedBravo_user_managedBravo_user",
+        "consentRequired": false,
+        "displayName": "managedBravo_user_managedBravo_user",
+        "icon": null,
+        "name": "managedBravo_user_managedBravo_user",
+        "policies": [
+          {
+            "action": "ASYNC",
+            "situation": "ABSENT",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "ALL_GONE",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "AMBIGUOUS",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "CONFIRMED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "FOUND",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "FOUND_ALREADY_LINKED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "LINK_ONLY",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "MISSING",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "SOURCE_IGNORED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "SOURCE_MISSING",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "TARGET_IGNORED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "UNASSIGNED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "UNQUALIFIED",
+          },
+        ],
+        "properties": [],
+        "source": "managed/bravo_user",
+        "syncAfter": [],
+        "target": "managed/bravo_user",
+      },
+      {
+        "_id": "sync/managedAlpha_application_managedBravo_application",
+        "consentRequired": true,
+        "displayName": "Test Application Mapping",
+        "icon": null,
+        "name": "managedAlpha_application_managedBravo_application",
+        "policies": [
+          {
+            "action": "ASYNC",
+            "situation": "ABSENT",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "ALL_GONE",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "AMBIGUOUS",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "CONFIRMED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "FOUND",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "FOUND_ALREADY_LINKED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "LINK_ONLY",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "MISSING",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "SOURCE_IGNORED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "SOURCE_MISSING",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "TARGET_IGNORED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "UNASSIGNED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "UNQUALIFIED",
+          },
+        ],
+        "properties": [
+          {
+            "source": "authoritative",
+            "target": "_id",
+          },
+        ],
+        "source": "managed/alpha_application",
+        "sourceQuery": {
+          "_queryFilter": "(eq "" or eq "")",
+        },
+        "syncAfter": [
+          "managedBravo_user_managedBravo_user",
+        ],
+        "target": "managed/bravo_application",
+        "targetQuery": {
+          "_queryFilter": "!(eq "")",
+        },
+      },
+      {
+        "_id": "sync/managedAlpha_user_managedBravo_user",
+        "consentRequired": true,
+        "displayName": "Test Mapping for Frodo",
+        "icon": null,
+        "name": "managedAlpha_user_managedBravo_user",
+        "policies": [
+          {
+            "action": "ASYNC",
+            "situation": "ABSENT",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "ALL_GONE",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "AMBIGUOUS",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "CONFIRMED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "FOUND",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "FOUND_ALREADY_LINKED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "LINK_ONLY",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "MISSING",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "SOURCE_IGNORED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "SOURCE_MISSING",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "TARGET_IGNORED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "UNASSIGNED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "UNQUALIFIED",
+          },
+        ],
+        "properties": [
+          {
+            "condition": {
+              "globals": {},
+              "source": "console.log("Hello World!");",
+              "type": "text/javascript",
+            },
+            "default": [
+              "Default value string",
+            ],
+            "source": "accountStatus",
+            "target": "applications",
+            "transform": {
+              "globals": {},
+              "source": "console.log("hello");",
+              "type": "text/javascript",
+            },
+          },
+        ],
+        "source": "managed/alpha_user",
+        "syncAfter": [
+          "managedBravo_user_managedBravo_user",
+          "managedAlpha_application_managedBravo_application",
+        ],
+        "target": "managed/bravo_user",
+      },
+      {
+        "_id": "sync/managedBravo_user_managedAlpha_user",
+        "consentRequired": false,
+        "displayName": "Frodo test mapping",
+        "icon": null,
+        "name": "managedBravo_user_managedAlpha_user",
+        "policies": [
+          {
+            "action": "ASYNC",
+            "situation": "ABSENT",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "ALL_GONE",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "AMBIGUOUS",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "CONFIRMED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "FOUND",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "FOUND_ALREADY_LINKED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "LINK_ONLY",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "MISSING",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "SOURCE_IGNORED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "SOURCE_MISSING",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "TARGET_IGNORED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "UNASSIGNED",
+          },
+          {
+            "action": "ASYNC",
+            "situation": "UNQUALIFIED",
+          },
+        ],
+        "properties": [],
+        "source": "managed/bravo_user",
+        "syncAfter": [
+          "managedBravo_user_managedBravo_user",
+          "managedAlpha_application_managedBravo_application",
+          "managedAlpha_user_managedBravo_user",
+        ],
+        "target": "managed/alpha_user",
+      },
+      {
+        "_id": "sync/AlphaUser2GoogleApps",
+        "consentRequired": false,
+        "correlationQuery": [
+          {
+            "expressionTree": {
+              "all": [
+                "__NAME__",
+              ],
+            },
+            "file": "ui/correlateTreeToQueryFilter.js",
+            "linkQualifier": "default",
+            "mapping": "AlphaUser2GoogleApps",
+            "type": "text/javascript",
+          },
+        ],
+        "displayName": "AlphaUser2GoogleApps",
+        "enableSync": {
+          "$bool": "&{esv.gac.enable.mapping}",
+        },
+        "icon": null,
+        "name": "AlphaUser2GoogleApps",
+        "onCreate": {
+          "globals": {},
+          "source": "target.orgUnitPath = "/NewAccounts";",
+          "type": "text/javascript",
+        },
+        "onUpdate": {
+          "globals": {},
+          "source": "//testing1234
+target.givenName = oldTarget.givenName;
+target.familyName = oldTarget.familyName;
+target.__NAME__ = oldTarget.__NAME__;",
+          "type": "text/javascript",
+        },
+        "policies": [
+          {
+            "action": "EXCEPTION",
+            "situation": "AMBIGUOUS",
+          },
+          {
+            "action": "UNLINK",
+            "situation": "SOURCE_MISSING",
+          },
+          {
+            "action": {
+              "globals": {},
+              "source": "// Timing Constants
+var ATTEMPT = 6; // Number of attempts to find the Google user.
+var SLEEP_TIME = 500; // Milliseconds between retries.
+var SYSTEM_ENDPOINT = "system/GoogleApps/__ACCOUNT__";
+var MAPPING_NAME = "AlphaUser2GoogleApps";
+var GOOGLE_DOMAIN = identityServer.getProperty("esv.gac.domain");
+var googleEmail = source.userName + "@" + GOOGLE_DOMAIN;
+var frUserGUID = source._id;
+var resultingAction = "ASYNC";
+
+// Get the Google GUID
+var linkQueryParams = {'_queryFilter': 'firstId eq "' + frUserGUID + '" and linkType eq "' + MAPPING_NAME + '"'};
+var linkResults = openidm.query("repo/link/", linkQueryParams, null);
+var googleGUID;
+
+if (linkResults.resultCount === 1) {
+  googleGUID = linkResults.result[0].secondId;
+}
+
+var queryResults; // Resulting query from looking for the Google user.
+var params = {'_queryFilter': '__UID__ eq "' + googleGUID + '"'};
+
+for (var i = 1; i <= ATTEMPT; i++) {
+    queryResults = openidm.query(SYSTEM_ENDPOINT, params);
+    if (queryResults.result && queryResults.result.length > 0) {
+        logger.info("idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in " + i + " attempts. Query result: " + JSON.stringify(queryResults));
+        resultingAction = "UPDATE";
+        break;
+    }
+    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.
+}
+
+if (!queryResults.result || queryResults.resultCount === 0) {
+    logger.warn("idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - " + googleEmail + " not found after " + ATTEMPT + " attempts.");
+    resultingAction = "UNLINK";
+}
+resultingAction;
+",
+              "type": "text/javascript",
+            },
+            "situation": "MISSING",
+          },
+          {
+            "action": "EXCEPTION",
+            "situation": "FOUND_ALREADY_LINKED",
+          },
+          {
+            "action": "IGNORE",
+            "situation": "UNQUALIFIED",
+          },
+          {
+            "action": "IGNORE",
+            "situation": "UNASSIGNED",
+          },
+          {
+            "action": "UNLINK",
+            "situation": "LINK_ONLY",
+          },
+          {
+            "action": "IGNORE",
+            "situation": "TARGET_IGNORED",
+          },
+          {
+            "action": "IGNORE",
+            "situation": "SOURCE_IGNORED",
+          },
+          {
+            "action": "IGNORE",
+            "situation": "ALL_GONE",
+          },
+          {
+            "action": "UPDATE",
+            "situation": "CONFIRMED",
+          },
+          {
+            "action": "LINK",
+            "situation": "FOUND",
+          },
+          {
+            "action": "CREATE",
+            "situation": "ABSENT",
+          },
+        ],
+        "properties": [
+          {
+            "condition": {
+              "globals": {},
+              "source": "object.custom_password_encrypted != null",
+              "type": "text/javascript",
+            },
+            "source": "custom_password_encrypted",
+            "target": "__PASSWORD__",
+            "transform": {
+              "globals": {},
+              "source": "openidm.decrypt(source);",
+              "type": "text/javascript",
+            },
+          },
+          {
+            "source": "cn",
+            "target": "__NAME__",
+            "transform": {
+              "globals": {},
+              "source": "source + "@" + identityServer.getProperty("esv.gac.domain");",
+              "type": "text/javascript",
+            },
+          },
+          {
+            "source": "givenName",
+            "target": "givenName",
+          },
+          {
+            "source": "",
+            "target": "familyName",
+            "transform": {
+              "globals": {},
+              "source": "if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {
+  source.sn + " (Student)"
+} else {
+  source.sn
+}",
+              "type": "text/javascript",
+            },
+          },
+        ],
+        "queuedSync": {
+          "enabled": true,
+          "maxQueueSize": 20000,
+          "maxRetries": 5,
+          "pageSize": 100,
+          "pollingInterval": 1000,
+          "postRetryAction": "logged-ignore",
+          "retryDelay": 1000,
+        },
+        "source": "managed/alpha_user",
+        "syncAfter": [
+          "managedBravo_user_managedBravo_user",
+          "managedAlpha_application_managedBravo_application",
+          "managedAlpha_user_managedBravo_user",
+          "managedBravo_user_managedAlpha_user",
+        ],
+        "target": "system/GoogleApps/__ACCOUNT__",
+        "validSource": {
+          "globals": {},
+          "source": "var isGoogleEligible = true;
+//var logMsg = "idmlog: ---AplhaUser2GAC (username: " + source.userName + " - userType: " + source.frIndexedInteger1 + " cn: " + source.cn + ") -";
+var logMsg = "idmlog: ---AplhaUser2GAC (username: " + source.userName + " - userType: " + source.frIndexedInteger1 + ") -";
+
+//Get Applicable userTypes (no Parent accounts)
+if (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {
+	isGoogleEligible = false;
+	logMsg = logMsg + " Account type not eligible.";
+}
+
+//Make sure the account has a valid encrypted password.
+if (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {
+	isGoogleEligible = false;
+	logMsg = logMsg + " No encrypted password yet.";
+}
+
+//Check that CN exists and has no space.
+if (source.cn && source.cn.includes(' ')) {
+	isGoogleEligible = false;
+	logMsg = logMsg + " CN with a space is not allowed.";
+}
+
+if (!isGoogleEligible) {
+	logMsg = logMsg + " Not sent to Google."
+	logger.info(logMsg);
+} 
+
+if (isGoogleEligible) {
+	logMsg = logMsg + " Sent to Google."
+	logger.info(logMsg);
+}
+
+isGoogleEligible;
+",
+          "type": "text/javascript",
+        },
+      },
+      {
+        "_id": "sync/mapping1",
+        "consentRequired": false,
+        "displayName": "mapping1",
+        "linkQualifiers": [],
+        "name": "mapping1",
+        "policies": [],
+        "properties": [],
+        "source": "system/connector1/bravo_user",
+        "syncAfter": [
+          "managedBravo_user_managedBravo_user",
+          "managedAlpha_application_managedBravo_application",
+          "managedAlpha_user_managedBravo_user",
+          "managedBravo_user_managedAlpha_user",
+          "AlphaUser2GoogleApps",
+        ],
+        "target": "system/connector1/bravo_user",
+      },
+      {
+        "_id": "sync/mapping11",
+        "consentRequired": true,
+        "displayName": "mapping11",
+        "linkQualifiers": [],
+        "name": "mapping11",
+        "policies": [],
+        "properties": [],
+        "source": "managed/bravo_user",
+        "syncAfter": [
+          "managedBravo_user_managedBravo_user",
+          "managedAlpha_application_managedBravo_application",
+          "managedAlpha_user_managedBravo_user",
+          "managedBravo_user_managedAlpha_user",
+          "AlphaUser2GoogleApps",
+          "mapping1",
+        ],
+        "target": "managed/bravo_user",
+      },
+      {
+        "_id": "sync/mapping3",
+        "consentRequired": false,
+        "displayName": "mapping3",
+        "linkQualifiers": [],
+        "name": "mapping3",
+        "policies": [],
+        "properties": [],
+        "source": "managed/bravo_user",
+        "syncAfter": [
+          "managedBravo_user_managedBravo_user",
+          "managedAlpha_application_managedBravo_application",
+          "managedAlpha_user_managedBravo_user",
+          "managedBravo_user_managedAlpha_user",
+          "AlphaUser2GoogleApps",
+          "mapping1",
+          "mapping11",
+        ],
+        "target": "managed/bravo_user",
+      },
+    ],
+  },
+}
+`;
+
+exports[`MappingOps importFirstMapping() 1: Should import first sync mapping 1`] = `
+{
+  "_id": "sync/mapping7",
+  "consentRequired": false,
+  "displayName": "mapping7",
+  "linkQualifiers": [],
+  "name": "mapping7",
+  "policies": [],
+  "properties": [],
+  "source": "managed/bravo_user",
+  "syncAfter": [],
+  "target": "managed/bravo_user",
+}
+`;
+
+exports[`MappingOps importFirstMapping() 2: Should import first regular mapping 1`] = `
+{
+  "_id": "mapping/mapping8",
+  "consentRequired": false,
+  "displayName": "mapping8",
+  "linkQualifiers": [],
+  "name": "mapping8",
+  "policies": [],
+  "properties": [],
+  "source": "managed/bravo_user",
+  "syncAfter": [],
+  "target": "managed/bravo_user",
+}
+`;
+
+exports[`MappingOps importMapping() 1: Should import sync mapping 1`] = `
+{
+  "_id": "sync/mapping5",
+  "consentRequired": false,
+  "displayName": "mapping5",
+  "linkQualifiers": [],
+  "name": "mapping5",
+  "policies": [],
+  "properties": [],
+  "source": "managed/bravo_user",
+  "syncAfter": [],
+  "target": "managed/bravo_user",
+}
+`;
+
+exports[`MappingOps importMapping() 2: Should import regular mapping 1`] = `
+{
+  "_id": "mapping/mapping6",
+  "consentRequired": false,
+  "displayName": "mapping6",
+  "linkQualifiers": [],
+  "name": "mapping6",
+  "policies": [],
+  "properties": [],
+  "source": "managed/bravo_user",
+  "syncAfter": [],
+  "target": "managed/bravo_user",
+}
+`;
+
+exports[`MappingOps importMappings() 1: Should import mappings 1`] = `
+[
+  {
+    "_id": "mapping/mapping10",
+    "consentRequired": false,
+    "displayName": "mapping10",
+    "linkQualifiers": [],
+    "name": "mapping10",
+    "policies": [],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [],
+    "target": "managed/bravo_user",
+  },
+  {
+    "_id": "sync/mapping9",
+    "consentRequired": false,
+    "displayName": "mapping9",
+    "linkQualifiers": [],
+    "name": "mapping9",
+    "policies": [],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [],
+    "target": "managed/bravo_user",
+  },
+]
+`;
+
+exports[`MappingOps readMapping() 1: Should read sync mapping 1`] = `
+{
+  "_id": "sync/mapping1",
+  "consentRequired": false,
+  "displayName": "mapping1",
+  "linkQualifiers": [],
+  "name": "mapping1",
+  "policies": [],
+  "properties": [],
+  "source": "system/connector1/bravo_user",
+  "syncAfter": [
+    "managedBravo_user_managedBravo_user",
+    "managedAlpha_application_managedBravo_application",
+    "managedAlpha_user_managedBravo_user",
+    "managedBravo_user_managedAlpha_user",
+    "AlphaUser2GoogleApps",
+  ],
+  "target": "system/connector1/bravo_user",
+}
+`;
+
+exports[`MappingOps readMapping() 2: Should read regular mapping 1`] = `
+{
+  "_id": "mapping/mapping2",
+  "consentRequired": false,
+  "displayName": "mapping2",
+  "linkQualifiers": [],
+  "name": "mapping2",
+  "policies": [],
+  "properties": [],
+  "source": "managed/bravo_user",
+  "syncAfter": [],
+  "target": "managed/bravo_user",
+}
+`;
+
+exports[`MappingOps readMappings() 1: Read mappings 1`] = `
+[
+  {
+    "_id": "sync/managedBravo_user_managedBravo_user",
+    "consentRequired": false,
+    "displayName": "managedBravo_user_managedBravo_user",
+    "icon": null,
+    "name": "managedBravo_user_managedBravo_user",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [],
+    "target": "managed/bravo_user",
+  },
+  {
+    "_id": "sync/managedAlpha_application_managedBravo_application",
+    "consentRequired": true,
+    "displayName": "Test Application Mapping",
+    "icon": null,
+    "name": "managedAlpha_application_managedBravo_application",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [
+      {
+        "source": "authoritative",
+        "target": "_id",
+      },
+    ],
+    "source": "managed/alpha_application",
+    "sourceQuery": {
+      "_queryFilter": "(eq "" or eq "")",
+    },
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+    ],
+    "target": "managed/bravo_application",
+    "targetQuery": {
+      "_queryFilter": "!(eq "")",
+    },
+  },
+  {
+    "_id": "sync/managedAlpha_user_managedBravo_user",
+    "consentRequired": true,
+    "displayName": "Test Mapping for Frodo",
+    "icon": null,
+    "name": "managedAlpha_user_managedBravo_user",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [
+      {
+        "condition": {
+          "globals": {},
+          "source": "console.log("Hello World!");",
+          "type": "text/javascript",
+        },
+        "default": [
+          "Default value string",
+        ],
+        "source": "accountStatus",
+        "target": "applications",
+        "transform": {
+          "globals": {},
+          "source": "console.log("hello");",
+          "type": "text/javascript",
+        },
+      },
+    ],
+    "source": "managed/alpha_user",
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+      "managedAlpha_application_managedBravo_application",
+    ],
+    "target": "managed/bravo_user",
+  },
+  {
+    "_id": "sync/managedBravo_user_managedAlpha_user",
+    "consentRequired": false,
+    "displayName": "Frodo test mapping",
+    "icon": null,
+    "name": "managedBravo_user_managedAlpha_user",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+      "managedAlpha_application_managedBravo_application",
+      "managedAlpha_user_managedBravo_user",
+    ],
+    "target": "managed/alpha_user",
+  },
+  {
+    "_id": "sync/AlphaUser2GoogleApps",
+    "consentRequired": false,
+    "correlationQuery": [
+      {
+        "expressionTree": {
+          "all": [
+            "__NAME__",
+          ],
+        },
+        "file": "ui/correlateTreeToQueryFilter.js",
+        "linkQualifier": "default",
+        "mapping": "AlphaUser2GoogleApps",
+        "type": "text/javascript",
+      },
+    ],
+    "displayName": "AlphaUser2GoogleApps",
+    "enableSync": {
+      "$bool": "&{esv.gac.enable.mapping}",
+    },
+    "icon": null,
+    "name": "AlphaUser2GoogleApps",
+    "onCreate": {
+      "globals": {},
+      "source": "target.orgUnitPath = "/NewAccounts";",
+      "type": "text/javascript",
+    },
+    "onUpdate": {
+      "globals": {},
+      "source": "//testing1234
+target.givenName = oldTarget.givenName;
+target.familyName = oldTarget.familyName;
+target.__NAME__ = oldTarget.__NAME__;",
+      "type": "text/javascript",
+    },
+    "policies": [
+      {
+        "action": "EXCEPTION",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "UNLINK",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": {
+          "globals": {},
+          "source": "// Timing Constants
+var ATTEMPT = 6; // Number of attempts to find the Google user.
+var SLEEP_TIME = 500; // Milliseconds between retries.
+var SYSTEM_ENDPOINT = "system/GoogleApps/__ACCOUNT__";
+var MAPPING_NAME = "AlphaUser2GoogleApps";
+var GOOGLE_DOMAIN = identityServer.getProperty("esv.gac.domain");
+var googleEmail = source.userName + "@" + GOOGLE_DOMAIN;
+var frUserGUID = source._id;
+var resultingAction = "ASYNC";
+
+// Get the Google GUID
+var linkQueryParams = {'_queryFilter': 'firstId eq "' + frUserGUID + '" and linkType eq "' + MAPPING_NAME + '"'};
+var linkResults = openidm.query("repo/link/", linkQueryParams, null);
+var googleGUID;
+
+if (linkResults.resultCount === 1) {
+  googleGUID = linkResults.result[0].secondId;
+}
+
+var queryResults; // Resulting query from looking for the Google user.
+var params = {'_queryFilter': '__UID__ eq "' + googleGUID + '"'};
+
+for (var i = 1; i <= ATTEMPT; i++) {
+    queryResults = openidm.query(SYSTEM_ENDPOINT, params);
+    if (queryResults.result && queryResults.result.length > 0) {
+        logger.info("idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in " + i + " attempts. Query result: " + JSON.stringify(queryResults));
+        resultingAction = "UPDATE";
+        break;
+    }
+    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.
+}
+
+if (!queryResults.result || queryResults.resultCount === 0) {
+    logger.warn("idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - " + googleEmail + " not found after " + ATTEMPT + " attempts.");
+    resultingAction = "UNLINK";
+}
+resultingAction;
+",
+          "type": "text/javascript",
+        },
+        "situation": "MISSING",
+      },
+      {
+        "action": "EXCEPTION",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "IGNORE",
+        "situation": "UNQUALIFIED",
+      },
+      {
+        "action": "IGNORE",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "UNLINK",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "IGNORE",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "IGNORE",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "IGNORE",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "UPDATE",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "LINK",
+        "situation": "FOUND",
+      },
+      {
+        "action": "CREATE",
+        "situation": "ABSENT",
+      },
+    ],
+    "properties": [
+      {
+        "condition": {
+          "globals": {},
+          "source": "object.custom_password_encrypted != null",
+          "type": "text/javascript",
+        },
+        "source": "custom_password_encrypted",
+        "target": "__PASSWORD__",
+        "transform": {
+          "globals": {},
+          "source": "openidm.decrypt(source);",
+          "type": "text/javascript",
+        },
+      },
+      {
+        "source": "cn",
+        "target": "__NAME__",
+        "transform": {
+          "globals": {},
+          "source": "source + "@" + identityServer.getProperty("esv.gac.domain");",
+          "type": "text/javascript",
+        },
+      },
+      {
+        "source": "givenName",
+        "target": "givenName",
+      },
+      {
+        "source": "",
+        "target": "familyName",
+        "transform": {
+          "globals": {},
+          "source": "if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {
+  source.sn + " (Student)"
+} else {
+  source.sn
+}",
+          "type": "text/javascript",
+        },
+      },
+    ],
+    "queuedSync": {
+      "enabled": true,
+      "maxQueueSize": 20000,
+      "maxRetries": 5,
+      "pageSize": 100,
+      "pollingInterval": 1000,
+      "postRetryAction": "logged-ignore",
+      "retryDelay": 1000,
+    },
+    "source": "managed/alpha_user",
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+      "managedAlpha_application_managedBravo_application",
+      "managedAlpha_user_managedBravo_user",
+      "managedBravo_user_managedAlpha_user",
+    ],
+    "target": "system/GoogleApps/__ACCOUNT__",
+    "validSource": {
+      "globals": {},
+      "source": "var isGoogleEligible = true;
+//var logMsg = "idmlog: ---AplhaUser2GAC (username: " + source.userName + " - userType: " + source.frIndexedInteger1 + " cn: " + source.cn + ") -";
+var logMsg = "idmlog: ---AplhaUser2GAC (username: " + source.userName + " - userType: " + source.frIndexedInteger1 + ") -";
+
+//Get Applicable userTypes (no Parent accounts)
+if (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {
+	isGoogleEligible = false;
+	logMsg = logMsg + " Account type not eligible.";
+}
+
+//Make sure the account has a valid encrypted password.
+if (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {
+	isGoogleEligible = false;
+	logMsg = logMsg + " No encrypted password yet.";
+}
+
+//Check that CN exists and has no space.
+if (source.cn && source.cn.includes(' ')) {
+	isGoogleEligible = false;
+	logMsg = logMsg + " CN with a space is not allowed.";
+}
+
+if (!isGoogleEligible) {
+	logMsg = logMsg + " Not sent to Google."
+	logger.info(logMsg);
+} 
+
+if (isGoogleEligible) {
+	logMsg = logMsg + " Sent to Google."
+	logger.info(logMsg);
+}
+
+isGoogleEligible;
+",
+      "type": "text/javascript",
+    },
+  },
+  {
+    "_id": "sync/mapping1",
+    "consentRequired": false,
+    "displayName": "mapping1",
+    "linkQualifiers": [],
+    "name": "mapping1",
+    "policies": [],
+    "properties": [],
+    "source": "system/connector1/bravo_user",
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+      "managedAlpha_application_managedBravo_application",
+      "managedAlpha_user_managedBravo_user",
+      "managedBravo_user_managedAlpha_user",
+      "AlphaUser2GoogleApps",
+    ],
+    "target": "system/connector1/bravo_user",
+  },
+  {
+    "_id": "sync/mapping11",
+    "consentRequired": false,
+    "displayName": "mapping11",
+    "linkQualifiers": [],
+    "name": "mapping11",
+    "policies": [],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+      "managedAlpha_application_managedBravo_application",
+      "managedAlpha_user_managedBravo_user",
+      "managedBravo_user_managedAlpha_user",
+      "AlphaUser2GoogleApps",
+      "mapping1",
+    ],
+    "target": "managed/bravo_user",
+  },
+  {
+    "_id": "mapping/managedAlpha_assignment_managedBravo_assignment",
+    "consentRequired": false,
+    "displayName": "managedAlpha_assignment_managedBravo_assignment",
+    "icon": null,
+    "name": "managedAlpha_assignment_managedBravo_assignment",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [],
+    "source": "managed/alpha_assignment",
+    "target": "managed/bravo_assignment",
+  },
+  {
+    "_id": "mapping/managedBravo_group_managedBravo_group",
+    "consentRequired": false,
+    "displayName": "managedBravo_group_managedBravo_group",
+    "icon": null,
+    "name": "managedBravo_group_managedBravo_group",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [],
+    "source": "managed/bravo_group",
+    "target": "managed/bravo_group",
+  },
+  {
+    "_id": "mapping/mapping12",
+    "consentRequired": false,
+    "displayName": "mapping12",
+    "linkQualifiers": [],
+    "name": "mapping12",
+    "policies": [],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [],
+    "target": "managed/bravo_user",
+  },
+  {
+    "_id": "mapping/mapping2",
+    "consentRequired": false,
+    "displayName": "mapping2",
+    "linkQualifiers": [],
+    "name": "mapping2",
+    "policies": [],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [],
+    "target": "managed/bravo_user",
+  },
+  {
+    "_id": "mapping/managedBravo_user_managedBravo_user0",
+    "consentRequired": false,
+    "displayName": "managedBravo_user_managedBravo_user0",
+    "icon": null,
+    "name": "managedBravo_user_managedBravo_user0",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [
+      "managedAlpha_assignment_managedBravo_assignment",
+    ],
+    "target": "managed/bravo_user",
+  },
+]
+`;
+
+exports[`MappingOps readNewMappings() 1: Read new mappings 1`] = `
+[
+  {
+    "_id": "mapping/managedAlpha_assignment_managedBravo_assignment",
+    "consentRequired": false,
+    "displayName": "managedAlpha_assignment_managedBravo_assignment",
+    "icon": null,
+    "name": "managedAlpha_assignment_managedBravo_assignment",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [],
+    "source": "managed/alpha_assignment",
+    "target": "managed/bravo_assignment",
+  },
+  {
+    "_id": "mapping/managedBravo_group_managedBravo_group",
+    "consentRequired": false,
+    "displayName": "managedBravo_group_managedBravo_group",
+    "icon": null,
+    "name": "managedBravo_group_managedBravo_group",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [],
+    "source": "managed/bravo_group",
+    "target": "managed/bravo_group",
+  },
+  {
+    "_id": "mapping/mapping12",
+    "consentRequired": false,
+    "displayName": "mapping12",
+    "linkQualifiers": [],
+    "name": "mapping12",
+    "policies": [],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [],
+    "target": "managed/bravo_user",
+  },
+  {
+    "_id": "mapping/mapping2",
+    "consentRequired": false,
+    "displayName": "mapping2",
+    "linkQualifiers": [],
+    "name": "mapping2",
+    "policies": [],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [],
+    "target": "managed/bravo_user",
+  },
+  {
+    "_id": "mapping/managedBravo_user_managedBravo_user0",
+    "consentRequired": false,
+    "displayName": "managedBravo_user_managedBravo_user0",
+    "icon": null,
+    "name": "managedBravo_user_managedBravo_user0",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [
+      "managedAlpha_assignment_managedBravo_assignment",
+    ],
+    "target": "managed/bravo_user",
+  },
+]
+`;
+
+exports[`MappingOps readSyncMappings() 1: Read sync mappings 1`] = `
+[
+  {
+    "_id": "sync/managedBravo_user_managedBravo_user",
+    "consentRequired": false,
+    "displayName": "managedBravo_user_managedBravo_user",
+    "icon": null,
+    "name": "managedBravo_user_managedBravo_user",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [],
+    "target": "managed/bravo_user",
+  },
+  {
+    "_id": "sync/managedAlpha_application_managedBravo_application",
+    "consentRequired": true,
+    "displayName": "Test Application Mapping",
+    "icon": null,
+    "name": "managedAlpha_application_managedBravo_application",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [
+      {
+        "source": "authoritative",
+        "target": "_id",
+      },
+    ],
+    "source": "managed/alpha_application",
+    "sourceQuery": {
+      "_queryFilter": "(eq "" or eq "")",
+    },
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+    ],
+    "target": "managed/bravo_application",
+    "targetQuery": {
+      "_queryFilter": "!(eq "")",
+    },
+  },
+  {
+    "_id": "sync/managedAlpha_user_managedBravo_user",
+    "consentRequired": true,
+    "displayName": "Test Mapping for Frodo",
+    "icon": null,
+    "name": "managedAlpha_user_managedBravo_user",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [
+      {
+        "condition": {
+          "globals": {},
+          "source": "console.log("Hello World!");",
+          "type": "text/javascript",
+        },
+        "default": [
+          "Default value string",
+        ],
+        "source": "accountStatus",
+        "target": "applications",
+        "transform": {
+          "globals": {},
+          "source": "console.log("hello");",
+          "type": "text/javascript",
+        },
+      },
+    ],
+    "source": "managed/alpha_user",
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+      "managedAlpha_application_managedBravo_application",
+    ],
+    "target": "managed/bravo_user",
+  },
+  {
+    "_id": "sync/managedBravo_user_managedAlpha_user",
+    "consentRequired": false,
+    "displayName": "Frodo test mapping",
+    "icon": null,
+    "name": "managedBravo_user_managedAlpha_user",
+    "policies": [
+      {
+        "action": "ASYNC",
+        "situation": "ABSENT",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "ASYNC",
+        "situation": "UNQUALIFIED",
+      },
+    ],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+      "managedAlpha_application_managedBravo_application",
+      "managedAlpha_user_managedBravo_user",
+    ],
+    "target": "managed/alpha_user",
+  },
+  {
+    "_id": "sync/AlphaUser2GoogleApps",
+    "consentRequired": false,
+    "correlationQuery": [
+      {
+        "expressionTree": {
+          "all": [
+            "__NAME__",
+          ],
+        },
+        "file": "ui/correlateTreeToQueryFilter.js",
+        "linkQualifier": "default",
+        "mapping": "AlphaUser2GoogleApps",
+        "type": "text/javascript",
+      },
+    ],
+    "displayName": "AlphaUser2GoogleApps",
+    "enableSync": {
+      "$bool": "&{esv.gac.enable.mapping}",
+    },
+    "icon": null,
+    "name": "AlphaUser2GoogleApps",
+    "onCreate": {
+      "globals": {},
+      "source": "target.orgUnitPath = "/NewAccounts";",
+      "type": "text/javascript",
+    },
+    "onUpdate": {
+      "globals": {},
+      "source": "//testing1234
+target.givenName = oldTarget.givenName;
+target.familyName = oldTarget.familyName;
+target.__NAME__ = oldTarget.__NAME__;",
+      "type": "text/javascript",
+    },
+    "policies": [
+      {
+        "action": "EXCEPTION",
+        "situation": "AMBIGUOUS",
+      },
+      {
+        "action": "UNLINK",
+        "situation": "SOURCE_MISSING",
+      },
+      {
+        "action": {
+          "globals": {},
+          "source": "// Timing Constants
+var ATTEMPT = 6; // Number of attempts to find the Google user.
+var SLEEP_TIME = 500; // Milliseconds between retries.
+var SYSTEM_ENDPOINT = "system/GoogleApps/__ACCOUNT__";
+var MAPPING_NAME = "AlphaUser2GoogleApps";
+var GOOGLE_DOMAIN = identityServer.getProperty("esv.gac.domain");
+var googleEmail = source.userName + "@" + GOOGLE_DOMAIN;
+var frUserGUID = source._id;
+var resultingAction = "ASYNC";
+
+// Get the Google GUID
+var linkQueryParams = {'_queryFilter': 'firstId eq "' + frUserGUID + '" and linkType eq "' + MAPPING_NAME + '"'};
+var linkResults = openidm.query("repo/link/", linkQueryParams, null);
+var googleGUID;
+
+if (linkResults.resultCount === 1) {
+  googleGUID = linkResults.result[0].secondId;
+}
+
+var queryResults; // Resulting query from looking for the Google user.
+var params = {'_queryFilter': '__UID__ eq "' + googleGUID + '"'};
+
+for (var i = 1; i <= ATTEMPT; i++) {
+    queryResults = openidm.query(SYSTEM_ENDPOINT, params);
+    if (queryResults.result && queryResults.result.length > 0) {
+        logger.info("idmlog: ---AlphaUser2GoogleApps - Missing->UPDATE - Result found in " + i + " attempts. Query result: " + JSON.stringify(queryResults));
+        resultingAction = "UPDATE";
+        break;
+    }
+    java.lang.Thread.sleep(SLEEP_TIME); // Wait before trying again.
+}
+
+if (!queryResults.result || queryResults.resultCount === 0) {
+    logger.warn("idmlog: ---AlphaUser2GoogleApps - Missing->UNLINK - " + googleEmail + " not found after " + ATTEMPT + " attempts.");
+    resultingAction = "UNLINK";
+}
+resultingAction;
+",
+          "type": "text/javascript",
+        },
+        "situation": "MISSING",
+      },
+      {
+        "action": "EXCEPTION",
+        "situation": "FOUND_ALREADY_LINKED",
+      },
+      {
+        "action": "IGNORE",
+        "situation": "UNQUALIFIED",
+      },
+      {
+        "action": "IGNORE",
+        "situation": "UNASSIGNED",
+      },
+      {
+        "action": "UNLINK",
+        "situation": "LINK_ONLY",
+      },
+      {
+        "action": "IGNORE",
+        "situation": "TARGET_IGNORED",
+      },
+      {
+        "action": "IGNORE",
+        "situation": "SOURCE_IGNORED",
+      },
+      {
+        "action": "IGNORE",
+        "situation": "ALL_GONE",
+      },
+      {
+        "action": "UPDATE",
+        "situation": "CONFIRMED",
+      },
+      {
+        "action": "LINK",
+        "situation": "FOUND",
+      },
+      {
+        "action": "CREATE",
+        "situation": "ABSENT",
+      },
+    ],
+    "properties": [
+      {
+        "condition": {
+          "globals": {},
+          "source": "object.custom_password_encrypted != null",
+          "type": "text/javascript",
+        },
+        "source": "custom_password_encrypted",
+        "target": "__PASSWORD__",
+        "transform": {
+          "globals": {},
+          "source": "openidm.decrypt(source);",
+          "type": "text/javascript",
+        },
+      },
+      {
+        "source": "cn",
+        "target": "__NAME__",
+        "transform": {
+          "globals": {},
+          "source": "source + "@" + identityServer.getProperty("esv.gac.domain");",
+          "type": "text/javascript",
+        },
+      },
+      {
+        "source": "givenName",
+        "target": "givenName",
+      },
+      {
+        "source": "",
+        "target": "familyName",
+        "transform": {
+          "globals": {},
+          "source": "if (source.frIndexedInteger1 > 2 && source.frIndexedInteger1 < 6) {
+  source.sn + " (Student)"
+} else {
+  source.sn
+}",
+          "type": "text/javascript",
+        },
+      },
+    ],
+    "queuedSync": {
+      "enabled": true,
+      "maxQueueSize": 20000,
+      "maxRetries": 5,
+      "pageSize": 100,
+      "pollingInterval": 1000,
+      "postRetryAction": "logged-ignore",
+      "retryDelay": 1000,
+    },
+    "source": "managed/alpha_user",
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+      "managedAlpha_application_managedBravo_application",
+      "managedAlpha_user_managedBravo_user",
+      "managedBravo_user_managedAlpha_user",
+    ],
+    "target": "system/GoogleApps/__ACCOUNT__",
+    "validSource": {
+      "globals": {},
+      "source": "var isGoogleEligible = true;
+//var logMsg = "idmlog: ---AplhaUser2GAC (username: " + source.userName + " - userType: " + source.frIndexedInteger1 + " cn: " + source.cn + ") -";
+var logMsg = "idmlog: ---AplhaUser2GAC (username: " + source.userName + " - userType: " + source.frIndexedInteger1 + ") -";
+
+//Get Applicable userTypes (no Parent accounts)
+if (source.frIndexedInteger1 !== 0 && source.frIndexedInteger1 !== 1 && source.frIndexedInteger1 !== 3 && source.frIndexedInteger1 !== 4 && source.frIndexedInteger1 !== 5) {
+	isGoogleEligible = false;
+	logMsg = logMsg + " Account type not eligible.";
+}
+
+//Make sure the account has a valid encrypted password.
+if (source.custom_password_encrypted == undefined || source.custom_password_encrypted == null) {
+	isGoogleEligible = false;
+	logMsg = logMsg + " No encrypted password yet.";
+}
+
+//Check that CN exists and has no space.
+if (source.cn && source.cn.includes(' ')) {
+	isGoogleEligible = false;
+	logMsg = logMsg + " CN with a space is not allowed.";
+}
+
+if (!isGoogleEligible) {
+	logMsg = logMsg + " Not sent to Google."
+	logger.info(logMsg);
+} 
+
+if (isGoogleEligible) {
+	logMsg = logMsg + " Sent to Google."
+	logger.info(logMsg);
+}
+
+isGoogleEligible;
+",
+      "type": "text/javascript",
+    },
+  },
+  {
+    "_id": "sync/mapping1",
+    "consentRequired": false,
+    "displayName": "mapping1",
+    "linkQualifiers": [],
+    "name": "mapping1",
+    "policies": [],
+    "properties": [],
+    "source": "system/connector1/bravo_user",
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+      "managedAlpha_application_managedBravo_application",
+      "managedAlpha_user_managedBravo_user",
+      "managedBravo_user_managedAlpha_user",
+      "AlphaUser2GoogleApps",
+    ],
+    "target": "system/connector1/bravo_user",
+  },
+  {
+    "_id": "sync/mapping11",
+    "consentRequired": false,
+    "displayName": "mapping11",
+    "linkQualifiers": [],
+    "name": "mapping11",
+    "policies": [],
+    "properties": [],
+    "source": "managed/bravo_user",
+    "syncAfter": [
+      "managedBravo_user_managedBravo_user",
+      "managedAlpha_application_managedBravo_application",
+      "managedAlpha_user_managedBravo_user",
+      "managedBravo_user_managedAlpha_user",
+      "AlphaUser2GoogleApps",
+      "mapping1",
+    ],
+    "target": "managed/bravo_user",
+  },
+]
+`;
+
+exports[`MappingOps updateMapping() 1: Should update sync mapping 1`] = `
+{
+  "_id": "sync/mapping11",
+  "consentRequired": true,
+  "displayName": "mapping11",
+  "linkQualifiers": [],
+  "name": "mapping11",
+  "policies": [],
+  "properties": [],
+  "source": "managed/bravo_user",
+  "syncAfter": [],
+  "target": "managed/bravo_user",
+}
+`;
+
+exports[`MappingOps updateMapping() 2: Should update regular mapping 1`] = `
+{
+  "_id": "mapping/mapping12",
+  "consentRequired": true,
+  "displayName": "mapping12",
+  "linkQualifiers": [],
+  "name": "mapping12",
+  "policies": [],
+  "properties": [],
+  "source": "managed/bravo_user",
+  "syncAfter": [],
+  "target": "managed/bravo_user",
+}
+`;

--- a/src/utils/ExportImportUtils.ts
+++ b/src/utils/ExportImportUtils.ts
@@ -325,9 +325,21 @@ export function getFilePath({
   mkdirs: boolean;
   state: State;
 }): string {
-  return state.getDirectory()
+  const path = state.getDirectory()
     ? `${getWorkingDirectory({ mkdirs, state })}/${fileName}`
     : fileName;
+  // If the fileName contains directories, make those directories.
+  if (mkdirs && fileName.includes('/')) {
+    const dir = path.substring(0, path.lastIndexOf('/'));
+    if (!fs.existsSync(dir)) {
+      debugMessage({
+        message: `ExportImportUtils.getFilePath: creating directory '${dir}'`,
+        state,
+      });
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  }
+  return path;
 }
 
 /**


### PR DESCRIPTION
This PR improves MappingOps functions by fixing bugs, improving code, and adding tests. 

The changes here are necessary for the PR in frodo-cli that adds the new mapping command.

One thing to note is that this PR adds a sorting function for sorting mappings in the readMappings function according to sync order. This is good for the list and rename sub-commands in the CLI where ordering mappings by sync order would be a nice feature to have. There is an endpoint that is supposed to return all mappings in correct sync order which should be used instead when reading mappings, but I found that it doesn't always work as described in the [documentation](https://backstage.forgerock.com/docs/idm/7.5/synchronization-guide/mappings.html). In short, I found that not all mappings are always returned from the endpoint, and when I have successfully pulled all mappings from the endpoint, I found that the legacy mappings were ordered after the regular mappings instead of before as it should be according to the documentation. It's possible that the endpoint may not work as intended due to how I am creating/importing the regular mappings, but I'm not certain. In my experience, I haven't found a way to get the endpoint to work consistently, but if we can find a way to get it to work then we should probably use it instead.