### PR TITLE
Fix and Improve Script Exports and Imports

### DIFF
--- a/src/ops/ConfigOps.ts
+++ b/src/ops/ConfigOps.ts
@@ -427,7 +427,7 @@ export async function exportFullConfiguration({
           exportScripts,
           {
             options: {
-              includeLibraries: false,
+              deps: false,
               includeDefault,
               useStringArrays,
             },
@@ -617,6 +617,7 @@ export async function importFullConfiguration({
         scriptName: '',
         importData: importData.realm[realm],
         options: {
+          deps: false,
           reUuid: reUuidScripts,
           includeDefault,
         },

--- a/src/ops/ScriptOps.test.ts
+++ b/src/ops/ScriptOps.test.ts
@@ -255,7 +255,8 @@ describe('ScriptOps', () => {
       lastModifiedDate: 0,
     } as ScriptSkeleton,
   };
-  const import1: { name: string; data: ScriptOps.ScriptExportInterface } = {
+  const import1: { id: string; name: string; data: ScriptOps.ScriptExportInterface } = {
+    id: '5b3e4dd2-8060-4029-9ec1-6867932ab939',
     name: 'FrodoTestScript5',
     data: {
       meta: {
@@ -305,7 +306,8 @@ describe('ScriptOps', () => {
       },
     },
   };
-  const import2: { name: string; data: ScriptOps.ScriptExportInterface } = {
+  const import2: { id: string; name: string; data: ScriptOps.ScriptExportInterface } = {
+    id: '01e1a3c0-038b-4c16-956a-6c9d89328cff',
     name: 'Authentication Tree Decision Node Script',
     data: {
       meta: {
@@ -477,7 +479,7 @@ describe('ScriptOps', () => {
     test('1: Export all scripts', async () => {
       const response = await ScriptOps.exportScripts({
         options: {
-          includeLibraries: false,
+          deps: false,
           includeDefault: false,
           useStringArrays: true,
         },
@@ -491,7 +493,7 @@ describe('ScriptOps', () => {
     test('2: Export all scripts, including default scripts', async () => {
       const response = await ScriptOps.exportScripts({
         options: {
-          includeLibraries: false,
+          deps: false,
           includeDefault: true,
           useStringArrays: true,
         },
@@ -511,9 +513,11 @@ describe('ScriptOps', () => {
     test(`1: Import all scripts`, async () => {
       expect.assertions(1);
       const outcome = await ScriptOps.importScripts({
+        scriptId: '',
         scriptName: '',
         importData: import1.data,
         options: {
+          deps: true,
           reUuid: false,
           includeDefault: true,
         },
@@ -525,6 +529,7 @@ describe('ScriptOps', () => {
     test(`2: Import script by name`, async () => {
       expect.assertions(1);
       const result = await ScriptOps.importScripts({
+        scriptId: '',
         scriptName: import1.name,
         importData: import1.data,
         state,
@@ -532,12 +537,25 @@ describe('ScriptOps', () => {
       expect(result).toMatchSnapshot();
     });
 
-    test(`3: Import no scripts when excluding default scripts and only default scripts given`, async () => {
+    test(`3: Import script by id`, async () => {
       expect.assertions(1);
       const result = await ScriptOps.importScripts({
+        scriptId: import1.id,
+        scriptName: '',
+        importData: import1.data,
+        state,
+      });
+      expect(result).toMatchSnapshot();
+    });
+
+    test(`4: Import no scripts when excluding default scripts and only default scripts given`, async () => {
+      expect.assertions(1);
+      const result = await ScriptOps.importScripts({
+        scriptId: '',
         scriptName: '',
         importData: import2.data,
         options: {
+          deps: true,
           reUuid: false,
           includeDefault: false,
         },

--- a/src/test/mock-recordings/ScriptOps_3024995978/importScripts_707210791/3-Import-script-by-id_4252806626/recording.har
+++ b/src/test/mock-recordings/ScriptOps_3024995978/importScripts_707210791/3-Import-script-by-id_4252806626/recording.har
@@ -1,0 +1,178 @@
+{
+  "log": {
+    "_recordingName": "ScriptOps/importScripts()/3: Import script by id",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "e0852cf5a59dbf439163318b09ea5cf3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 969,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-9b7cf8d0-b63f-48de-a65a-5ac39ee5716a"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "969"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1977,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"5b3e4dd2-8060-4029-9ec1-6867932ab939\",\"name\":\"FrodoTestScript5\",\"description\":\"Check if username has already been collected.\",\"script\":\"LyogQ2hlY2sgVXNlcm5hbWUKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogQ2hlY2sgaWYgdXNlcm5hbWUgaGFzIGFscmVhZHkgYmVlbiBjb2xsZWN0ZWQuCiAqIFJldHVybiAia25vd24iIGlmIHllcywgInVua25vd24iIG90aGVyd2lzZS4KICogCiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuCiAqIAogKiBUaGUgU2NyaXB0ZWQgRGVjaXNpb24gTm9kZSBuZWVkcyB0aGUgZm9sbG93aW5nIG91dGNvbWVzIGRlZmluZWQ6CiAqIC0ga25vd24KICogLSB1bmtub3duCiAqLwooZnVuY3Rpb24gKCkgewogICAgaWYgKG51bGwgIT0gc2hhcmVkU3RhdGUuZ2V0KCJ1c2VybmFtZSIpKSB7CiAgICAgICAgb3V0Y29tZSA9ICJrbm93biI7CiAgICB9CiAgICBlbHNlIHsKICAgICAgICBvdXRjb21lID0gInVua25vd24iOwogICAgfQp9KCkpOw==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/5b3e4dd2-8060-4029-9ec1-6867932ab939"
+        },
+        "response": {
+          "bodySize": 1150,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1150,
+            "text": "{\"_id\":\"5b3e4dd2-8060-4029-9ec1-6867932ab939\",\"_rev\":\"-134762788\",\"name\":\"FrodoTestScript5\",\"description\":\"Check if username has already been collected.\",\"script\":\"LyogQ2hlY2sgVXNlcm5hbWUKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogQ2hlY2sgaWYgdXNlcm5hbWUgaGFzIGFscmVhZHkgYmVlbiBjb2xsZWN0ZWQuCiAqIFJldHVybiAia25vd24iIGlmIHllcywgInVua25vd24iIG90aGVyd2lzZS4KICogCiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuCiAqIAogKiBUaGUgU2NyaXB0ZWQgRGVjaXNpb24gTm9kZSBuZWVkcyB0aGUgZm9sbG93aW5nIG91dGNvbWVzIGRlZmluZWQ6CiAqIC0ga25vd24KICogLSB1bmtub3duCiAqLwooZnVuY3Rpb24gKCkgewogICAgaWYgKG51bGwgIT0gc2hhcmVkU3RhdGUuZ2V0KCJ1c2VybmFtZSIpKSB7CiAgICAgICAgb3V0Y29tZSA9ICJrbm93biI7CiAgICB9CiAgICBlbHNlIHsKICAgICAgICBvdXRjb21lID0gInVua25vd24iOwogICAgfQp9KCkpOw==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"creationDate\":1723668133912,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1723668133912,\"evaluatorVersion\":\"1.0\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-134762788\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/5b3e4dd2-8060-4029-9ec1-6867932ab939"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1150"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 14 Aug 2024 20:42:13 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-9b7cf8d0-b63f-48de-a65a-5ac39ee5716a"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 917,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/5b3e4dd2-8060-4029-9ec1-6867932ab939",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2024-08-14T20:42:13.868Z",
+        "time": 70,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 70
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/snapshots/ops/ScriptOps.test.js.snap
+++ b/src/test/snapshots/ops/ScriptOps.test.js.snap
@@ -13889,7 +13889,27 @@ exports[`ScriptOps importScripts() 2: Import script by name 1`] = `
 ]
 `;
 
-exports[`ScriptOps importScripts() 3: Import no scripts when excluding default scripts and only default scripts given 1`] = `[]`;
+exports[`ScriptOps importScripts() 3: Import script by id 1`] = `
+[
+  {
+    "_id": "5b3e4dd2-8060-4029-9ec1-6867932ab939",
+    "_rev": "-134762788",
+    "context": "AUTHENTICATION_TREE_DECISION_NODE",
+    "createdBy": "id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config",
+    "creationDate": 1723668133912,
+    "default": false,
+    "description": "Check if username has already been collected.",
+    "evaluatorVersion": "1.0",
+    "language": "JAVASCRIPT",
+    "lastModifiedBy": "id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config",
+    "lastModifiedDate": 1723668133912,
+    "name": "FrodoTestScript5",
+    "script": "LyogQ2hlY2sgVXNlcm5hbWUKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogQ2hlY2sgaWYgdXNlcm5hbWUgaGFzIGFscmVhZHkgYmVlbiBjb2xsZWN0ZWQuCiAqIFJldHVybiAia25vd24iIGlmIHllcywgInVua25vd24iIG90aGVyd2lzZS4KICogCiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuCiAqIAogKiBUaGUgU2NyaXB0ZWQgRGVjaXNpb24gTm9kZSBuZWVkcyB0aGUgZm9sbG93aW5nIG91dGNvbWVzIGRlZmluZWQ6CiAqIC0ga25vd24KICogLSB1bmtub3duCiAqLwooZnVuY3Rpb24gKCkgewogICAgaWYgKG51bGwgIT0gc2hhcmVkU3RhdGUuZ2V0KCJ1c2VybmFtZSIpKSB7CiAgICAgICAgb3V0Y29tZSA9ICJrbm93biI7CiAgICB9CiAgICBlbHNlIHsKICAgICAgICBvdXRjb21lID0gInVua25vd24iOwogICAgfQp9KCkpOw==",
+  },
+]
+`;
+
+exports[`ScriptOps importScripts() 4: Import no scripts when excluding default scripts and only default scripts given 1`] = `[]`;
 
 exports[`ScriptOps readScript() 1: Read script by id 'c9cb4b1e-1cd3-4e5b-8f56-140f83ba9f6d' 1`] = `
 {


### PR DESCRIPTION
This PR makes a few updates to help fix and improve script exports and imports. The main changes include:

1. Fixing script imports so that they can correctly import a single script.
2. Adding the option to import scripts by id
3. Implementing useStringArrays in exports and allowing imports to support single-string scripts in addition to string array scripts.
4. Make getting library scripts recursive in the event that there are library scripts dependent on other library scripts so that they all get exported.

There was some refactoring done as well to reduce code redundancy. Additionally, the includeLibraries flag was changed to be deps instead to be consistent with how the rest of Frodo handles dependencies. 

There is a PR in frodo-cli (with the same name as this one) that updates the CLI accordingly with these new changes in addition to some other bug fixes.