### PR TITLE
Update module build output to improve compatibility for ESM modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "2.1.0",
   "type": "commonjs",
   "main": "./dist/index.js",
-  "module": "./dist/esm/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
     }
   },
   "scripts": {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   bundle: true,
-  legacyOutput: true,
+  legacyOutput: false,
   external: [
     // list all the dev dependencies, which do NOT need to be bundled as indicated in package.json (_devDependencies)
     '@jest/globals',


### PR DESCRIPTION
Updates the `tsup` build configuration to package ESM module code with the `.mjs` file format, which ensures that CommonJs index.js is packaged into the same directory as index.mjs, and the types can be resolved from both.