### PR TITLE
Improve support for custom platform deployments (non-forgeops or customized forgeops)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tsup.config.bundled_*.mjs
 types
 dist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Improve support for custom platform deployments (non-forgeops or customized forgeops)
+
+  - rockcarver/frodo-cli#429: Added state functions to support custom oauth2 clients for IDM API calls:
+  
+    - `state.setAdminClientId(clientId: string): void`
+    - `state.getAdminClientId(): string`
+    - `state.setAdminRedirectUri(redirectUri: string): void`
+    - `state.getAdminRedirectUri(): string`
+
+  - rockcarver/frodo-cli#359: Added state functions to support custom IDM host URLs for all IDM API calls (e.g. platform deployments hosting AM and IDM on/in different DNS hosts/domains):
+  
+    - `state.setIdmHost(host: string): void`
+    - `state.getIdmHost(): string`
+
 ## [2.1.1] - 2024-08-23
 
 ### Fixed

--- a/src/api/IdmConfigApi.ts
+++ b/src/api/IdmConfigApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../shared/State';
-import { getHostBaseUrl } from '../utils/ForgeRockUtils';
+import { getIdmBaseUrl } from '../utils/ForgeRockUtils';
 import {
   IdObjectSkeletonInterface,
   NoIdObjectSkeletonInterface,
@@ -9,9 +9,9 @@ import {
 } from './ApiTypes';
 import { generateIdmApi } from './BaseApi';
 
-const idmAllConfigURLTemplate = '%s/openidm/config';
-const idmConfigURLTemplate = '%s/openidm/config/%s';
-const idmConfigEntityQueryTemplate = '%s/openidm/config?_queryFilter=%s';
+const idmAllConfigURLTemplate = '%s/config';
+const idmConfigURLTemplate = '%s/config/%s';
+const idmConfigEntityQueryTemplate = '%s/config?_queryFilter=%s';
 
 export type IdmConfigStub = IdObjectSkeletonInterface & {
   _id: string;
@@ -33,10 +33,7 @@ export async function getConfigStubs({
 }: {
   state: State;
 }): Promise<IdmConfigStubs> {
-  const urlString = util.format(
-    idmAllConfigURLTemplate,
-    getHostBaseUrl(state.getHost())
-  );
+  const urlString = util.format(idmAllConfigURLTemplate, getIdmBaseUrl(state));
   const { data } = await generateIdmApi({ state }).get(urlString);
   return data;
 }
@@ -52,7 +49,7 @@ export async function getConfigEntities({
 }): Promise<PagedResult<IdObjectSkeletonInterface>> {
   const urlString = util.format(
     idmConfigEntityQueryTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     'true'
   );
   const { data } = await generateIdmApi({ state }).get(urlString);
@@ -73,7 +70,7 @@ export async function getConfigEntitiesByType({
 }): Promise<PagedResult<NoIdObjectSkeletonInterface>> {
   const urlString = util.format(
     idmConfigEntityQueryTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     encodeURIComponent(`_id sw '${type}'`)
   );
   const { data } = await generateIdmApi({ state }).get(urlString);
@@ -94,7 +91,7 @@ export async function getConfigEntity({
 }) {
   const urlString = util.format(
     idmConfigURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     entityId
   );
   const { data } = await generateIdmApi({ state }).get(urlString);
@@ -122,7 +119,7 @@ export async function putConfigEntity({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     idmConfigURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     wait ? `${entityId}?waitForCompletion=true` : entityId
   );
   const { data } = await generateIdmApi({ state }).put(urlString, entityData);
@@ -143,7 +140,7 @@ export async function deleteConfigEntity({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     idmConfigURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     entityId
   );
   const { data } = await generateIdmApi({ state }).delete(urlString, {

--- a/src/api/IdmScriptApi.ts
+++ b/src/api/IdmScriptApi.ts
@@ -1,10 +1,10 @@
 import util from 'util';
 
 import { State } from '../shared/State';
-import { getHostBaseUrl } from '../utils/ForgeRockUtils';
+import { getIdmBaseUrl } from '../utils/ForgeRockUtils';
 import { generateIdmApi } from './BaseApi';
 
-const scriptActionsUrlTemplate = '%s/openidm/script?_action=%s';
+const scriptActionsUrlTemplate = '%s/script?_action=%s';
 
 /**
  * Test connector servers
@@ -19,7 +19,7 @@ export async function compileScript({
 }): Promise<string | object> {
   const urlString = util.format(
     scriptActionsUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     'compile'
   );
   const postData = {
@@ -44,7 +44,7 @@ export async function evaluateScript({
 }): Promise<any> {
   const urlString = util.format(
     scriptActionsUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     'eval'
   );
   const postData = {

--- a/src/api/IdmSystemApi.ts
+++ b/src/api/IdmSystemApi.ts
@@ -1,20 +1,18 @@
 import util from 'util';
 
 import { State } from '../shared/State';
-import { getHostBaseUrl } from '../utils/ForgeRockUtils';
+import { getIdmBaseUrl } from '../utils/ForgeRockUtils';
 import { IdObjectSkeletonInterface, PagedResult } from './ApiTypes';
 import { generateIdmApi } from './BaseApi';
 
-const systemActionsUrlTemplate = '%s/openidm/system?_action=%s';
-const systemTestUrlTemplate = '%s/openidm/system/%s?_action=test';
-const systemObjectActionsUrlTemplate = '%s/openidm/system/%s/%s?_action=%s';
+const systemActionsUrlTemplate = '%s/system?_action=%s';
+const systemTestUrlTemplate = '%s/system/%s?_action=test';
+const systemObjectActionsUrlTemplate = '%s/system/%s/%s?_action=%s';
 const systemRunScriptUrlTemplate =
-  '%s/openidm/system/%s?_action=script&scriptId=%s&scriptExecuteMode=resource';
-const systemQueryAllUrlTemplate =
-  '%s/openidm/system/%s/%s?_queryId=query-all-ids';
-const systemQueryByFilterUrlTemplate =
-  '%s/openidm/system/%s/%s?_queryFilter=%s';
-const systemObjectUrlTemplate = '%s/openidm/system/%s/%s/%s';
+  '%s/system/%s?_action=script&scriptId=%s&scriptExecuteMode=resource';
+const systemQueryAllUrlTemplate = '%s/system/%s/%s?_queryId=query-all-ids';
+const systemQueryByFilterUrlTemplate = '%s/system/%s/%s?_queryFilter=%s';
+const systemObjectUrlTemplate = '%s/system/%s/%s/%s';
 
 export const DEFAULT_PAGE_SIZE: number = 1000;
 
@@ -54,7 +52,7 @@ export async function testConnectorServers({
 }): Promise<TestConnectorServersInterface> {
   const urlString = util.format(
     systemActionsUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     'testConnectorServers'
   );
   const { data } = await generateIdmApi({ state, requestOverride: {} }).post(
@@ -70,7 +68,7 @@ export async function readAvailableSystems({
 }): Promise<SystemStatusInterface[]> {
   const urlString = util.format(
     systemActionsUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     'test'
   );
   const { data } = await generateIdmApi({ requestOverride: {}, state }).post(
@@ -88,7 +86,7 @@ export async function readSystemStatus({
 }): Promise<SystemStatusInterface> {
   const urlString = util.format(
     systemTestUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     systemName
   );
   const { data } = await generateIdmApi({ requestOverride: {}, state }).post(
@@ -112,7 +110,7 @@ export async function authenticateSystemObject({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     systemObjectActionsUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     systemName,
     systemObjectType,
     'authenticate'
@@ -135,7 +133,7 @@ export async function runSystemScript({
 }) {
   const urlString = util.format(
     systemRunScriptUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     systemName,
     scriptName
   );
@@ -167,7 +165,7 @@ export async function queryAllSystemObjectIds({
     : `${systemQueryAllUrlTemplate}${pagingParams}`;
   const urlString = util.format(
     urlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     systemName,
     systemObjectType
   );
@@ -201,7 +199,7 @@ export async function querySystemObjects({
     : `${systemQueryByFilterUrlTemplate}${pagingParams}${fieldsParam}`;
   const urlString = util.format(
     urlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     systemName,
     systemObjectType,
     decodeURIComponent(filter) === filter ? encodeURIComponent(filter) : filter
@@ -228,7 +226,7 @@ export async function getSystemObject({
   const fieldsParam = `_fields=${fields.join(',')}`;
   const urlString = util.format(
     `${systemObjectUrlTemplate}?${fieldsParam}`,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     systemName,
     systemObjectType,
     systemObjectId
@@ -252,7 +250,7 @@ export async function createSystemObject({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     systemObjectActionsUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     systemName,
     systemObjectType,
     'create'
@@ -281,7 +279,7 @@ export async function putSystemObject({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     systemObjectUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     systemName,
     systemObjectType,
     systemObjectId
@@ -325,7 +323,7 @@ export async function patchSystemObject({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     systemObjectUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     systemName,
     systemObjectType,
     systemObjectId
@@ -350,7 +348,7 @@ export async function deleteSystemObject({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     systemObjectUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     systemName,
     systemObjectType,
     systemObjectId

--- a/src/api/ManagedObjectApi.ts
+++ b/src/api/ManagedObjectApi.ts
@@ -1,14 +1,14 @@
 import util from 'util';
 
 import { State } from '../shared/State';
-import { getHostBaseUrl } from '../utils/ForgeRockUtils';
+import { getIdmBaseUrl } from '../utils/ForgeRockUtils';
 import { IdObjectSkeletonInterface, PagedResult } from './ApiTypes';
 import { generateIdmApi } from './BaseApi';
 
-const createManagedObjectURLTemplate = '%s/openidm/managed/%s?_action=create';
-const managedObjectByIdURLTemplate = '%s/openidm/managed/%s/%s';
-const queryAllManagedObjectURLTemplate = `%s/openidm/managed/%s?_queryFilter=true&_pageSize=%s`;
-const queryManagedObjectURLTemplate = `%s/openidm/managed/%s?_queryFilter=%s&_pageSize=%s`;
+const createManagedObjectURLTemplate = '%s/managed/%s?_action=create';
+const managedObjectByIdURLTemplate = '%s/managed/%s/%s';
+const queryAllManagedObjectURLTemplate = `%s/managed/%s?_queryFilter=true&_pageSize=%s`;
+const queryManagedObjectURLTemplate = `%s/managed/%s?_queryFilter=%s&_pageSize=%s`;
 
 export const DEFAULT_PAGE_SIZE: number = 1000;
 
@@ -51,7 +51,7 @@ export async function getManagedObject({
   const fieldsParam = `_fields=${fields.join(',')}`;
   const urlString = util.format(
     `${managedObjectByIdURLTemplate}?${fieldsParam}`,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     type,
     id
   );
@@ -79,7 +79,7 @@ export async function createManagedObject({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     createManagedObjectURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     moType
   );
   const { data } = await generateIdmApi({ requestOverride: {}, state }).post(
@@ -112,7 +112,7 @@ export async function putManagedObject({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     managedObjectByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     type,
     id
   );
@@ -150,7 +150,7 @@ export async function patchManagedObject({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     managedObjectByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     type,
     id
   );
@@ -193,7 +193,7 @@ export async function queryManagedObjects({
           pageCookie
         )}`
       : `${queryManagedObjectURLTemplate}&${fieldsParam}`,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     type,
     encodeURIComponent(filter),
     pageSize
@@ -233,7 +233,7 @@ export async function queryAllManagedObjectsByType({
     : `${queryAllManagedObjectURLTemplate}${fieldsParam}`;
   const urlString = util.format(
     urlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     type,
     pageSize
   );
@@ -258,7 +258,7 @@ export async function deleteManagedObject({
 }): Promise<IdObjectSkeletonInterface> {
   const urlString = util.format(
     managedObjectByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     type,
     id
   );

--- a/src/api/RealmApi.ts
+++ b/src/api/RealmApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../shared/State';
-import { getHostBaseUrl } from '../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../utils/ForgeRockUtils';
 import { IdObjectSkeletonInterface, PagedResult } from './ApiTypes';
 import { generateAmApi } from './BaseApi';
 
@@ -133,7 +133,7 @@ export async function deleteRealm({
 }): Promise<RealmSkeleton> {
   const urlString = util.format(
     realmURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     realmId
   );
   const { data } = await generateAmApi({

--- a/src/api/ReconApi.ts
+++ b/src/api/ReconApi.ts
@@ -1,19 +1,18 @@
 import util from 'util';
 
 import { State } from '../shared/State';
-import { getHostBaseUrl } from '../utils/ForgeRockUtils';
+import { getIdmBaseUrl } from '../utils/ForgeRockUtils';
 import { IdObjectSkeletonInterface } from './ApiTypes';
 import { generateIdmApi } from './BaseApi';
 
 const apiVersion = 'resource=1.0';
 const apiConfig = { headers: { 'Accept-API-Version': apiVersion } };
 
-const reconUrlTemplate = '%s/openidm/recon';
-const reconByIdUrlTemplate = '%s/openidm/recon/%s';
-const startReconUrlTemplate = '%s/openidm/recon?_action=recon&mapping=%s';
-const startReconByIdUrlTemplate =
-  '%s/openidm/recon?_action=reconById&mapping=%s&id=%s';
-const cancelReconUrlTemplate = '%s/openidm/recon/%s?_action=cancel';
+const reconUrlTemplate = '%s/recon';
+const reconByIdUrlTemplate = '%s/recon/%s';
+const startReconUrlTemplate = '%s/recon?_action=recon&mapping=%s';
+const startReconByIdUrlTemplate = '%s/recon?_action=reconById&mapping=%s&id=%s';
+const cancelReconUrlTemplate = '%s/recon/%s?_action=cancel';
 
 export type ReconType = IdObjectSkeletonInterface & {
   mapping: string;
@@ -153,10 +152,7 @@ export async function getRecons({
 }: {
   state: State;
 }): Promise<ReconType[]> {
-  const urlString = util.format(
-    reconUrlTemplate,
-    getHostBaseUrl(state.getHost())
-  );
+  const urlString = util.format(reconUrlTemplate, getIdmBaseUrl(state));
   const { data } = await generateIdmApi({
     requestOverride: apiConfig,
     state,
@@ -173,7 +169,7 @@ export async function getRecon({
 }): Promise<ReconType> {
   const urlString = util.format(
     reconByIdUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     reconId
   );
   const { data } = await generateIdmApi({
@@ -192,7 +188,7 @@ export async function startRecon({
 }): Promise<ReconStatusType> {
   const urlString = util.format(
     startReconUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     mappingName
   );
   const { data } = await generateIdmApi({
@@ -213,7 +209,7 @@ export async function startReconById({
 }): Promise<ReconStatusType> {
   const urlString = util.format(
     startReconByIdUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     mappingName,
     objectId
   );
@@ -233,7 +229,7 @@ export async function cancelRecon({
 }): Promise<ReconStatusType> {
   const urlString = util.format(
     cancelReconUrlTemplate,
-    getHostBaseUrl(state.getHost()),
+    getIdmBaseUrl(state),
     reconId
   );
   const { data } = await generateIdmApi({

--- a/src/api/cloud/EnvCSRsApi.ts
+++ b/src/api/cloud/EnvCSRsApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { NoIdObjectSkeletonInterface } from '../ApiTypes';
 import { generateEnvApi } from '../BaseApi';
 
@@ -137,7 +137,7 @@ export async function getCSRs({
 }): Promise<CSRResponse[]> {
   const urlString = util.format(
     csrsURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -164,7 +164,7 @@ export async function createCSR({
 }): Promise<CSRResponse> {
   const urlString = util.format(
     csrsURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -189,7 +189,7 @@ export async function deleteCSR({
 }): Promise<CSRResponse> {
   const urlString = util.format(
     csrByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     csrId
   );
   const { data } = await generateEnvApi({
@@ -217,7 +217,7 @@ export async function getCSR({
 }): Promise<CSRResponse> {
   const urlString = util.format(
     csrByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     csrId
   );
   const { data } = await generateEnvApi({
@@ -248,7 +248,7 @@ export async function updateCSR({
 }): Promise<CSRResponse> {
   const urlString = util.format(
     csrByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     csrId
   );
   const { data } = await generateEnvApi({

--- a/src/api/cloud/EnvCertificatesApi.ts
+++ b/src/api/cloud/EnvCertificatesApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { NoIdObjectSkeletonInterface } from '../ApiTypes';
 import { generateEnvApi } from '../BaseApi';
 
@@ -41,7 +41,7 @@ export async function getCertificates({
 }): Promise<CertificateResponse[]> {
   const urlString = util.format(
     certificatesURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -74,7 +74,7 @@ export async function createCertificate({
 }): Promise<CertificateResponse> {
   const urlString = util.format(
     certificatesURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -103,7 +103,7 @@ export async function deleteCertificate({
 }): Promise<CertificateResponse> {
   const urlString = util.format(
     certificateByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     certificateId
   );
   const { data } = await generateEnvApi({
@@ -131,7 +131,7 @@ export async function getCertificate({
 }): Promise<CertificateResponse> {
   const urlString = util.format(
     certificateByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     certificateId
   );
   const { data } = await generateEnvApi({
@@ -162,7 +162,7 @@ export async function updateCertificate({
 }): Promise<CertificateResponse> {
   const urlString = util.format(
     certificateByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     certificateId
   );
   const { data } = await generateEnvApi({

--- a/src/api/cloud/EnvContentSecurityPolicyApi.ts
+++ b/src/api/cloud/EnvContentSecurityPolicyApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { generateEnvApi } from '../BaseApi';
 
 const enforcedPolicyURLTemplate =
@@ -109,7 +109,7 @@ export async function getEnforcedContentSecurityPolicy({
 }): Promise<ContentSecurityPolicy> {
   const urlString = util.format(
     enforcedPolicyURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -136,7 +136,7 @@ export async function setEnforcedContentSecurityPolicy({
 }): Promise<ContentSecurityPolicy> {
   const urlString = util.format(
     enforcedPolicyURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -156,7 +156,7 @@ export async function getReportOnlyContentSecurityPolicy({
 }): Promise<ContentSecurityPolicy> {
   const urlString = util.format(
     reportOnlyPolicyURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -183,7 +183,7 @@ export async function setReportOnlyContentSecurityPolicy({
 }): Promise<ContentSecurityPolicy> {
   const urlString = util.format(
     reportOnlyPolicyURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),

--- a/src/api/cloud/EnvCookieDomainsApi.ts
+++ b/src/api/cloud/EnvCookieDomainsApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { generateEnvApi } from '../BaseApi';
 
 const cookieDomainsURLTemplate = '%s/environment/cookie-domains';
@@ -31,7 +31,7 @@ export async function getCookieDomains({
 }): Promise<CookieDomains> {
   const urlString = util.format(
     cookieDomainsURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -58,7 +58,7 @@ export async function setCookieDomains({
 }): Promise<CookieDomains> {
   const urlString = util.format(
     cookieDomainsURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),

--- a/src/api/cloud/EnvCustomDomainsApi.ts
+++ b/src/api/cloud/EnvCustomDomainsApi.ts
@@ -3,7 +3,7 @@ import util from 'util';
 import { State } from '../../shared/State';
 import {
   getCurrentRealmName,
-  getHostBaseUrl,
+  getHostOnlyUrl,
 } from '../../utils/ForgeRockUtils';
 import { generateEnvApi } from '../BaseApi';
 
@@ -40,7 +40,7 @@ export async function verifyCNAME({
 }): Promise<''> {
   const urlString = util.format(
     verifyCNAMEURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -60,7 +60,7 @@ export async function getCustomDomains({
 }): Promise<CustomDomains> {
   const urlString = util.format(
     customDomainsURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     getCurrentRealmName(state)
   );
   const { data } = await generateEnvApi({
@@ -88,7 +88,7 @@ export async function setCustomDomains({
 }): Promise<CustomDomains> {
   const urlString = util.format(
     customDomainsURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     getCurrentRealmName(state)
   );
   const { data } = await generateEnvApi({

--- a/src/api/cloud/EnvFederationEnforcementApi.ts
+++ b/src/api/cloud/EnvFederationEnforcementApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { generateEnvApi } from '../BaseApi';
 
 const federationEnforcementURLTemplate =
@@ -32,7 +32,7 @@ export async function getFederationEnforcement({
 }): Promise<FederationEnforcement> {
   const urlString = util.format(
     federationEnforcementURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -59,7 +59,7 @@ export async function setFederationEnforcement({
 }): Promise<FederationEnforcement> {
   const urlString = util.format(
     federationEnforcementURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),

--- a/src/api/cloud/EnvInfoApi.ts
+++ b/src/api/cloud/EnvInfoApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { generateAmApi } from '../BaseApi';
 
 const envInfoURLTemplate = '%s/environment/info';
@@ -37,7 +37,7 @@ export async function getEnvInfo({
 }): Promise<EnvInfoInterface> {
   const urlString = util.format(
     envInfoURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateAmApi({
     resource: getApiConfig(),

--- a/src/api/cloud/EnvPromotionApi.ts
+++ b/src/api/cloud/EnvPromotionApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { generateEnvApi } from '../BaseApi';
 
 const promotionURLTemplate = '%s/environment/promotion';
@@ -157,7 +157,7 @@ export async function lockEnvironment({
 }): Promise<LockResponse> {
   const urlString = util.format(
     lockEnvURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -182,7 +182,7 @@ export async function unlockEnvironment({
 }): Promise<LockResponse> {
   const urlString = util.format(
     unlockEnvByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     promotionId
   );
   const { data } = await generateEnvApi({
@@ -205,7 +205,7 @@ export async function getLockStatus({
 }): Promise<LockStatus> {
   const urlString = util.format(
     lockStatusURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -232,7 +232,7 @@ export async function promoteConfiguration({
 }): Promise<PromotionResponse> {
   const urlString = util.format(
     lockEnvURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -254,7 +254,7 @@ export async function getPromotionStatus({
 }): Promise<PromotionStatus> {
   const urlString = util.format(
     promoteEnvURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -278,7 +278,7 @@ export async function getLastPromotionReport({
 }): Promise<PromotionReport> {
   const urlString = util.format(
     reportURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -305,7 +305,7 @@ export async function getPromotionReport({
 }): Promise<PromotionReport> {
   const urlString = util.format(
     reportByIdURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     reportId
   );
   const { data } = await generateEnvApi({
@@ -332,7 +332,7 @@ export async function getProvisionalPromotionReport({
 }): Promise<PromotionReport> {
   const urlString = util.format(
     provisionalPromotionReportURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -356,7 +356,7 @@ export async function getProvisionalRollbackReport({
 }): Promise<PromotionReport> {
   const urlString = util.format(
     provisionalRollbackReportURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -380,7 +380,7 @@ export async function getPromotionReports({
 }): Promise<PromotionReportStub[]> {
   const urlString = util.format(
     reportsURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -407,7 +407,7 @@ export async function rollbackPromotion({
 }): Promise<RollbackResponse> {
   const urlString = util.format(
     rollbackURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),

--- a/src/api/cloud/EnvReleaseApi.ts
+++ b/src/api/cloud/EnvReleaseApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { generateEnvApi } from '../BaseApi';
 
 const releaseURLTemplate = '%s/environment/release';
@@ -32,7 +32,7 @@ export async function getRelease({
 }): Promise<Release> {
   const urlString = util.format(
     releaseURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),

--- a/src/api/cloud/EnvSSOCookieConfigApi.ts
+++ b/src/api/cloud/EnvSSOCookieConfigApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { generateEnvApi } from '../BaseApi';
 
 const ssoCookieConfigURLTemplate = '%s/environment/sso-cookie';
@@ -32,7 +32,7 @@ export async function getSSOCookieConfig({
 }): Promise<SSOCookieConfig> {
   const urlString = util.format(
     ssoCookieConfigURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -56,7 +56,7 @@ export async function resetSSOCookieConfig({
 }): Promise<SSOCookieConfig> {
   const urlString = util.format(
     resetSsoCookieConfigURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -81,7 +81,7 @@ export async function setSSOCookieConfig({
 }): Promise<SSOCookieConfig> {
   const urlString = util.format(
     ssoCookieConfigURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),

--- a/src/api/cloud/EsvCountApi.ts
+++ b/src/api/cloud/EsvCountApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { generateEnvApi } from '../BaseApi';
 
 const countOfESVsURLTemplate = '%s/environment/count';
@@ -29,7 +29,7 @@ export async function getEsvCount({
 }): Promise<EsvCountResponse> {
   const urlString = util.format(
     countOfESVsURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),

--- a/src/api/cloud/FeatureApi.ts
+++ b/src/api/cloud/FeatureApi.ts
@@ -2,7 +2,7 @@ import util from 'util';
 
 import { IdObjectSkeletonInterface } from '../../api/ApiTypes';
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { generateAmApi } from '../BaseApi';
 
 const envInfoURLTemplate = '%s/feature?_queryFilter=true';
@@ -25,7 +25,7 @@ export async function getFeatures({ state }: { state: State }): Promise<{
 }> {
   const urlString = util.format(
     envInfoURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateAmApi({ resource: getApiConfig(), state }).get(
     urlString,

--- a/src/api/cloud/LogApi.ts
+++ b/src/api/cloud/LogApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import {
   type NoIdObjectSkeletonInterface,
   type PagedResult,
@@ -56,7 +56,7 @@ export async function getLogApiKey({
 }): Promise<LogApiKey> {
   const urlString = util.format(
     logsAPIKeyURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     keyId
   );
   const { data } = await generateLogKeysApi({ state }).get(urlString);
@@ -74,7 +74,7 @@ export async function getLogApiKeys({
 }): Promise<PagedResult<LogApiKey>> {
   const urlString = util.format(
     logsGetAPIKeysURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateLogKeysApi({ state }).get(urlString);
   return data;
@@ -91,7 +91,7 @@ export async function getSources({
 }): Promise<PagedResult<string>> {
   const urlString = util.format(
     logsSourcesURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateLogApi({ state }).get(urlString);
   return data;
@@ -121,7 +121,7 @@ export async function isLogApiKeyValid({
     };
     const urlString = util.format(
       logsSourcesURLTemplate,
-      getHostBaseUrl(state.getHost())
+      getHostOnlyUrl(state.getHost())
     );
     await generateLogApi({ requestOverride, state }).get(urlString);
     return true;
@@ -144,7 +144,7 @@ export async function createLogApiKey({
 }): Promise<LogApiKey> {
   const urlString = util.format(
     logsCreateAPIKeyAndSecretURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateLogKeysApi({ state }).post(urlString, {
     name: keyName,
@@ -166,7 +166,7 @@ export async function deleteLogApiKey({
 }): Promise<unknown> {
   const urlString = util.format(
     logsAPIKeyURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     keyId
   );
   const { data } = await generateLogKeysApi({ state }).delete(urlString, {
@@ -192,7 +192,7 @@ export async function tail({
 }): Promise<PagedResult<LogEventSkeleton>> {
   let urlString = util.format(
     logsTailURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     encodeURIComponent(source)
   );
   if (cookie) {
@@ -225,7 +225,7 @@ export async function fetch({
 }): Promise<PagedResult<LogEventSkeleton>> {
   let urlString = util.format(
     logsFetchURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     encodeURIComponent(source),
     startTs,
     endTs

--- a/src/api/cloud/SecretsApi.ts
+++ b/src/api/cloud/SecretsApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { IdObjectSkeletonInterface, PagedResult } from '../ApiTypes';
 import { generateEnvApi } from '../BaseApi';
 
@@ -86,7 +86,7 @@ export async function getSecrets({
 }): Promise<PagedResult<SecretSkeleton>> {
   const urlString = util.format(
     secretsListURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -111,7 +111,7 @@ export async function getSecret({
 }): Promise<SecretSkeleton> {
   const urlString = util.format(
     secretURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     secretId
   );
   const { data } = await generateEnvApi({
@@ -155,7 +155,7 @@ export async function putSecret({
   };
   const urlString = util.format(
     secretURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     secretId
   );
   const { data } = await generateEnvApi({
@@ -184,7 +184,7 @@ export async function setSecretDescription({
 }): Promise<any> {
   const urlString = util.format(
     secretSetDescriptionURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     secretId
   );
   const { data } = await generateEnvApi({
@@ -208,7 +208,7 @@ export async function deleteSecret({
 }) {
   const urlString = util.format(
     secretURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     secretId
   );
   const { data } = await generateEnvApi({
@@ -234,7 +234,7 @@ export async function getSecretVersions({
 }): Promise<VersionOfSecretSkeleton[]> {
   const urlString = util.format(
     secretListVersionsURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     secretId
   );
   const { data } = await generateEnvApi({
@@ -263,7 +263,7 @@ export async function createNewVersionOfSecret({
 }): Promise<VersionOfSecretSkeleton> {
   const urlString = util.format(
     secretCreateNewVersionURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     secretId
   );
   const { data } = await generateEnvApi({
@@ -290,7 +290,7 @@ export async function getVersionOfSecret({
 }): Promise<VersionOfSecretSkeleton> {
   const urlString = util.format(
     secretGetVersionURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     secretId,
     version
   );
@@ -323,7 +323,7 @@ export async function setStatusOfVersionOfSecret({
 }): Promise<VersionOfSecretSkeleton> {
   const urlString = util.format(
     secretVersionStatusURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     secretId,
     version
   );
@@ -351,7 +351,7 @@ export async function deleteVersionOfSecret({
 }): Promise<VersionOfSecretSkeleton> {
   const urlString = util.format(
     secretGetVersionURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     secretId,
     version
   );

--- a/src/api/cloud/StartupApi.ts
+++ b/src/api/cloud/StartupApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { generateEnvApi } from '../BaseApi';
 
 const startupURLTemplate = '%s/environment/startup';
@@ -29,7 +29,7 @@ export async function getStatus({
 }): Promise<RestartStatus> {
   const urlString = util.format(
     startupURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -53,7 +53,7 @@ export async function initiateRestart({
   if (restartStatus === RestartStatus.ready) {
     const urlString = util.format(
       startupInitiateRestartURLTemplate,
-      getHostBaseUrl(state.getHost())
+      getHostOnlyUrl(state.getHost())
     );
     const { data } = await generateEnvApi({
       resource: getApiConfig(),

--- a/src/api/cloud/VariablesApi.ts
+++ b/src/api/cloud/VariablesApi.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 
 import { State } from '../../shared/State';
-import { getHostBaseUrl } from '../../utils/ForgeRockUtils';
+import { getHostOnlyUrl } from '../../utils/ForgeRockUtils';
 import { IdObjectSkeletonInterface, PagedResult } from '../ApiTypes';
 import { generateEnvApi } from '../BaseApi';
 
@@ -71,7 +71,7 @@ export async function getVariables({
 }): Promise<PagedResult<VariableSkeleton>> {
   const urlString = util.format(
     variablesListURLTemplate,
-    getHostBaseUrl(state.getHost())
+    getHostOnlyUrl(state.getHost())
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
@@ -96,7 +96,7 @@ export async function getVariable({
 }): Promise<VariableSkeleton> {
   const urlString = util.format(
     variableURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     variableId
   );
   const { data } = await generateEnvApi({
@@ -135,7 +135,7 @@ export async function putVariable({
   };
   const urlString = util.format(
     variableURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     variableId
   );
   const { data } = await generateEnvApi({
@@ -164,7 +164,7 @@ export async function setVariableDescription({
 }): Promise<any> {
   const urlString = util.format(
     variableSetDescriptionURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     variableId
   );
   const { data } = await generateEnvApi({
@@ -188,7 +188,7 @@ export async function deleteVariable({
 }): Promise<VariableSkeleton> {
   const urlString = util.format(
     variableURLTemplate,
-    getHostBaseUrl(state.getHost()),
+    getHostOnlyUrl(state.getHost()),
     variableId
   );
   const { data } = await generateEnvApi({

--- a/src/shared/State.ts
+++ b/src/shared/State.ts
@@ -27,6 +27,16 @@ export type State = {
    * @returns the AM host base URL
    */
   getHost(): string;
+  /**
+   * Set the IDM host base URL
+   * @param host Identity Management base URL, e.g.: https://cdk.iam.example.com/openidm. To use a connection profile, just specify a unique substring.
+   */
+  setIdmHost(host: string): void;
+  /**
+   * Get the IDM host base URL
+   * @returns the IDM host base URL
+   */
+  getIdmHost(): string;
   setUsername(username: string): void;
   getUsername(): string;
   setPassword(password: string): void;
@@ -35,6 +45,10 @@ export type State = {
   getRealm(): string;
   setDeploymentType(type: string): void;
   getDeploymentType(): string;
+  setAdminClientId(type: string): void;
+  getAdminClientId(): string;
+  setAdminClientRedirectUri(type: string): void;
+  getAdminClientRedirectUri(): string;
   setAllowInsecureConnection(allowInsecureConnection: boolean): void;
   getAllowInsecureConnection(): boolean;
   setCookieName(name: string): void;
@@ -165,6 +179,12 @@ export default (initialState: StateInterface): State => {
     getHost() {
       return state.host || process.env.FRODO_HOST;
     },
+    setIdmHost(host: string) {
+      state.idmHost = host;
+    },
+    getIdmHost() {
+      return state.idmHost || process.env.FRODO_IDM_HOST;
+    },
 
     setUsername(username: string) {
       state.username = username;
@@ -192,6 +212,21 @@ export default (initialState: StateInterface): State => {
     },
     getDeploymentType() {
       return state.deploymentType;
+    },
+
+    setAdminClientId(clientId: string) {
+      state.adminClientId = clientId;
+    },
+    getAdminClientId() {
+      return state.adminClientId || process.env.FRODO_LOGIN_CLIENT_ID;
+    },
+    setAdminClientRedirectUri(redirectUri: string) {
+      state.adminClientRedirectUri = redirectUri;
+    },
+    getAdminClientRedirectUri() {
+      return (
+        state.adminClientRedirectUri || process.env.FRODO_LOGIN_REDIRECT_URI
+      );
     },
 
     setAllowInsecureConnection(allowInsecureConnection: boolean) {
@@ -461,10 +496,13 @@ export default (initialState: StateInterface): State => {
 export interface StateInterface {
   // connection settings
   host?: string;
+  idmHost?: string;
   username?: string;
   password?: string;
   realm?: string;
   deploymentType?: string;
+  adminClientId?: string;
+  adminClientRedirectUri?: string;
   allowInsecureConnection?: boolean;
   // customize authentication
   authenticationHeaderOverrides?: Record<string, string>;

--- a/src/utils/ForgeRockUtils.test.ts
+++ b/src/utils/ForgeRockUtils.test.ts
@@ -6,59 +6,50 @@
  * Note: FRODO_DEBUG=1 is optional and enables debug logging for some output
  * in case things don't function as expected
  */
-import {
-  getRealmPath,
-  getCurrentRealmPath,
-  getHostBaseUrl,
-  getCurrentRealmManagedUser,
-  getConfigPath,
-  getRealmPathGlobal,
-  getRealmUsingExportFormat,
-} from './ForgeRockUtils';
+import * as ForgeRockUtils from './ForgeRockUtils';
 import { state } from '../index';
 import Constants from '../shared/Constants';
 
 describe('ForgeRockUtils', () => {
-
   describe('getRealmUsingExportFormat()', () => {
-    test("Should get root realm", () => {
+    test('Should get root realm', () => {
       const realm = 'root';
-      const testString = getRealmUsingExportFormat(realm);
+      const testString = ForgeRockUtils.getRealmUsingExportFormat(realm);
       expect(testString).toBe('/');
     });
 
-    test("Should get alpha realm", () => {
+    test('Should get alpha realm', () => {
       const realm = 'root-alpha';
-      const testString = getRealmUsingExportFormat(realm);
+      const testString = ForgeRockUtils.getRealmUsingExportFormat(realm);
       expect(testString).toBe('/alpha');
     });
 
-    test("Should handle nested realms", () => {
+    test('Should handle nested realms', () => {
       const realm = 'root-alpha-beta-gamma';
-      const testString = getRealmUsingExportFormat(realm);
+      const testString = ForgeRockUtils.getRealmUsingExportFormat(realm);
       expect(testString).toBe('/alpha/beta/gamma');
     });
   });
 
   describe('getConfigPath()', () => {
-    test("Should get global config path", () => {
-      expect(getConfigPath(true)).toBe("global-config");
+    test('Should get global config path', () => {
+      expect(ForgeRockUtils.getConfigPath(true)).toBe('global-config');
     });
 
-    test("Should get realm config path", () => {
-      expect(getConfigPath(false)).toBe("realm-config");
+    test('Should get realm config path', () => {
+      expect(ForgeRockUtils.getConfigPath(false)).toBe('realm-config');
     });
   });
 
   describe('getRealmPathGlobal()', () => {
-    test("Should return nothing for global", () => {
-      expect(getRealmPathGlobal(true, state)).toBe("");
+    test('Should return nothing for global', () => {
+      expect(ForgeRockUtils.getRealmPathGlobal(true, state)).toBe('');
     });
 
-    test("Should return current realm path for realm config", () => {
+    test('Should return current realm path for realm config', () => {
       const realm = '/parent/child';
       state.setRealm(realm);
-      const testString = getRealmPathGlobal(false, state);
+      const testString = ForgeRockUtils.getRealmPathGlobal(false, state);
       expect(testString).toBe('/realms/root/realms/parent/realms/child');
     });
   });
@@ -66,31 +57,31 @@ describe('ForgeRockUtils', () => {
   describe('getRealmPath()', () => {
     test("Should prepend realm path to specified realm 'alpha'", () => {
       const realm = 'alpha';
-      const testString = getRealmPath(realm);
+      const testString = ForgeRockUtils.getRealmPath(realm);
       expect(testString).toBe('/realms/root/realms/alpha');
     });
 
     test('Should prepend realmPath to specified realm with leading slash', () => {
       const realm = '/alpha';
-      const testString = getRealmPath(realm);
+      const testString = ForgeRockUtils.getRealmPath(realm);
       expect(testString).toBe('/realms/root/realms/alpha');
     });
 
     test("'/' should resolve to root", () => {
       const realm = '/';
-      const testString = getRealmPath(realm);
+      const testString = ForgeRockUtils.getRealmPath(realm);
       expect(testString).toBe('/realms/root');
     });
 
     test('Should handle multiple leading slashes', () => {
       const realm = '//alpha';
-      const testString = getRealmPath(realm);
+      const testString = ForgeRockUtils.getRealmPath(realm);
       expect(testString).toBe('/realms/root/realms/alpha');
     });
 
     test('Should handle nested realms', () => {
       const realm = '/parent/child';
-      const testString = getRealmPath(realm);
+      const testString = ForgeRockUtils.getRealmPath(realm);
       expect(testString).toBe('/realms/root/realms/parent/realms/child');
     });
   });
@@ -99,69 +90,42 @@ describe('ForgeRockUtils', () => {
     test("Should prepend realm path to specified realm 'alpha'", () => {
       const realm = 'alpha';
       state.setRealm(realm);
-      const testString = getCurrentRealmPath(state);
+      const testString = ForgeRockUtils.getCurrentRealmPath(state);
       expect(testString).toBe('/realms/root/realms/alpha');
     });
 
     test('Should prepend realmPath to specified realm with leading slash', () => {
       const realm = '/alpha';
       state.setRealm(realm);
-      const testString = getCurrentRealmPath(state);
+      const testString = ForgeRockUtils.getCurrentRealmPath(state);
       expect(testString).toBe('/realms/root/realms/alpha');
     });
 
     test("'/' should resolve to root", () => {
       const realm = '/';
       state.setRealm(realm);
-      const testString = getCurrentRealmPath(state);
+      const testString = ForgeRockUtils.getCurrentRealmPath(state);
       expect(testString).toBe('/realms/root');
     });
 
     test('Should handle multiple leading slashes', () => {
       const realm = '//alpha';
       state.setRealm(realm);
-      const testString = getCurrentRealmPath(state);
+      const testString = ForgeRockUtils.getCurrentRealmPath(state);
       expect(testString).toBe('/realms/root/realms/alpha');
     });
 
     test('Should handle nested realms', () => {
       const realm = '/parent/child';
       state.setRealm(realm);
-      const testString = getCurrentRealmPath(state);
+      const testString = ForgeRockUtils.getCurrentRealmPath(state);
       expect(testString).toBe('/realms/root/realms/parent/realms/child');
     });
   });
 
-  describe('getTenantURL()', () => {
-    test('Should parse the https protocol and the hostname', () => {
-      const URL_WITH_TENANT =
-        'https://example.frodo.com/am/ui-admin/#realms/%2Falpha/dashboard';
-
-      const parsed = getHostBaseUrl(URL_WITH_TENANT);
-
-      expect(parsed).toBe('https://example.frodo.com');
-    });
-
-    test('Should not validate protocol', () => {
-      const URL_WITH_TENANT =
-        'ftp://example.frodo.com/am/ui-admin/#realms/%2Falpha/dashboard';
-      const parsed = getHostBaseUrl(URL_WITH_TENANT);
-      expect(parsed).toBe('ftp://example.frodo.com');
-    });
-
-    test('Invalid URL should throw', () => {
-      const URL_WITH_TENANT =
-        '//:example.frodo.com/am/ui-admin/#realms/%2Falpha/dashboard';
-      const trap = () => {
-        getHostBaseUrl(URL_WITH_TENANT);
-      };
-      expect(trap).toThrow('Invalid URL');
-    });
-  });
-
-  describe('OpsUtils - getRealmManagedUser()', () => {
+  describe('getRealmManagedUser()', () => {
     test('getRealmManagedUser() 0: Method is implemented', async () => {
-      expect(getCurrentRealmManagedUser).toBeDefined();
+      expect(ForgeRockUtils.getCurrentRealmManagedUser).toBeDefined();
     });
 
     test('getRealmManagedUser() 1: should prepend realm to managed user type in identity cloud', () => {
@@ -171,7 +135,7 @@ describe('ForgeRockUtils', () => {
       state.setRealm(REALM);
       state.setDeploymentType(DEPLOYMENT_TYPE);
       // Act
-      const testString = getCurrentRealmManagedUser({ state });
+      const testString = ForgeRockUtils.getCurrentRealmManagedUser({ state });
       // Assert
       expect(testString).toBe('alpha_user');
     });
@@ -183,7 +147,7 @@ describe('ForgeRockUtils', () => {
       state.setRealm(REALM);
       state.setDeploymentType(DEPLOYMENT_TYPE);
       // Act
-      const testString = getCurrentRealmManagedUser({ state });
+      const testString = ForgeRockUtils.getCurrentRealmManagedUser({ state });
       // Assert
       expect(testString).toBe('alpha_user');
     });
@@ -195,7 +159,7 @@ describe('ForgeRockUtils', () => {
       state.setRealm(REALM);
       state.setDeploymentType(DEPLOYMENT_TYPE);
       // Act
-      const testString = getCurrentRealmManagedUser({ state });
+      const testString = ForgeRockUtils.getCurrentRealmManagedUser({ state });
       // Assert
       expect(testString).toBe('user');
     });
@@ -207,9 +171,63 @@ describe('ForgeRockUtils', () => {
       state.setRealm(REALM);
       state.setDeploymentType(DEPLOYMENT_TYPE);
       // Act
-      const testString = getCurrentRealmManagedUser({ state });
+      const testString = ForgeRockUtils.getCurrentRealmManagedUser({ state });
       // Assert
       expect(testString).toBe('user');
+    });
+  });
+
+  describe('getHostUrl()', () => {
+    test('Method is implemented', async () => {
+      expect(ForgeRockUtils.getHostOnlyUrl).toBeDefined();
+    });
+
+    test('Should parse the https protocol and the hostname', () => {
+      const URL_WITH_TENANT =
+        'https://example.frodo.com/am/ui-admin/#realms/%2Falpha/dashboard';
+
+      const parsed = ForgeRockUtils.getHostOnlyUrl(URL_WITH_TENANT);
+
+      expect(parsed).toBe('https://example.frodo.com');
+    });
+
+    test('Should not validate protocol', () => {
+      const URL_WITH_TENANT =
+        'ftp://example.frodo.com/am/ui-admin/#realms/%2Falpha/dashboard';
+      const parsed = ForgeRockUtils.getHostOnlyUrl(URL_WITH_TENANT);
+      expect(parsed).toBe('ftp://example.frodo.com');
+    });
+
+    test('Invalid URL should throw', () => {
+      const URL_WITH_TENANT =
+        '//:example.frodo.com/am/ui-admin/#realms/%2Falpha/dashboard';
+      const trap = () => {
+        ForgeRockUtils.getHostOnlyUrl(URL_WITH_TENANT);
+      };
+      expect(trap).toThrow('Invalid URL');
+    });
+  });
+
+  describe('getIdmBaseUrl()', () => {
+    test('Method is implemented', async () => {
+      expect(ForgeRockUtils.getIdmBaseUrl).toBeDefined();
+    });
+
+    test(`By default should use AM host URL with default '/openidm' path`, () => {
+      const AM_BASE_URL = 'https://example.frodo.com/am';
+      const DEFAULT_IDM_BASE_URL = 'https://example.frodo.com/openidm';
+      state.setHost(AM_BASE_URL);
+      const idmBaseUrl = ForgeRockUtils.getIdmBaseUrl(state);
+      expect(idmBaseUrl).toBe(DEFAULT_IDM_BASE_URL);
+    });
+
+    test('Should return override URL if specified', () => {
+      const AM_BASE_URL = 'https://example.frodo.com/am';
+      const CUSTOM_IDM_BASE_URL = 'https://example.frodo.com/idm';
+      state.setHost(AM_BASE_URL);
+      state.setIdmHost(CUSTOM_IDM_BASE_URL);
+      const parsed = ForgeRockUtils.getIdmBaseUrl(state);
+      expect(parsed).toBe(CUSTOM_IDM_BASE_URL);
     });
   });
 });

--- a/src/utils/ForgeRockUtils.ts
+++ b/src/utils/ForgeRockUtils.ts
@@ -9,6 +9,30 @@ export type FRUtils = {
   getCurrentRealmName(): string;
   getCurrentRealmManagedUser(): string;
   getRealmName(realm: string): string;
+  /**
+   * Get host URL without path and query params
+   * @param {string} url tenant URL with path and query params
+   * @returns {string} AM host URL without path and query params
+   */
+  getHostUrl(url: string): string;
+  /**
+   * Get IDM base URL
+   * @returns {string} IDM host URL without path and query params
+   */
+  getIdmBaseUrl(): string;
+
+  // deprecated
+
+  /**
+   * Get host URL without path and query params
+   * @param {string} url tenant URL with path and query params
+   * @returns {string} AM host URL without path and query params
+   * @deprecated since v2.1.2 use {@link FRUtils.getHostUrl | getHostUrl} instead
+   * ```javascript
+   * getHostUrl(url: string): string
+   * ```
+   * @group Deprecated
+   */
   getHostBaseUrl(url: string): string;
 };
 
@@ -17,29 +41,32 @@ export default (state: State): FRUtils => {
     applyNameCollisionPolicy(name: string): string {
       return applyNameCollisionPolicy(name);
     },
-
     getRealmPath(realm: string): string {
       return getRealmPath(realm);
     },
-
     getCurrentRealmPath(): string {
       return getCurrentRealmPath(state);
     },
-
     getCurrentRealmName(): string {
       return getCurrentRealmName(state);
     },
-
     getCurrentRealmManagedUser(): string {
       return getCurrentRealmManagedUser({ state });
     },
-
     getRealmName(realm: string): string {
       return getRealmName(realm);
     },
+    getHostUrl(url: string): string {
+      return getHostOnlyUrl(url);
+    },
+    getIdmBaseUrl(): string {
+      return getIdmBaseUrl(state);
+    },
+
+    // deprecated
 
     getHostBaseUrl(url: string): string {
-      return getHostBaseUrl(url);
+      return getHostOnlyUrl(url);
     },
   };
 };
@@ -187,11 +214,23 @@ export function getRealmName(realm: string): string {
 }
 
 /**
- * Get tenant base URL
- * @param {string} url tenant URL with path and query params
- * @returns {string} tenant base URL without path and query params
+ * Get host-only URL without path and query params
+ * @param {string} url URL with path and query params
+ * @returns {string} AM host URL without path and query params
  */
-export function getHostBaseUrl(url: string): string {
+export function getHostOnlyUrl(url: string): string {
   const parsedUrl = new URL(url);
   return `${parsedUrl.protocol}//${parsedUrl.host}`;
+}
+
+/**
+ * Get IDM base URL
+ * @param {State} state State object
+ * @returns {string} IDM host URL without path and query params
+ */
+export function getIdmBaseUrl(state: State): string {
+  if (state.getIdmHost()) {
+    return state.getIdmHost();
+  }
+  return `${getHostOnlyUrl(state.getHost())}/openidm`;
 }


### PR DESCRIPTION
  - rockcarver/frodo-cli#429: Added state functions to support custom oauth2 clients for IDM API calls:
  
    - `state.setAdminClientId(clientId: string): void`
    - `state.getAdminClientId(): string`
    - `state.setAdminRedirectUri(redirectUri: string): void`
    - `state.getAdminRedirectUri(): string`

  - rockcarver/frodo-cli#359: Added state functions to support custom IDM host URLs for all IDM API calls (e.g. platform deployments hosting AM and IDM on/in different DNS hosts/domains):
  
    - `state.setIdmHost(host: string): void`
    - `state.getIdmHost(): string`