### PR TITLE
Add User Imports and Exports

### DIFF
--- a/src/api/UserApi.ts
+++ b/src/api/UserApi.ts
@@ -1,0 +1,394 @@
+import util from 'util';
+
+import Constants from '../shared/Constants';
+import { State } from '../shared/State';
+import { printMessage } from '../utils/Console';
+import { getCurrentRealmPath } from '../utils/ForgeRockUtils';
+import { IdObjectSkeletonInterface, PagedResult } from './ApiTypes';
+import { generateAmApi } from './BaseApi';
+
+const userURLTemplate = '%s/json%s/users/%s';
+const usersURLTemplate = '%s/json%s/users?_queryFilter=true';
+const userServiceURLTemplate = '%s/json%s/users/%s/services/%s';
+const userServicesURLTemplate =
+  '%s/json%s/users/%s/services?_action=nextdescendents';
+const userConfigURL = '%s/json%s/users/%s/%s?_queryFilter=true';
+const userConfigPaths = [
+  'devices/2fa/binding',
+  'devices/2fa/oath',
+  'devices/2fa/push',
+  'devices/2fa/webauthn',
+  'devices/profile',
+  'devices/trusted',
+  'groups',
+  'oauth2/applications',
+  'oauth2/resources/labels',
+  'oauth2/resources/sets',
+  'policies',
+  'uma/auditHistory',
+  'uma/pendingrequests',
+  'uma/policies',
+];
+const groupURLTemplate = '%s/json%s/groups/%s';
+const groupsURLTemplate = '%s/json%s/groups?_queryFilter=true';
+
+const configApiVersion = 'protocol=2.0,resource=1.0';
+const identityApiVersion = 'protocol=2.0,resource=4.0';
+
+function getConfigApiConfig() {
+  return {
+    apiVersion: configApiVersion,
+  };
+}
+
+function getIdentityApiConfig() {
+  return {
+    apiVersion: identityApiVersion,
+  };
+}
+
+export type UserSkeleton = IdObjectSkeletonInterface & {
+  realm: string;
+  username: string;
+  mail: string[];
+  givenName: string[];
+  objectClass: string[];
+  dn: string[];
+  cn: string[];
+  createTimestamp: string[];
+  employeeNumber: string[];
+  uid: string[];
+  universalid: string[];
+  inetUserStatus: string[];
+  sn: string[];
+  telephoneNumber?: string[];
+  modifyTimestamp?: string[];
+  postalAddress?: string[];
+};
+
+export type UserConfigSkeleton = {
+  devices: {
+    profile: Record<string, IdObjectSkeletonInterface>;
+    trusted: Record<string, IdObjectSkeletonInterface>;
+    '2fa': {
+      binding: Record<string, IdObjectSkeletonInterface>;
+      oath: Record<string, IdObjectSkeletonInterface>;
+      push: Record<string, IdObjectSkeletonInterface>;
+      webauthn: Record<string, IdObjectSkeletonInterface>;
+    };
+  };
+  groups: Record<string, IdObjectSkeletonInterface>;
+  oauth2: {
+    applications: Record<string, IdObjectSkeletonInterface>;
+    resources: {
+      labels: Record<string, IdObjectSkeletonInterface>;
+      sets: Record<string, IdObjectSkeletonInterface>;
+    };
+  };
+  policies: Record<string, IdObjectSkeletonInterface>;
+  services: Record<string, IdObjectSkeletonInterface>;
+  uma: {
+    auditHistory: Record<string, IdObjectSkeletonInterface>;
+    pendingrequests: Record<string, IdObjectSkeletonInterface>;
+    policies: Record<string, IdObjectSkeletonInterface>;
+  };
+};
+
+export type UserGroupSkeleton = IdObjectSkeletonInterface & {
+  username: string;
+  realm: string;
+  universalid: string[];
+  members: {
+    uniqueMember: string[];
+  };
+  dn: string[];
+  cn: string[];
+  objectclass: string[];
+  privileges: Record<string, boolean>[];
+};
+
+/**
+ * Get user by id
+ * @param {string} userId the user id
+ * @returns {Promise<UserSkeleton>} a promise that resolves to a user object
+ */
+export async function getUser({
+  userId,
+  state,
+}: {
+  userId: string;
+  state: State;
+}): Promise<UserSkeleton> {
+  const urlString = util.format(
+    userURLTemplate,
+    state.getHost(),
+    getCurrentRealmPath(state),
+    userId
+  );
+  const { data } = await generateAmApi({
+    resource: getIdentityApiConfig(),
+    state,
+  }).get(urlString, {
+    withCredentials: true,
+  });
+  return data;
+}
+
+/**
+ * Get all users
+ * @returns {Promise<PagedResult<UserSkeleton>>} a promise that resolves to an array of user objects
+ */
+export async function getUsers({
+  state,
+}: {
+  state: State;
+}): Promise<PagedResult<UserSkeleton>> {
+  const urlString = util.format(
+    usersURLTemplate,
+    state.getHost(),
+    getCurrentRealmPath(state)
+  );
+  const { data } = await generateAmApi({
+    resource: getIdentityApiConfig(),
+    state,
+  }).get(urlString, {
+    withCredentials: true,
+  });
+  return data;
+}
+
+/**
+ * Get user configurations
+ * @param {string} userId the user id
+ * @returns {Promise<UserConfigSkeleton>} a promise that resolves to an object containing all the user configuration
+ */
+export async function getUserConfig({
+  userId,
+  state,
+}: {
+  userId: string;
+  state: State;
+}): Promise<UserConfigSkeleton> {
+  const userConfig = {} as UserConfigSkeleton;
+  //Get user services
+  const serviceUrlString = util.format(
+    userServicesURLTemplate,
+    state.getHost(),
+    getCurrentRealmPath(state),
+    userId
+  );
+  try {
+    const { data } = await generateAmApi({
+      resource: getConfigApiConfig(),
+      state,
+    }).post(serviceUrlString, undefined, {
+      withCredentials: true,
+    });
+    userConfig.services = data.result;
+  } catch (e) {
+    printMessage({
+      message: `Error exporting service config for user with id '${userId}' from url '${serviceUrlString}': ${e.message}`,
+      type: 'error',
+      state,
+    });
+  }
+  //Get the rest of the config
+  for (const configPath of userConfigPaths) {
+    // policies configuration has forbidden access in cloud platform deployments, so only export it when exporting from classic deployments.
+    if (
+      configPath === 'policies' &&
+      state.getDeploymentType() !== Constants.CLASSIC_DEPLOYMENT_TYPE_KEY
+    ) {
+      continue;
+    }
+    const urlString = util.format(
+      userConfigURL,
+      state.getHost(),
+      getCurrentRealmPath(state),
+      userId,
+      configPath
+    );
+    try {
+      const { data } = await generateAmApi({
+        resource: getConfigApiConfig(),
+        state,
+      }).get(urlString, {
+        withCredentials: true,
+      });
+      const pathParts = configPath.split('/');
+      let current = userConfig;
+      for (let i = 0; i < pathParts.length; i++) {
+        const part = pathParts[i];
+        if (i === pathParts.length - 1) {
+          current[part] = data.result;
+          break;
+        }
+        if (!current[part]) {
+          current[part] = {};
+        }
+        current = current[part];
+      }
+    } catch (e) {
+      if (e.httpStatus === 404 || e.response?.status === 404) {
+        //Ignore this case, since some user config does not exist in certain realms. For example, the UMA config does not exist when UMA is not supported for a given realm, resulting in a 404 error.
+      } else {
+        printMessage({
+          message: `Error exporting config for user with id '${userId}' from url '${urlString}': ${e.message}`,
+          type: 'error',
+          state,
+        });
+      }
+    }
+  }
+  return userConfig;
+}
+
+/**
+ * Get user group by id
+ * @param {string} groupId the group id
+ * @returns {Promise<UserGroupSkeleton>} a promise that resolves to a group object
+ */
+export async function getUserGroup({
+  groupId,
+  state,
+}: {
+  groupId: string;
+  state: State;
+}): Promise<UserGroupSkeleton> {
+  const urlString = util.format(
+    groupURLTemplate,
+    state.getHost(),
+    getCurrentRealmPath(state),
+    groupId
+  );
+  const { data } = await generateAmApi({
+    resource: getIdentityApiConfig(),
+    state,
+  }).get(urlString, {
+    withCredentials: true,
+  });
+  return data;
+}
+
+/**
+ * Get all user groups
+ * @returns {Promise<PagedResult<UserGroupSkeleton>>} a promise that resolves to an array of group objects
+ */
+export async function getUserGroups({
+  state,
+}: {
+  state: State;
+}): Promise<PagedResult<UserGroupSkeleton>> {
+  const urlString = util.format(
+    groupsURLTemplate,
+    state.getHost(),
+    getCurrentRealmPath(state)
+  );
+  const { data } = await generateAmApi({
+    resource: getIdentityApiConfig(),
+    state,
+  }).get(urlString, {
+    withCredentials: true,
+  });
+  return data;
+}
+
+/**
+ * Put user
+ * @param {UserSkeleton} userData the user data
+ * @returns {Promise<UserSkeleton>} a promise that resolves to a user object
+ */
+export async function putUser({
+  userData,
+  state,
+}: {
+  userData: UserSkeleton;
+  state: State;
+}): Promise<UserSkeleton> {
+  const urlString = util.format(
+    userURLTemplate,
+    state.getHost(),
+    getCurrentRealmPath(state),
+    userData._id
+  );
+  const { data } = await generateAmApi({
+    resource: getIdentityApiConfig(),
+    state,
+  }).put(urlString, userData, {
+    withCredentials: true,
+    headers: { 'If-Match': '*' },
+  });
+  return data;
+}
+
+/**
+ * Put user configurations
+ * @param {string} userId the user id
+ * @param {UserConfigSkeleton} configData the user config data
+ * @returns {Promise<UserConfigSkeleton>} a promise that resolves to an object containing all the user configuration
+ */
+export async function putUserConfig({
+  userId,
+  configData,
+  state,
+}: {
+  userId: string;
+  configData: UserConfigSkeleton;
+  state: State;
+}): Promise<UserConfigSkeleton> {
+  const userConfig = {} as UserConfigSkeleton;
+  //Put user services
+  for (const [id, service] of Object.entries(configData.services)) {
+    const serviceUrlString = util.format(
+      userServiceURLTemplate,
+      state.getHost(),
+      getCurrentRealmPath(state),
+      userId,
+      id
+    );
+    try {
+      const { data } = await generateAmApi({
+        resource: getConfigApiConfig(),
+        state,
+      }).put(serviceUrlString, service, {
+        withCredentials: true,
+      });
+      userConfig.services[id] = data;
+    } catch (e) {
+      printMessage({
+        message: `Error importing service config for user with id '${userId}' from url '${serviceUrlString}': ${e.message}`,
+        type: 'error',
+        state,
+      });
+    }
+  }
+  // TODO: Put the rest of the config
+  return { ...configData, ...userConfig };
+}
+
+/**
+ * Put user group by id
+ * @param {UserGroupSkeleton} groupData the group data
+ * @returns {Promise<UserGroupSkeleton>} a promise that resolves to a group object
+ */
+export async function putUserGroup({
+  groupData,
+  state,
+}: {
+  groupData: UserGroupSkeleton;
+  state: State;
+}): Promise<UserGroupSkeleton> {
+  const urlString = util.format(
+    groupURLTemplate,
+    state.getHost(),
+    getCurrentRealmPath(state),
+    groupData._id
+  );
+  const { data } = await generateAmApi({
+    resource: getIdentityApiConfig(),
+    state,
+  }).put(urlString, groupData, {
+    withCredentials: true,
+  });
+  return data;
+}

--- a/src/lib/FrodoLib.ts
+++ b/src/lib/FrodoLib.ts
@@ -76,6 +76,7 @@ import ServiceOps, { Service } from '../ops/ServiceOps';
 import SessionOps, { Session } from '../ops/SessionOps';
 import ThemeOps, { Theme } from '../ops/ThemeOps';
 import TokenCacheOps, { TokenCache } from '../ops/TokenCacheOps';
+import UserOps, { User } from '../ops/UserOps';
 import VersionUtils, { Version } from '../ops/VersionUtils';
 // non-instantiable modules
 import ConstantsImpl, { Constants } from '../shared/Constants';
@@ -178,6 +179,8 @@ export type Frodo = {
   session: Session;
 
   theme: Theme;
+
+  user: User;
 
   utils: FRUtils &
     ScriptValidation &
@@ -336,6 +339,8 @@ const FrodoLib = (config: StateInterface = {}): Frodo => {
     session: SessionOps(state),
 
     theme: ThemeOps(state),
+
+    user: UserOps(state),
 
     utils: {
       ...ForgeRockUtils(state),

--- a/src/ops/UserOps.test.ts
+++ b/src/ops/UserOps.test.ts
@@ -1,0 +1,166 @@
+/**
+ * To record and update snapshots, you must perform 3 steps in order:
+ *
+ * 1. Record API responses
+ *
+ *    To record API responses, you must call the test:record script and
+ *    override all the connection state required to connect to the
+ *    env to record from:
+ *
+ *    ATTENTION: For the recording to succeed, you MUST make sure to use a
+ *               user account, not a service account.
+ *
+ *        FRODO_DEBUG=1 FRODO_HOST=frodo-dev npm run test:record UserOps
+ *
+ *    The above command assumes that you have a connection profile for
+ *    'frodo-dev' on your development machine.
+ *
+ * 2. Update snapshots
+ *
+ *    After recording API responses, you must manually update/create snapshots
+ *    by running:
+ *
+ *        FRODO_DEBUG=1 npm run test:update UserOps
+ *
+ * 3. Test your changes
+ *
+ *    If 1 and 2 didn't produce any errors, you are ready to run the tests in
+ *    replay mode and make sure they all succeed as well:
+ *
+ *        FRODO_DEBUG=1 npm run test:only UserOps
+ *
+ * Note: FRODO_DEBUG=1 is optional and enables debug logging for some output
+ * in case things don't function as expected
+ */
+import { autoSetupPolly } from "../utils/AutoSetupPolly";
+import { filterRecording } from "../utils/PollyUtils";
+import * as UserOps from "./UserOps";
+import { state } from "../lib/FrodoLib";
+
+const ctx = autoSetupPolly();
+
+describe('UserOps', () => {
+  beforeEach(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      ctx.polly.server.any().on('beforePersist', (_req, recording) => {
+        filterRecording(recording);
+      });
+    }
+  });
+
+  describe('createUserExportTemplate()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.createUserExportTemplate).toBeDefined();
+    });
+
+    test('1: Create User Export Template', async () => {
+      const response = UserOps.createUserExportTemplate({ state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+  });
+
+  describe('readUser()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.readUser).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('readUsers()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.readUsers).toBeDefined();
+    });
+
+    test('1: Read Users', async () => {
+      const response = await UserOps.readUsers({ state });
+      expect(response).toMatchSnapshot();
+    });
+  });
+
+  describe('exportUser()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.exportUser).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('exportUsers()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.exportUsers).toBeDefined();
+    });
+
+    test('1: Export Users', async () => {
+      const response = await UserOps.exportUsers({ state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+  });
+
+  describe('createUserGroupExportTemplate()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.createUserGroupExportTemplate).toBeDefined();
+    });
+
+    test('1: Create User Group Export Template', async () => {
+      const response = UserOps.createUserGroupExportTemplate({ state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+  });
+
+  describe('readUserGroup()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.readUserGroup).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('readUserGroups()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.readUserGroups).toBeDefined();
+    });
+
+    test('1: Read User Groups', async () => {
+      const response = await UserOps.readUserGroups({ state });
+      expect(response).toMatchSnapshot();
+    });
+  });
+
+  describe('exportUserGroup()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.exportUserGroup).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('exportUserGroups()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.exportUserGroups).toBeDefined();
+    });
+
+    test('1: Export User Groups', async () => {
+      const response = await UserOps.exportUserGroups({ state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+  });
+
+  describe('importUsers()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.importUsers).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('importUserGroups()', () => {
+    test('0: Method is implemented', async () => {
+      expect(UserOps.importUserGroups).toBeDefined();
+    });
+    //TODO: create tests
+  });
+});

--- a/src/ops/UserOps.ts
+++ b/src/ops/UserOps.ts
@@ -1,0 +1,534 @@
+import {
+  getUser,
+  getUserConfig,
+  getUserGroup,
+  getUserGroups,
+  getUsers,
+  putUser,
+  putUserConfig,
+  putUserGroup,
+  UserConfigSkeleton,
+  UserGroupSkeleton,
+  UserSkeleton,
+} from '../api/UserApi';
+import { State } from '../shared/State';
+import {
+  createProgressIndicator,
+  debugMessage,
+  stopProgressIndicator,
+  updateProgressIndicator,
+} from '../utils/Console';
+import { getMetadata } from '../utils/ExportImportUtils';
+import { FrodoError } from './FrodoError';
+import { ExportMetaData } from './OpsTypes';
+
+export type User = {
+  /**
+   * Create an empty user export template
+   * @returns {UserExportInterface} an empty user export template
+   */
+  createUserExportTemplate(): UserExportInterface;
+  /**
+   * Read user by id
+   * @param {string} userId User id
+   * @returns {Promise<UserSkeleton>} a promise that resolves to a user object
+   */
+  readUser(userId: string): Promise<UserSkeleton>;
+  /**
+   * Read all users.
+   * @returns {Promise<UserSkeleton[]>} a promise that resolves to an array of user objects
+   */
+  readUsers(): Promise<UserSkeleton[]>;
+  /**
+   * Export a single user by id. The response can be saved to file as is.
+   * @param {string} userId User id
+   * @returns {Promise<UserExportInterface>} Promise resolving to a UserExportInterface object.
+   */
+  exportUser(userId: string): Promise<UserExportInterface>;
+  /**
+   * Export all users. The response can be saved to file as is.
+   * @returns {Promise<UserExportInterface>} Promise resolving to a UserExportInterface object.
+   */
+  exportUsers(): Promise<UserExportInterface>;
+  /**
+   * Create an empty user group export template
+   * @returns {UserGroupExportInterface} an empty user group export template
+   */
+  createUserGroupExportTemplate(): UserGroupExportInterface;
+  /**
+   * Read user group by id
+   * @param {string} groupId Group id
+   * @returns {Promise<UserGroupSkeleton>} a promise that resolves to a user group object
+   */
+  readUserGroup(groupId: string): Promise<UserGroupSkeleton>;
+  /**
+   * Read all user groups.
+   * @returns {Promise<UserGroupSkeleton[]>} a promise that resolves to an array of user group objects
+   */
+  readUserGroups(): Promise<UserGroupSkeleton[]>;
+  /**
+   * Export a single user group by id. The response can be saved to file as is.
+   * @param {string} groupId Group id
+   * @returns {Promise<UserGroupExportInterface>} Promise resolving to a UserGroupExportInterface object.
+   */
+  exportUserGroup(groupId: string): Promise<UserGroupExportInterface>;
+  /**
+   * Export all user groups. The response can be saved to file as is.
+   * @returns {Promise<UserGroupExportInterface>} Promise resolving to a UserGroupExportInterface object.
+   */
+  exportUserGroups(): Promise<UserGroupExportInterface>;
+  /**
+   * Import users and their config
+   * @param {UserExportInterface} importData user import data
+   * @param {string} userId Optional user id. If supplied, only the user of that id is imported.
+   * @returns {Promise<UserExportSkeleton[]>} the imported users
+   */
+  importUsers(
+    importData: UserExportInterface,
+    userId?: string
+  ): Promise<UserExportSkeleton[]>;
+  /**
+   * Import user groups
+   * @param {UserGroupExportInterface} importData user group import data
+   * @param {string} groupId Optional user group id. If supplied, only the group of that id is imported.
+   * @returns {Promise<UserGroupSkeleton[]>} the imported user groups
+   */
+  importUserGroups(
+    importData: UserGroupExportInterface,
+    groupId?: string
+  ): Promise<UserGroupSkeleton[]>;
+};
+
+export default (state: State): User => {
+  return {
+    createUserExportTemplate(): UserExportInterface {
+      return createUserExportTemplate({ state });
+    },
+    async readUser(userId: string): Promise<UserSkeleton> {
+      return readUser({ userId, state });
+    },
+    async readUsers(): Promise<UserSkeleton[]> {
+      return readUsers({ state });
+    },
+    async exportUser(userId: string): Promise<UserExportInterface> {
+      return exportUser({ userId, state });
+    },
+    async exportUsers(): Promise<UserExportInterface> {
+      return exportUsers({ state });
+    },
+    createUserGroupExportTemplate(): UserGroupExportInterface {
+      return createUserGroupExportTemplate({ state });
+    },
+    async readUserGroup(groupId: string): Promise<UserGroupSkeleton> {
+      return readUserGroup({ groupId, state });
+    },
+    async readUserGroups(): Promise<UserGroupSkeleton[]> {
+      return readUserGroups({ state });
+    },
+    async exportUserGroup(groupId: string): Promise<UserGroupExportInterface> {
+      return exportUserGroup({ groupId, state });
+    },
+    async exportUserGroups(): Promise<UserGroupExportInterface> {
+      return exportUserGroups({ state });
+    },
+    importUsers(
+      importData: UserExportInterface,
+      userId?: string
+    ): Promise<UserExportSkeleton[]> {
+      return importUsers({
+        importData,
+        userId,
+        state,
+      });
+    },
+    importUserGroups(
+      importData: UserGroupExportInterface,
+      groupId?: string
+    ): Promise<UserGroupSkeleton[]> {
+      return importUserGroups({
+        importData,
+        groupId,
+        state,
+      });
+    },
+  };
+};
+
+export type UserExportSkeleton = UserSkeleton & {
+  config: UserConfigSkeleton;
+};
+
+export interface UserExportInterface {
+  meta?: ExportMetaData;
+  user: Record<string, UserExportSkeleton>;
+}
+
+export interface UserGroupExportInterface {
+  meta?: ExportMetaData;
+  userGroup: Record<string, UserGroupSkeleton>;
+}
+
+/**
+ * Create an empty user export template
+ * @returns {UserExportInterface} an empty user export template
+ */
+export function createUserExportTemplate({
+  state,
+}: {
+  state: State;
+}): UserExportInterface {
+  return {
+    meta: getMetadata({ state }),
+    user: {},
+  };
+}
+
+/**
+ * Read user by id
+ * @param {string} userId User id
+ * @returns {Promise<UserSkeleton>} a promise that resolves to a user object
+ */
+export async function readUser({
+  userId,
+  state,
+}: {
+  userId: string;
+  state: State;
+}): Promise<UserSkeleton> {
+  try {
+    return getUser({ userId, state });
+  } catch (error) {
+    throw new FrodoError(`Error reading user ${userId}`, error);
+  }
+}
+
+/**
+ * Read all users.
+ * @returns {Promise<UserSkeleton[]>} a promise that resolves to an array of user objects
+ */
+export async function readUsers({
+  state,
+}: {
+  state: State;
+}): Promise<UserSkeleton[]> {
+  try {
+    debugMessage({
+      message: `UserOps.readUsers: start`,
+      state,
+    });
+    const { result } = await getUsers({ state });
+    debugMessage({ message: `UserOps.readUsers: end`, state });
+    return result;
+  } catch (error) {
+    throw new FrodoError(`Error reading users`, error);
+  }
+}
+
+/**
+ * Export a single user by id. The response can be saved to file as is.
+ * @param {string} userId User id
+ * @returns {Promise<UserExportInterface>} Promise resolving to a UserExportInterface object.
+ */
+export async function exportUser({
+  userId,
+  state,
+}: {
+  userId: string;
+  state: State;
+}): Promise<UserExportInterface> {
+  try {
+    const user = (await readUser({
+      userId,
+      state,
+    })) as UserExportSkeleton;
+    user.config = await getUserConfig({ userId, state });
+    const exportData = createUserExportTemplate({ state });
+    exportData.user[userId] = user;
+    return exportData;
+  } catch (error) {
+    throw new FrodoError(`Error exporting user ${userId}`, error);
+  }
+}
+
+/**
+ * Export all users. The response can be saved to file as is.
+ * @returns {Promise<UserExportInterface>} Promise resolving to a UserExportInterface object.
+ */
+export async function exportUsers({
+  state,
+}: {
+  state: State;
+}): Promise<UserExportInterface> {
+  let indicatorId: string;
+  try {
+    debugMessage({
+      message: `UserOps.exportUsers: start`,
+      state,
+    });
+    const exportData = createUserExportTemplate({ state });
+    const users = await readUsers({ state });
+    indicatorId = createProgressIndicator({
+      total: users.length,
+      message: 'Exporting users...',
+      state,
+    });
+    for (const user of users) {
+      updateProgressIndicator({
+        id: indicatorId,
+        message: `Exporting user ${user._id}`,
+        state,
+      });
+      user.config = await getUserConfig({ userId: user._id, state });
+      exportData.user[user._id] = user as UserExportSkeleton;
+    }
+    stopProgressIndicator({
+      id: indicatorId,
+      message: `Exported ${users.length} users.`,
+      state,
+    });
+    debugMessage({ message: `UserOps.exportUsers: end`, state });
+    return exportData;
+  } catch (error) {
+    stopProgressIndicator({
+      id: indicatorId,
+      message: `Error exporting users.`,
+      status: 'fail',
+      state,
+    });
+    throw new FrodoError(`Error reading users`, error);
+  }
+}
+
+/**
+ * Create an empty user group export template
+ * @returns {UserGroupExportInterface} an empty user group export template
+ */
+export function createUserGroupExportTemplate({
+  state,
+}: {
+  state: State;
+}): UserGroupExportInterface {
+  return {
+    meta: getMetadata({ state }),
+    userGroup: {},
+  };
+}
+
+/**
+ * Read user group by id
+ * @param {string} groupId User group id
+ * @returns {Promise<UserGroupSkeleton>} a promise that resolves to a user group object
+ */
+export async function readUserGroup({
+  groupId,
+  state,
+}: {
+  groupId: string;
+  state: State;
+}): Promise<UserGroupSkeleton> {
+  try {
+    return getUserGroup({ groupId, state });
+  } catch (error) {
+    throw new FrodoError(`Error reading user group ${groupId}`, error);
+  }
+}
+
+/**
+ * Read all user groups.
+ * @returns {Promise<UserGroupSkeleton[]>} a promise that resolves to an array of user group objects
+ */
+export async function readUserGroups({
+  state,
+}: {
+  state: State;
+}): Promise<UserGroupSkeleton[]> {
+  try {
+    debugMessage({
+      message: `UserOps.readUserGroups: start`,
+      state,
+    });
+    const { result } = await getUserGroups({ state });
+    // getUserGroups doesn't return groups with the privileges attribute, so request each group individually
+    const groups = Promise.all(
+      result.map((g) => readUserGroup({ groupId: g._id, state }))
+    );
+    debugMessage({ message: `UserOps.readUserGroups: end`, state });
+    return groups;
+  } catch (error) {
+    throw new FrodoError(`Error reading user groups`, error);
+  }
+}
+
+/**
+ * Export a single user group by id. The response can be saved to file as is.
+ * @param {string} groupId User group id
+ * @returns {Promise<UserGroupExportInterface>} Promise resolving to a UserGroupExportInterface object.
+ */
+export async function exportUserGroup({
+  groupId,
+  state,
+}: {
+  groupId: string;
+  state: State;
+}): Promise<UserGroupExportInterface> {
+  try {
+    const group = await readUserGroup({
+      groupId,
+      state,
+    });
+    const exportData = createUserGroupExportTemplate({ state });
+    exportData.userGroup[groupId] = group;
+    return exportData;
+  } catch (error) {
+    throw new FrodoError(`Error exporting user group ${groupId}`, error);
+  }
+}
+
+/**
+ * Export all user groups. The response can be saved to file as is.
+ * @returns {Promise<UserGroupExportInterface>} Promise resolving to a UserGroupExportInterface object.
+ */
+export async function exportUserGroups({
+  state,
+}: {
+  state: State;
+}): Promise<UserGroupExportInterface> {
+  let indicatorId: string;
+  try {
+    debugMessage({
+      message: `UserOps.exportUserGroups: start`,
+      state,
+    });
+    const exportData = createUserGroupExportTemplate({ state });
+    const groups = await readUserGroups({ state });
+    indicatorId = createProgressIndicator({
+      total: groups.length,
+      message: 'Exporting user groups...',
+      state,
+    });
+    for (const group of groups) {
+      updateProgressIndicator({
+        id: indicatorId,
+        message: `Exporting user group ${group._id}`,
+        state,
+      });
+      exportData.userGroup[group._id] = group;
+    }
+    stopProgressIndicator({
+      id: indicatorId,
+      message: `Exported ${groups.length} user groups.`,
+      state,
+    });
+    debugMessage({ message: `UserOps.exportUserGroups: end`, state });
+    return exportData;
+  } catch (error) {
+    stopProgressIndicator({
+      id: indicatorId,
+      message: `Error exporting user groups.`,
+      status: 'fail',
+      state,
+    });
+    throw new FrodoError(`Error reading user groups`, error);
+  }
+}
+
+/**
+ * Import users and their config
+ * @param {UserExportInterface} importData user import data
+ * @param {string} userId Optional user id. If supplied, only the user of that id is imported.
+ * @returns {Promise<UserExportSkeleton[]>} the imported users
+ */
+export async function importUsers({
+  importData,
+  userId,
+  state,
+}: {
+  importData: UserExportInterface;
+  userId?: string;
+  state: State;
+}): Promise<UserExportSkeleton[]> {
+  const errors = [];
+  try {
+    debugMessage({ message: `UserOps.importUsers: start`, state });
+    const response = [];
+    for (const user of Object.values(importData.user)) {
+      try {
+        if (userId && user._id !== userId) {
+          continue;
+        }
+        const config = user.config;
+        delete user.config;
+        const importedUser = await putUser({
+          userData: user,
+          state,
+        });
+        importedUser.config = await putUserConfig({
+          userId: user._id,
+          configData: config,
+          state,
+        });
+        response.push(importedUser);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      throw new FrodoError(`Error importing users`, errors);
+    }
+    debugMessage({ message: `UserOps.importUsers: end`, state });
+    return response;
+  } catch (error) {
+    // re-throw previously caught errors
+    if (errors.length > 0) {
+      throw error;
+    }
+    throw new FrodoError(`Error importing users`, error);
+  }
+}
+
+/**
+ * Import user groups
+ * @param {UserGroupExportInterface} importData user group import data
+ * @param {string} groupId Optional user group id. If supplied, only the group of that id is imported.
+ * @returns {Promise<UserGroupSkeleton[]>} the imported user groups
+ */
+export async function importUserGroups({
+  importData,
+  groupId,
+  state,
+}: {
+  importData: UserGroupExportInterface;
+  groupId?: string;
+  state: State;
+}): Promise<UserGroupSkeleton[]> {
+  const errors = [];
+  try {
+    debugMessage({ message: `UserOps.importUserGroups: start`, state });
+    const response = [];
+    for (const group of Object.values(importData.userGroup)) {
+      try {
+        if (groupId && group._id !== groupId) {
+          continue;
+        }
+        const result = await putUserGroup({
+          groupData: group,
+          state,
+        });
+        response.push(result);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      throw new FrodoError(`Error importing user groups`, errors);
+    }
+    debugMessage({ message: `UserOps.importUserGroups: end`, state });
+    return response;
+  } catch (error) {
+    // re-throw previously caught errors
+    if (errors.length > 0) {
+      throw error;
+    }
+    throw new FrodoError(`Error importing user groups`, error);
+  }
+}

--- a/src/test/mock-recordings/UserOps_3424069170/exportUserGroups_1062914627/1-Export-User-Groups_3554310717/recording.har
+++ b/src/test/mock-recordings/UserOps_3424069170/exportUserGroups_1062914627/1-Export-User-Groups_3554310717/recording.har
@@ -1,0 +1,317 @@
+{
+  "log": {
+    "_recordingName": "UserOps/exportUserGroups()/1: Export User Groups",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "e0dd74c59d16ee0e479208c411ab2188",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=4.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1936,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/groups?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 514,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 514,
+            "text": "{\"result\":[{\"_id\":\"test-group\",\"_rev\":\"-1\",\"realm\":\"/alpha\",\"username\":\"test-group\",\"universalid\":[\"id=test-group,ou=group,o=alpha,ou=services,ou=am-config\"],\"dn\":[\"cn=test-group,ou=groups,o=alpha,o=root,ou=identities\"],\"uniqueMember\":[\"fr-idm-uuid=346459bf-4159-4c4c-b929-f9ff5acc2f53,ou=user,o=alpha,o=root,ou=identities\"],\"cn\":[\"test-group\"],\"objectclass\":[\"top\",\"groupofuniquenames\"]}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=4.1, resource=4.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "514"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 793,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:22.022Z",
+        "time": 65,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 65
+        }
+      },
+      {
+        "_id": "fd74d91abd5913c96ed2b728b36e3362",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=4.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1929,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/groups/test-group"
+        },
+        "response": {
+          "bodySize": 949,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 949,
+            "text": "{\"_id\":\"test-group\",\"_rev\":\"581192241\",\"username\":\"test-group\",\"realm\":\"/alpha\",\"universalid\":[\"id=test-group,ou=group,o=alpha,ou=services,ou=am-config\"],\"members\":{\"uniqueMember\":[\"346459bf-4159-4c4c-b929-f9ff5acc2f53\"]},\"dn\":[\"cn=test-group,ou=groups,o=alpha,o=root,ou=identities\"],\"cn\":[\"test-group\"],\"objectclass\":[\"top\",\"groupofuniquenames\"],\"privileges\":{\"EntitlementRestAccess\":false,\"ApplicationReadAccess\":true,\"ResourceTypeReadAccess\":false,\"PrivilegeRestReadAccess\":true,\"SubjectAttributesReadAccess\":false,\"ApplicationTypesReadAccess\":true,\"PolicyAdmin\":false,\"AgentAdmin\":true,\"SubjectTypesReadAccess\":false,\"LogRead\":true,\"CacheAdmin\":false,\"ConditionTypesReadAccess\":true,\"SessionPropertyModifyAccess\":false,\"LogWrite\":true,\"FederationAdmin\":false,\"PrivilegeRestAccess\":true,\"LogAdmin\":false,\"RealmReadAccess\":true,\"RealmAdmin\":false,\"ApplicationModifyAccess\":true,\"ResourceTypeModifyAccess\":false,\"DecisionCombinersReadAccess\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"581192241\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "949"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 785,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:22.094Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/UserOps_3424069170/exportUsers_3235633950/1-Export-Users_1377960204/recording.har
+++ b/src/test/mock-recordings/UserOps_3424069170/exportUsers_3235633950/1-Export-Users_1377960204/recording.har
@@ -1,0 +1,8598 @@
+{
+  "log": {
+    "_recordingName": "UserOps/exportUsers()/1: Export Users",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "0be9e3f36eb6e526d3fec8f353b91f28",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=4.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1935,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 5364,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 5364,
+            "text": "{\"result\":[{\"_id\":\"9f528ec5-4e5a-4c0b-ac56-74f194c97276\",\"_rev\":\"-1\",\"realm\":\"/alpha\",\"username\":\"scotty\",\"fr-idm-uuid\":[\"9f528ec5-4e5a-4c0b-ac56-74f194c97276\"],\"fr-idm-managed-user-memberoforgid\":[\"dfe53b12-798c-4408-839b-fa7fd8ccd672\"],\"mail\":[\"mscott@ufa.org\"],\"givenName\":[\"Montgomery\"],\"objectClass\":[\"iplanet-am-managed-person\",\"inetuser\",\"inetOrgPerson\",\"sunFMSAML2NameIdentifier\",\"devicePrintProfilesContainer\",\"fr-ext-attrs\",\"iplanet-am-user-service\",\"iPlanetPreferences\",\"pushDeviceProfilesContainer\",\"forgerock-am-dashboard-service\",\"top\",\"kbaInfoContainer\",\"person\",\"organizationalPerson\",\"oathDeviceProfilesContainer\",\"sunAMAuthAccountLockout\",\"webauthnDeviceProfilesContainer\",\"deviceProfilesContainer\",\"iplanet-am-auth-configuration-service\",\"fr-idm-hybrid-obj\",\"fr-idm-managed-user-explicit\"],\"fr-idm-managed-organization-member\":[\"{\\\"firstResourceCollection\\\":\\\"managed/alpha_user\\\",\\\"firstResourceId\\\":\\\"9f528ec5-4e5a-4c0b-ac56-74f194c97276\\\",\\\"firstPropertyName\\\":\\\"memberOfOrg\\\",\\\"secondResourceCollection\\\":\\\"managed/alpha_organization\\\",\\\"secondResourceId\\\":\\\"dfe53b12-798c-4408-839b-fa7fd8ccd672\\\",\\\"secondPropertyName\\\":\\\"members\\\",\\\"properties\\\":{},\\\"_id\\\":\\\"fd7ec2b5-59c4-4755-8bbe-8a848875ddf5-121714\\\",\\\"_rev\\\":\\\"fd7ec2b5-59c4-4755-8bbe-8a848875ddf5-121715\\\"}uid=dfe53b12-798c-4408-839b-fa7fd8ccd672,ou=organization,o=alpha,o=root,ou=identities\"],\"dn\":[\"fr-idm-uuid=9f528ec5-4e5a-4c0b-ac56-74f194c97276,ou=user,o=alpha,o=root,ou=identities\"],\"cn\":[\"Montgomery Scott\"],\"modifyTimestamp\":[\"20240108232735Z\"],\"createTimestamp\":[\"20240108232723Z\"],\"uid\":[\"scotty\"],\"fr-idm-custom-attrs\":[\"{}\"],\"universalid\":[\"id=9f528ec5-4e5a-4c0b-ac56-74f194c97276,ou=user,o=alpha,ou=services,ou=am-config\"],\"inetUserStatus\":[\"Active\"],\"sn\":[\"Scott\"]},{\"_id\":\"58612ba5-a53d-4b3e-9715-1740d397e56e\",\"_rev\":\"-1\",\"realm\":\"/alpha\",\"username\":\"kirk\",\"fr-idm-uuid\":[\"58612ba5-a53d-4b3e-9715-1740d397e56e\"],\"mail\":[\"jtkirk@ufp.org\"],\"givenName\":[\"James\"],\"objectClass\":[\"iplanet-am-managed-person\",\"inetuser\",\"inetOrgPerson\",\"sunFMSAML2NameIdentifier\",\"devicePrintProfilesContainer\",\"fr-ext-attrs\",\"iplanet-am-user-service\",\"iPlanetPreferences\",\"pushDeviceProfilesContainer\",\"forgerock-am-dashboard-service\",\"top\",\"kbaInfoContainer\",\"person\",\"organizationalPerson\",\"oathDeviceProfilesContainer\",\"sunAMAuthAccountLockout\",\"webauthnDeviceProfilesContainer\",\"deviceProfilesContainer\",\"iplanet-am-auth-configuration-service\",\"fr-idm-hybrid-obj\",\"fr-idm-managed-user-explicit\"],\"dn\":[\"fr-idm-uuid=58612ba5-a53d-4b3e-9715-1740d397e56e,ou=user,o=alpha,o=root,ou=identities\"],\"cn\":[\"James Kirk\"],\"modifyTimestamp\":[\"20240122164335Z\"],\"createTimestamp\":[\"20240108232406Z\"],\"uid\":[\"kirk\"],\"fr-idm-custom-attrs\":[\"{}\"],\"fr-idm-preferences\":[\"{\\\"updates\\\":false,\\\"marketing\\\":false}\"],\"universalid\":[\"id=58612ba5-a53d-4b3e-9715-1740d397e56e,ou=user,o=alpha,ou=services,ou=am-config\"],\"inetUserStatus\":[\"Active\"],\"sn\":[\"Kirk\"]},{\"_id\":\"346459bf-4159-4c4c-b929-f9ff5acc2f53\",\"_rev\":\"-1\",\"realm\":\"/alpha\",\"username\":\"test\",\"fr-idm-uuid\":[\"346459bf-4159-4c4c-b929-f9ff5acc2f53\"],\"mail\":[\"test@test.com\"],\"givenName\":[\"Test\"],\"objectClass\":[\"iplanet-am-managed-person\",\"inetuser\",\"inetOrgPerson\",\"sunFMSAML2NameIdentifier\",\"devicePrintProfilesContainer\",\"fr-ext-attrs\",\"iplanet-am-user-service\",\"iPlanetPreferences\",\"pushDeviceProfilesContainer\",\"forgerock-am-dashboard-service\",\"top\",\"kbaInfoContainer\",\"person\",\"organizationalPerson\",\"oathDeviceProfilesContainer\",\"sunAMAuthAccountLockout\",\"webauthnDeviceProfilesContainer\",\"deviceProfilesContainer\",\"iplanet-am-auth-configuration-service\",\"fr-idm-hybrid-obj\",\"fr-idm-managed-user-explicit\"],\"dn\":[\"fr-idm-uuid=346459bf-4159-4c4c-b929-f9ff5acc2f53,ou=user,o=alpha,o=root,ou=identities\"],\"cn\":[\"Test User\"],\"modifyTimestamp\":[\"20240718171625Z\"],\"createTimestamp\":[\"20240718171624Z\"],\"uid\":[\"test\"],\"fr-idm-custom-attrs\":[\"{\\\"effectiveApplications\\\":[]}\"],\"universalid\":[\"id=346459bf-4159-4c4c-b929-f9ff5acc2f53,ou=user,o=alpha,ou=services,ou=am-config\"],\"isMemberOf\":[\"cn=test-group,ou=groups,o=alpha,o=root,ou=identities\"],\"inetUserStatus\":[\"Active\"],\"sn\":[\"User\"]},{\"_id\":\"146c2230-9448-4442-b86d-eb4a81a0121d\",\"_rev\":\"-1\",\"realm\":\"/alpha\",\"username\":\"vscheuber@gmail.com\",\"fr-idm-uuid\":[\"146c2230-9448-4442-b86d-eb4a81a0121d\"],\"mail\":[\"vscheuber@gmail.com\"],\"givenName\":[\"Scheuber\"],\"objectClass\":[\"iplanet-am-managed-person\",\"inetuser\",\"inetOrgPerson\",\"sunFMSAML2NameIdentifier\",\"devicePrintProfilesContainer\",\"fr-ext-attrs\",\"iplanet-am-user-service\",\"iPlanetPreferences\",\"pushDeviceProfilesContainer\",\"forgerock-am-dashboard-service\",\"top\",\"kbaInfoContainer\",\"person\",\"organizationalPerson\",\"oathDeviceProfilesContainer\",\"sunAMAuthAccountLockout\",\"webauthnDeviceProfilesContainer\",\"deviceProfilesContainer\",\"iplanet-am-auth-configuration-service\",\"fr-idm-hybrid-obj\",\"fr-idm-managed-user-explicit\"],\"dn\":[\"fr-idm-uuid=146c2230-9448-4442-b86d-eb4a81a0121d,ou=user,o=alpha,o=root,ou=identities\"],\"cn\":[\"Scheuber Volker\"],\"modifyTimestamp\":[\"20231207213130Z\"],\"createTimestamp\":[\"20231201013952Z\"],\"uid\":[\"vscheuber@gmail.com\"],\"fr-idm-custom-attrs\":[\"{}\"],\"universalid\":[\"id=146c2230-9448-4442-b86d-eb4a81a0121d,ou=user,o=alpha,ou=services,ou=am-config\"],\"inetUserStatus\":[\"Active\"],\"sn\":[\"Volker\"]}],\"resultCount\":4,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=4.1, resource=4.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "5364"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:17 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:17.950Z",
+        "time": 69,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 69
+        }
+      },
+      {
+        "_id": "bd3a0d4502c66f8a2e7170bb04d2b8e7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/services?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 32,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 32,
+            "text": "{\"result\":[{\"_id\":\"dashboard\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "32"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:17 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 765,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.029Z",
+        "time": 70,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 70
+        }
+      },
+      {
+        "_id": "420964de13de0c28d266f62906352763",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/devices/2fa/binding?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.108Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      },
+      {
+        "_id": "8334d567bd514446abd1eb8f1088d486",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/devices/2fa/oath?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.186Z",
+        "time": 64,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 64
+        }
+      },
+      {
+        "_id": "66b144aaeace2fe6478c80fec7154050",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/devices/2fa/push?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.256Z",
+        "time": 60,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 60
+        }
+      },
+      {
+        "_id": "4dbd7bf7fac6d9988caef002a156b659",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1993,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/devices/2fa/webauthn?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.323Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "874992167bf39dd8f41e0a22cc327503",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/devices/profile?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.389Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      },
+      {
+        "_id": "7bfda13a6eab4c1ed7dfa94625116f5b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/devices/trusted?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.457Z",
+        "time": 69,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 69
+        }
+      },
+      {
+        "_id": "4b064a9ad2b580a2e67734933f4ed1ea",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1979,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/groups?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 137,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 137,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "137"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.535Z",
+        "time": 63,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 63
+        }
+      },
+      {
+        "_id": "110a456afdb276e23dae815955040db6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/oauth2/applications?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.607Z",
+        "time": 63,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 63
+        }
+      },
+      {
+        "_id": "791cc0493f43a2e60c3a44cdea51acd6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1996,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/oauth2/resources/labels?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.679Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      },
+      {
+        "_id": "d3817e9b3a00c5577f33541b6a047a53",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1994,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/oauth2/resources/sets?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.758Z",
+        "time": 65,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 65
+        }
+      },
+      {
+        "_id": "6baf7d77269f5b82219f079dcb4808a6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/uma/auditHistory?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.832Z",
+        "time": 59,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 59
+        }
+      },
+      {
+        "_id": "c0c56c4d7c84ca8df7fe84e796c0c023",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/uma/pendingrequests?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.899Z",
+        "time": 55,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 55
+        }
+      },
+      {
+        "_id": "6645331d7dd6cf2cb48c71550e727531",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1985,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/9f528ec5-4e5a-4c0b-ac56-74f194c97276/uma/policies?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:18.962Z",
+        "time": 59,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 59
+        }
+      },
+      {
+        "_id": "c726ef37727f6a980cc75ba084a3cb4f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/services?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 32,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 32,
+            "text": "{\"result\":[{\"_id\":\"dashboard\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "32"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 765,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.030Z",
+        "time": 68,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 68
+        }
+      },
+      {
+        "_id": "64e3867732fd476eb170d4055ff42df2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/devices/2fa/binding?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.105Z",
+        "time": 54,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 54
+        }
+      },
+      {
+        "_id": "43c0914776844902d81d159e8c0375a4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/devices/2fa/oath?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.167Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "215dbea276d23424e99a4e431f0df26e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/devices/2fa/push?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.231Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      },
+      {
+        "_id": "e1bc566914220cd65ac09d44a4d4b9b4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1993,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/devices/2fa/webauthn?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.299Z",
+        "time": 56,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 56
+        }
+      },
+      {
+        "_id": "3aea206a23a0ad34a42e37da80cca4b4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/devices/profile?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.360Z",
+        "time": 59,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 59
+        }
+      },
+      {
+        "_id": "f26cfed0168a9833c5f2f2f8b58d9ac6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/devices/trusted?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.426Z",
+        "time": 60,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 60
+        }
+      },
+      {
+        "_id": "986fd62b8a4fc104e89fee9329f38dff",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1979,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/groups?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 137,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 137,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "137"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.492Z",
+        "time": 65,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 65
+        }
+      },
+      {
+        "_id": "f116ec220991ebe3654730a9c8dc10ed",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/oauth2/applications?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.564Z",
+        "time": 63,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 63
+        }
+      },
+      {
+        "_id": "baab52d5e539a1c9b5dab949edc08529",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1996,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/oauth2/resources/labels?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.633Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "ce2d20bd4e169faa67dd66a5034c643b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1994,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/oauth2/resources/sets?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.698Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "a093a8e69cdcbe34c8922b00a8b0b2a4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/uma/auditHistory?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.763Z",
+        "time": 57,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 57
+        }
+      },
+      {
+        "_id": "d4de6211f2a7d284a82fc44e90461a2a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/uma/pendingrequests?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.827Z",
+        "time": 57,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 57
+        }
+      },
+      {
+        "_id": "8736c164579a9d407b47c3c93da1f2c8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1985,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/58612ba5-a53d-4b3e-9715-1740d397e56e/uma/policies?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.899Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      },
+      {
+        "_id": "3df259f57332bc1ea9a7f9365dc5898d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/services?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 32,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 32,
+            "text": "{\"result\":[{\"_id\":\"dashboard\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "32"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 765,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:19.968Z",
+        "time": 65,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 65
+        }
+      },
+      {
+        "_id": "1364d0b47a97a5356bbd98d13c2d84b9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/devices/2fa/binding?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.040Z",
+        "time": 60,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 60
+        }
+      },
+      {
+        "_id": "4fded14dbc2d053f971bf7f118c4eb07",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/devices/2fa/oath?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.106Z",
+        "time": 60,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 60
+        }
+      },
+      {
+        "_id": "1b23ac89d4f957cb3319ffa3d886f5ec",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/devices/2fa/push?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.173Z",
+        "time": 59,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 59
+        }
+      },
+      {
+        "_id": "0c95741d4d06e8d7bf68b9feda98f4e9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1993,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/devices/2fa/webauthn?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.238Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "a179f0ad8f26f51bf1a834d3c7d3864c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/devices/profile?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.302Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      },
+      {
+        "_id": "c8a5cc41398803fd9ea5f041b336175a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/devices/trusted?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.370Z",
+        "time": 57,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 57
+        }
+      },
+      {
+        "_id": "a2177b3639f804378ecbe8ea4fa60605",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1979,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/groups?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 203,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 203,
+            "text": "{\"result\":[{\"_id\":\"test-group\",\"_rev\":\"-2100625394\",\"groupname\":\"test-group\"}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "203"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 793,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.431Z",
+        "time": 74,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 74
+        }
+      },
+      {
+        "_id": "81b9853cef31ddb2d4945e9b6e21891e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/oauth2/applications?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.511Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      },
+      {
+        "_id": "8c4b4b7bdcecf5561e9ae2e30fa3994b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1996,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/oauth2/resources/labels?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.577Z",
+        "time": 56,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 56
+        }
+      },
+      {
+        "_id": "cf5ffc3cff4a914dc8d0c90f971fc2ef",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1994,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/oauth2/resources/sets?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.641Z",
+        "time": 55,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 55
+        }
+      },
+      {
+        "_id": "310ca9ba4857ee87f16b514265c3c0bf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/uma/auditHistory?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.703Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "bcf5441d54f9f5defe1dc25be748ffca",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/uma/pendingrequests?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.769Z",
+        "time": 62,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 62
+        }
+      },
+      {
+        "_id": "45df25f24328a7abc1249099bd41c861",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1985,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/346459bf-4159-4c4c-b929-f9ff5acc2f53/uma/policies?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.839Z",
+        "time": 56,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 56
+        }
+      },
+      {
+        "_id": "42065e089efe2f71ae992e84675f3a15",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/services?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 32,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 32,
+            "text": "{\"result\":[{\"_id\":\"dashboard\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "32"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 765,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.902Z",
+        "time": 65,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 65
+        }
+      },
+      {
+        "_id": "f42475d473efc8aad6bc76b613fcf19d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/devices/2fa/binding?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:20.973Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "075c8a69fd6f18862c9412a5e69e15c5",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/devices/2fa/oath?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.038Z",
+        "time": 59,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 59
+        }
+      },
+      {
+        "_id": "d725ea8a4b9ab3c31e3f4f177f6e0f9c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/devices/2fa/push?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.103Z",
+        "time": 54,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 54
+        }
+      },
+      {
+        "_id": "440f118a1eb6e4398ce91577cd103533",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1993,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/devices/2fa/webauthn?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.163Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "1a413c4f862f138de513471fd611ad0d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/devices/profile?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.227Z",
+        "time": 56,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 56
+        }
+      },
+      {
+        "_id": "143d2702b4f53792720a40a9e368caf4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/devices/trusted?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.289Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "535d0b091da58e251157d6075a3d7af8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1979,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/groups?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 137,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 137,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "137"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.352Z",
+        "time": 59,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 59
+        }
+      },
+      {
+        "_id": "c1fa24ea83fdc06e873dc71f41a10582",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/oauth2/applications?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.418Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      },
+      {
+        "_id": "1438027c2ddd97b8230c5f1777b8a2d3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1996,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/oauth2/resources/labels?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.485Z",
+        "time": 62,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 62
+        }
+      },
+      {
+        "_id": "4f63fb811806c7d111654ebbac705870",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1994,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/oauth2/resources/sets?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.553Z",
+        "time": 59,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 59
+        }
+      },
+      {
+        "_id": "b16469a196e4bb4825bba1348245fa30",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1989,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/uma/auditHistory?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.618Z",
+        "time": 59,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 59
+        }
+      },
+      {
+        "_id": "013433a91648803c42ed673c4ad9d974",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/uma/pendingrequests?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.684Z",
+        "time": 59,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 59
+        }
+      },
+      {
+        "_id": "814c444afc911965b515a667ff75dd0c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1985,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users/146c2230-9448-4442-b86d-eb4a81a0121d/uma/policies?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 80,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"UMA is not supported in this realm\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "80"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 730,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.749Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/UserOps_3424069170/readUserGroups_3114713109/1-Read-User-Groups_1457809335/recording.har
+++ b/src/test/mock-recordings/UserOps_3424069170/readUserGroups_3114713109/1-Read-User-Groups_1457809335/recording.har
@@ -1,0 +1,317 @@
+{
+  "log": {
+    "_recordingName": "UserOps/readUserGroups()/1: Read User Groups",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "e0dd74c59d16ee0e479208c411ab2188",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=4.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1936,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/groups?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 514,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 514,
+            "text": "{\"result\":[{\"_id\":\"test-group\",\"_rev\":\"-1\",\"realm\":\"/alpha\",\"username\":\"test-group\",\"universalid\":[\"id=test-group,ou=group,o=alpha,ou=services,ou=am-config\"],\"dn\":[\"cn=test-group,ou=groups,o=alpha,o=root,ou=identities\"],\"uniqueMember\":[\"fr-idm-uuid=346459bf-4159-4c4c-b929-f9ff5acc2f53,ou=user,o=alpha,o=root,ou=identities\"],\"cn\":[\"test-group\"],\"objectclass\":[\"top\",\"groupofuniquenames\"]}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=4.1, resource=4.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "514"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 793,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.858Z",
+        "time": 78,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 78
+        }
+      },
+      {
+        "_id": "fd74d91abd5913c96ed2b728b36e3362",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=4.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1929,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/groups/test-group"
+        },
+        "response": {
+          "bodySize": 949,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 949,
+            "text": "{\"_id\":\"test-group\",\"_rev\":\"581192241\",\"username\":\"test-group\",\"realm\":\"/alpha\",\"universalid\":[\"id=test-group,ou=group,o=alpha,ou=services,ou=am-config\"],\"members\":{\"uniqueMember\":[\"346459bf-4159-4c4c-b929-f9ff5acc2f53\"]},\"dn\":[\"cn=test-group,ou=groups,o=alpha,o=root,ou=identities\"],\"cn\":[\"test-group\"],\"objectclass\":[\"top\",\"groupofuniquenames\"],\"privileges\":{\"EntitlementRestAccess\":false,\"ApplicationReadAccess\":true,\"ResourceTypeReadAccess\":false,\"PrivilegeRestReadAccess\":true,\"SubjectAttributesReadAccess\":false,\"ApplicationTypesReadAccess\":true,\"PolicyAdmin\":false,\"AgentAdmin\":true,\"SubjectTypesReadAccess\":false,\"LogRead\":true,\"CacheAdmin\":false,\"ConditionTypesReadAccess\":true,\"SessionPropertyModifyAccess\":false,\"LogWrite\":true,\"FederationAdmin\":false,\"PrivilegeRestAccess\":true,\"LogAdmin\":false,\"RealmReadAccess\":true,\"RealmAdmin\":false,\"ApplicationModifyAccess\":true,\"ResourceTypeModifyAccess\":false,\"DecisionCombinersReadAccess\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"581192241\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "949"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 785,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:21.943Z",
+        "time": 65,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 65
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/UserOps_3424069170/readUsers_2157690616/1-Read-Users_1528964058/recording.har
+++ b/src/test/mock-recordings/UserOps_3424069170/readUsers_2157690616/1-Read-Users_1528964058/recording.har
@@ -1,0 +1,166 @@
+{
+  "log": {
+    "_recordingName": "UserOps/readUsers()/1: Read Users",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "0be9e3f36eb6e526d3fec8f353b91f28",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=4.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1935,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/users?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 5364,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 5364,
+            "text": "{\"result\":[{\"_id\":\"9f528ec5-4e5a-4c0b-ac56-74f194c97276\",\"_rev\":\"-1\",\"realm\":\"/alpha\",\"username\":\"scotty\",\"fr-idm-uuid\":[\"9f528ec5-4e5a-4c0b-ac56-74f194c97276\"],\"fr-idm-managed-user-memberoforgid\":[\"dfe53b12-798c-4408-839b-fa7fd8ccd672\"],\"mail\":[\"mscott@ufa.org\"],\"givenName\":[\"Montgomery\"],\"objectClass\":[\"iplanet-am-managed-person\",\"inetuser\",\"inetOrgPerson\",\"sunFMSAML2NameIdentifier\",\"devicePrintProfilesContainer\",\"fr-ext-attrs\",\"iplanet-am-user-service\",\"iPlanetPreferences\",\"pushDeviceProfilesContainer\",\"forgerock-am-dashboard-service\",\"top\",\"kbaInfoContainer\",\"person\",\"organizationalPerson\",\"oathDeviceProfilesContainer\",\"sunAMAuthAccountLockout\",\"webauthnDeviceProfilesContainer\",\"deviceProfilesContainer\",\"iplanet-am-auth-configuration-service\",\"fr-idm-hybrid-obj\",\"fr-idm-managed-user-explicit\"],\"fr-idm-managed-organization-member\":[\"{\\\"firstResourceCollection\\\":\\\"managed/alpha_user\\\",\\\"firstResourceId\\\":\\\"9f528ec5-4e5a-4c0b-ac56-74f194c97276\\\",\\\"firstPropertyName\\\":\\\"memberOfOrg\\\",\\\"secondResourceCollection\\\":\\\"managed/alpha_organization\\\",\\\"secondResourceId\\\":\\\"dfe53b12-798c-4408-839b-fa7fd8ccd672\\\",\\\"secondPropertyName\\\":\\\"members\\\",\\\"properties\\\":{},\\\"_id\\\":\\\"fd7ec2b5-59c4-4755-8bbe-8a848875ddf5-121714\\\",\\\"_rev\\\":\\\"fd7ec2b5-59c4-4755-8bbe-8a848875ddf5-121715\\\"}uid=dfe53b12-798c-4408-839b-fa7fd8ccd672,ou=organization,o=alpha,o=root,ou=identities\"],\"dn\":[\"fr-idm-uuid=9f528ec5-4e5a-4c0b-ac56-74f194c97276,ou=user,o=alpha,o=root,ou=identities\"],\"cn\":[\"Montgomery Scott\"],\"modifyTimestamp\":[\"20240108232735Z\"],\"createTimestamp\":[\"20240108232723Z\"],\"uid\":[\"scotty\"],\"fr-idm-custom-attrs\":[\"{}\"],\"universalid\":[\"id=9f528ec5-4e5a-4c0b-ac56-74f194c97276,ou=user,o=alpha,ou=services,ou=am-config\"],\"inetUserStatus\":[\"Active\"],\"sn\":[\"Scott\"]},{\"_id\":\"58612ba5-a53d-4b3e-9715-1740d397e56e\",\"_rev\":\"-1\",\"realm\":\"/alpha\",\"username\":\"kirk\",\"fr-idm-uuid\":[\"58612ba5-a53d-4b3e-9715-1740d397e56e\"],\"mail\":[\"jtkirk@ufp.org\"],\"givenName\":[\"James\"],\"objectClass\":[\"iplanet-am-managed-person\",\"inetuser\",\"inetOrgPerson\",\"sunFMSAML2NameIdentifier\",\"devicePrintProfilesContainer\",\"fr-ext-attrs\",\"iplanet-am-user-service\",\"iPlanetPreferences\",\"pushDeviceProfilesContainer\",\"forgerock-am-dashboard-service\",\"top\",\"kbaInfoContainer\",\"person\",\"organizationalPerson\",\"oathDeviceProfilesContainer\",\"sunAMAuthAccountLockout\",\"webauthnDeviceProfilesContainer\",\"deviceProfilesContainer\",\"iplanet-am-auth-configuration-service\",\"fr-idm-hybrid-obj\",\"fr-idm-managed-user-explicit\"],\"dn\":[\"fr-idm-uuid=58612ba5-a53d-4b3e-9715-1740d397e56e,ou=user,o=alpha,o=root,ou=identities\"],\"cn\":[\"James Kirk\"],\"modifyTimestamp\":[\"20240122164335Z\"],\"createTimestamp\":[\"20240108232406Z\"],\"uid\":[\"kirk\"],\"fr-idm-custom-attrs\":[\"{}\"],\"fr-idm-preferences\":[\"{\\\"updates\\\":false,\\\"marketing\\\":false}\"],\"universalid\":[\"id=58612ba5-a53d-4b3e-9715-1740d397e56e,ou=user,o=alpha,ou=services,ou=am-config\"],\"inetUserStatus\":[\"Active\"],\"sn\":[\"Kirk\"]},{\"_id\":\"346459bf-4159-4c4c-b929-f9ff5acc2f53\",\"_rev\":\"-1\",\"realm\":\"/alpha\",\"username\":\"test\",\"fr-idm-uuid\":[\"346459bf-4159-4c4c-b929-f9ff5acc2f53\"],\"mail\":[\"test@test.com\"],\"givenName\":[\"Test\"],\"objectClass\":[\"iplanet-am-managed-person\",\"inetuser\",\"inetOrgPerson\",\"sunFMSAML2NameIdentifier\",\"devicePrintProfilesContainer\",\"fr-ext-attrs\",\"iplanet-am-user-service\",\"iPlanetPreferences\",\"pushDeviceProfilesContainer\",\"forgerock-am-dashboard-service\",\"top\",\"kbaInfoContainer\",\"person\",\"organizationalPerson\",\"oathDeviceProfilesContainer\",\"sunAMAuthAccountLockout\",\"webauthnDeviceProfilesContainer\",\"deviceProfilesContainer\",\"iplanet-am-auth-configuration-service\",\"fr-idm-hybrid-obj\",\"fr-idm-managed-user-explicit\"],\"dn\":[\"fr-idm-uuid=346459bf-4159-4c4c-b929-f9ff5acc2f53,ou=user,o=alpha,o=root,ou=identities\"],\"cn\":[\"Test User\"],\"modifyTimestamp\":[\"20240718171625Z\"],\"createTimestamp\":[\"20240718171624Z\"],\"uid\":[\"test\"],\"fr-idm-custom-attrs\":[\"{\\\"effectiveApplications\\\":[]}\"],\"universalid\":[\"id=346459bf-4159-4c4c-b929-f9ff5acc2f53,ou=user,o=alpha,ou=services,ou=am-config\"],\"isMemberOf\":[\"cn=test-group,ou=groups,o=alpha,o=root,ou=identities\"],\"inetUserStatus\":[\"Active\"],\"sn\":[\"User\"]},{\"_id\":\"146c2230-9448-4442-b86d-eb4a81a0121d\",\"_rev\":\"-1\",\"realm\":\"/alpha\",\"username\":\"vscheuber@gmail.com\",\"fr-idm-uuid\":[\"146c2230-9448-4442-b86d-eb4a81a0121d\"],\"mail\":[\"vscheuber@gmail.com\"],\"givenName\":[\"Scheuber\"],\"objectClass\":[\"iplanet-am-managed-person\",\"inetuser\",\"inetOrgPerson\",\"sunFMSAML2NameIdentifier\",\"devicePrintProfilesContainer\",\"fr-ext-attrs\",\"iplanet-am-user-service\",\"iPlanetPreferences\",\"pushDeviceProfilesContainer\",\"forgerock-am-dashboard-service\",\"top\",\"kbaInfoContainer\",\"person\",\"organizationalPerson\",\"oathDeviceProfilesContainer\",\"sunAMAuthAccountLockout\",\"webauthnDeviceProfilesContainer\",\"deviceProfilesContainer\",\"iplanet-am-auth-configuration-service\",\"fr-idm-hybrid-obj\",\"fr-idm-managed-user-explicit\"],\"dn\":[\"fr-idm-uuid=146c2230-9448-4442-b86d-eb4a81a0121d,ou=user,o=alpha,o=root,ou=identities\"],\"cn\":[\"Scheuber Volker\"],\"modifyTimestamp\":[\"20231207213130Z\"],\"createTimestamp\":[\"20231201013952Z\"],\"uid\":[\"vscheuber@gmail.com\"],\"fr-idm-custom-attrs\":[\"{}\"],\"universalid\":[\"id=146c2230-9448-4442-b86d-eb4a81a0121d,ou=user,o=alpha,ou=services,ou=am-config\"],\"inetUserStatus\":[\"Active\"],\"sn\":[\"Volker\"]}],\"resultCount\":4,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=4.1, resource=4.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "5364"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:52:17 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffe554e8-665a-4e7f-9be0-c70861513c21"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:52:17.799Z",
+        "time": 126,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 126
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/snapshots/ops/UserOps.test.js.snap
+++ b/src/test/snapshots/ops/UserOps.test.js.snap
@@ -1,0 +1,771 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserOps createUserExportTemplate() 1: Create User Export Template 1`] = `
+{
+  "meta": Any<Object>,
+  "user": {},
+}
+`;
+
+exports[`UserOps createUserGroupExportTemplate() 1: Create User Group Export Template 1`] = `
+{
+  "meta": Any<Object>,
+  "userGroup": {},
+}
+`;
+
+exports[`UserOps exportUserGroups() 1: Export User Groups 1`] = `
+{
+  "meta": Any<Object>,
+  "userGroup": {
+    "test-group": {
+      "_id": "test-group",
+      "_rev": "581192241",
+      "cn": [
+        "test-group",
+      ],
+      "dn": [
+        "cn=test-group,ou=groups,o=alpha,o=root,ou=identities",
+      ],
+      "members": {
+        "uniqueMember": [
+          "346459bf-4159-4c4c-b929-f9ff5acc2f53",
+        ],
+      },
+      "objectclass": [
+        "top",
+        "groupofuniquenames",
+      ],
+      "privileges": {
+        "AgentAdmin": true,
+        "ApplicationModifyAccess": true,
+        "ApplicationReadAccess": true,
+        "ApplicationTypesReadAccess": true,
+        "CacheAdmin": false,
+        "ConditionTypesReadAccess": true,
+        "DecisionCombinersReadAccess": true,
+        "EntitlementRestAccess": false,
+        "FederationAdmin": false,
+        "LogAdmin": false,
+        "LogRead": true,
+        "LogWrite": true,
+        "PolicyAdmin": false,
+        "PrivilegeRestAccess": true,
+        "PrivilegeRestReadAccess": true,
+        "RealmAdmin": false,
+        "RealmReadAccess": true,
+        "ResourceTypeModifyAccess": false,
+        "ResourceTypeReadAccess": false,
+        "SessionPropertyModifyAccess": false,
+        "SubjectAttributesReadAccess": false,
+        "SubjectTypesReadAccess": false,
+      },
+      "realm": "/alpha",
+      "universalid": [
+        "id=test-group,ou=group,o=alpha,ou=services,ou=am-config",
+      ],
+      "username": "test-group",
+    },
+  },
+}
+`;
+
+exports[`UserOps exportUsers() 1: Export Users 1`] = `
+{
+  "meta": Any<Object>,
+  "user": {
+    "146c2230-9448-4442-b86d-eb4a81a0121d": {
+      "_id": "146c2230-9448-4442-b86d-eb4a81a0121d",
+      "_rev": "-1",
+      "cn": [
+        "Scheuber Volker",
+      ],
+      "config": {
+        "devices": {
+          "2fa": {
+            "binding": [],
+            "oath": [],
+            "push": [],
+            "webauthn": [],
+          },
+          "profile": [],
+          "trusted": [],
+        },
+        "groups": [],
+        "oauth2": {
+          "applications": [],
+        },
+        "services": [
+          {
+            "_id": "dashboard",
+          },
+        ],
+      },
+      "createTimestamp": [
+        "20231201013952Z",
+      ],
+      "dn": [
+        "fr-idm-uuid=146c2230-9448-4442-b86d-eb4a81a0121d,ou=user,o=alpha,o=root,ou=identities",
+      ],
+      "fr-idm-custom-attrs": [
+        "{}",
+      ],
+      "fr-idm-uuid": [
+        "146c2230-9448-4442-b86d-eb4a81a0121d",
+      ],
+      "givenName": [
+        "Scheuber",
+      ],
+      "inetUserStatus": [
+        "Active",
+      ],
+      "mail": [
+        "vscheuber@gmail.com",
+      ],
+      "modifyTimestamp": [
+        "20231207213130Z",
+      ],
+      "objectClass": [
+        "iplanet-am-managed-person",
+        "inetuser",
+        "inetOrgPerson",
+        "sunFMSAML2NameIdentifier",
+        "devicePrintProfilesContainer",
+        "fr-ext-attrs",
+        "iplanet-am-user-service",
+        "iPlanetPreferences",
+        "pushDeviceProfilesContainer",
+        "forgerock-am-dashboard-service",
+        "top",
+        "kbaInfoContainer",
+        "person",
+        "organizationalPerson",
+        "oathDeviceProfilesContainer",
+        "sunAMAuthAccountLockout",
+        "webauthnDeviceProfilesContainer",
+        "deviceProfilesContainer",
+        "iplanet-am-auth-configuration-service",
+        "fr-idm-hybrid-obj",
+        "fr-idm-managed-user-explicit",
+      ],
+      "realm": "/alpha",
+      "sn": [
+        "Volker",
+      ],
+      "uid": [
+        "vscheuber@gmail.com",
+      ],
+      "universalid": [
+        "id=146c2230-9448-4442-b86d-eb4a81a0121d,ou=user,o=alpha,ou=services,ou=am-config",
+      ],
+      "username": "vscheuber@gmail.com",
+    },
+    "346459bf-4159-4c4c-b929-f9ff5acc2f53": {
+      "_id": "346459bf-4159-4c4c-b929-f9ff5acc2f53",
+      "_rev": "-1",
+      "cn": [
+        "Test User",
+      ],
+      "config": {
+        "devices": {
+          "2fa": {
+            "binding": [],
+            "oath": [],
+            "push": [],
+            "webauthn": [],
+          },
+          "profile": [],
+          "trusted": [],
+        },
+        "groups": [
+          {
+            "_id": "test-group",
+            "_rev": "-2100625394",
+            "groupname": "test-group",
+          },
+        ],
+        "oauth2": {
+          "applications": [],
+        },
+        "services": [
+          {
+            "_id": "dashboard",
+          },
+        ],
+      },
+      "createTimestamp": [
+        "20240718171624Z",
+      ],
+      "dn": [
+        "fr-idm-uuid=346459bf-4159-4c4c-b929-f9ff5acc2f53,ou=user,o=alpha,o=root,ou=identities",
+      ],
+      "fr-idm-custom-attrs": [
+        "{"effectiveApplications":[]}",
+      ],
+      "fr-idm-uuid": [
+        "346459bf-4159-4c4c-b929-f9ff5acc2f53",
+      ],
+      "givenName": [
+        "Test",
+      ],
+      "inetUserStatus": [
+        "Active",
+      ],
+      "isMemberOf": [
+        "cn=test-group,ou=groups,o=alpha,o=root,ou=identities",
+      ],
+      "mail": [
+        "test@test.com",
+      ],
+      "modifyTimestamp": [
+        "20240718171625Z",
+      ],
+      "objectClass": [
+        "iplanet-am-managed-person",
+        "inetuser",
+        "inetOrgPerson",
+        "sunFMSAML2NameIdentifier",
+        "devicePrintProfilesContainer",
+        "fr-ext-attrs",
+        "iplanet-am-user-service",
+        "iPlanetPreferences",
+        "pushDeviceProfilesContainer",
+        "forgerock-am-dashboard-service",
+        "top",
+        "kbaInfoContainer",
+        "person",
+        "organizationalPerson",
+        "oathDeviceProfilesContainer",
+        "sunAMAuthAccountLockout",
+        "webauthnDeviceProfilesContainer",
+        "deviceProfilesContainer",
+        "iplanet-am-auth-configuration-service",
+        "fr-idm-hybrid-obj",
+        "fr-idm-managed-user-explicit",
+      ],
+      "realm": "/alpha",
+      "sn": [
+        "User",
+      ],
+      "uid": [
+        "test",
+      ],
+      "universalid": [
+        "id=346459bf-4159-4c4c-b929-f9ff5acc2f53,ou=user,o=alpha,ou=services,ou=am-config",
+      ],
+      "username": "test",
+    },
+    "58612ba5-a53d-4b3e-9715-1740d397e56e": {
+      "_id": "58612ba5-a53d-4b3e-9715-1740d397e56e",
+      "_rev": "-1",
+      "cn": [
+        "James Kirk",
+      ],
+      "config": {
+        "devices": {
+          "2fa": {
+            "binding": [],
+            "oath": [],
+            "push": [],
+            "webauthn": [],
+          },
+          "profile": [],
+          "trusted": [],
+        },
+        "groups": [],
+        "oauth2": {
+          "applications": [],
+        },
+        "services": [
+          {
+            "_id": "dashboard",
+          },
+        ],
+      },
+      "createTimestamp": [
+        "20240108232406Z",
+      ],
+      "dn": [
+        "fr-idm-uuid=58612ba5-a53d-4b3e-9715-1740d397e56e,ou=user,o=alpha,o=root,ou=identities",
+      ],
+      "fr-idm-custom-attrs": [
+        "{}",
+      ],
+      "fr-idm-preferences": [
+        "{"updates":false,"marketing":false}",
+      ],
+      "fr-idm-uuid": [
+        "58612ba5-a53d-4b3e-9715-1740d397e56e",
+      ],
+      "givenName": [
+        "James",
+      ],
+      "inetUserStatus": [
+        "Active",
+      ],
+      "mail": [
+        "jtkirk@ufp.org",
+      ],
+      "modifyTimestamp": [
+        "20240122164335Z",
+      ],
+      "objectClass": [
+        "iplanet-am-managed-person",
+        "inetuser",
+        "inetOrgPerson",
+        "sunFMSAML2NameIdentifier",
+        "devicePrintProfilesContainer",
+        "fr-ext-attrs",
+        "iplanet-am-user-service",
+        "iPlanetPreferences",
+        "pushDeviceProfilesContainer",
+        "forgerock-am-dashboard-service",
+        "top",
+        "kbaInfoContainer",
+        "person",
+        "organizationalPerson",
+        "oathDeviceProfilesContainer",
+        "sunAMAuthAccountLockout",
+        "webauthnDeviceProfilesContainer",
+        "deviceProfilesContainer",
+        "iplanet-am-auth-configuration-service",
+        "fr-idm-hybrid-obj",
+        "fr-idm-managed-user-explicit",
+      ],
+      "realm": "/alpha",
+      "sn": [
+        "Kirk",
+      ],
+      "uid": [
+        "kirk",
+      ],
+      "universalid": [
+        "id=58612ba5-a53d-4b3e-9715-1740d397e56e,ou=user,o=alpha,ou=services,ou=am-config",
+      ],
+      "username": "kirk",
+    },
+    "9f528ec5-4e5a-4c0b-ac56-74f194c97276": {
+      "_id": "9f528ec5-4e5a-4c0b-ac56-74f194c97276",
+      "_rev": "-1",
+      "cn": [
+        "Montgomery Scott",
+      ],
+      "config": {
+        "devices": {
+          "2fa": {
+            "binding": [],
+            "oath": [],
+            "push": [],
+            "webauthn": [],
+          },
+          "profile": [],
+          "trusted": [],
+        },
+        "groups": [],
+        "oauth2": {
+          "applications": [],
+        },
+        "services": [
+          {
+            "_id": "dashboard",
+          },
+        ],
+      },
+      "createTimestamp": [
+        "20240108232723Z",
+      ],
+      "dn": [
+        "fr-idm-uuid=9f528ec5-4e5a-4c0b-ac56-74f194c97276,ou=user,o=alpha,o=root,ou=identities",
+      ],
+      "fr-idm-custom-attrs": [
+        "{}",
+      ],
+      "fr-idm-managed-organization-member": [
+        "{"firstResourceCollection":"managed/alpha_user","firstResourceId":"9f528ec5-4e5a-4c0b-ac56-74f194c97276","firstPropertyName":"memberOfOrg","secondResourceCollection":"managed/alpha_organization","secondResourceId":"dfe53b12-798c-4408-839b-fa7fd8ccd672","secondPropertyName":"members","properties":{},"_id":"fd7ec2b5-59c4-4755-8bbe-8a848875ddf5-121714","_rev":"fd7ec2b5-59c4-4755-8bbe-8a848875ddf5-121715"}uid=dfe53b12-798c-4408-839b-fa7fd8ccd672,ou=organization,o=alpha,o=root,ou=identities",
+      ],
+      "fr-idm-managed-user-memberoforgid": [
+        "dfe53b12-798c-4408-839b-fa7fd8ccd672",
+      ],
+      "fr-idm-uuid": [
+        "9f528ec5-4e5a-4c0b-ac56-74f194c97276",
+      ],
+      "givenName": [
+        "Montgomery",
+      ],
+      "inetUserStatus": [
+        "Active",
+      ],
+      "mail": [
+        "mscott@ufa.org",
+      ],
+      "modifyTimestamp": [
+        "20240108232735Z",
+      ],
+      "objectClass": [
+        "iplanet-am-managed-person",
+        "inetuser",
+        "inetOrgPerson",
+        "sunFMSAML2NameIdentifier",
+        "devicePrintProfilesContainer",
+        "fr-ext-attrs",
+        "iplanet-am-user-service",
+        "iPlanetPreferences",
+        "pushDeviceProfilesContainer",
+        "forgerock-am-dashboard-service",
+        "top",
+        "kbaInfoContainer",
+        "person",
+        "organizationalPerson",
+        "oathDeviceProfilesContainer",
+        "sunAMAuthAccountLockout",
+        "webauthnDeviceProfilesContainer",
+        "deviceProfilesContainer",
+        "iplanet-am-auth-configuration-service",
+        "fr-idm-hybrid-obj",
+        "fr-idm-managed-user-explicit",
+      ],
+      "realm": "/alpha",
+      "sn": [
+        "Scott",
+      ],
+      "uid": [
+        "scotty",
+      ],
+      "universalid": [
+        "id=9f528ec5-4e5a-4c0b-ac56-74f194c97276,ou=user,o=alpha,ou=services,ou=am-config",
+      ],
+      "username": "scotty",
+    },
+  },
+}
+`;
+
+exports[`UserOps readUserGroups() 1: Read User Groups 1`] = `
+[
+  {
+    "_id": "test-group",
+    "_rev": "581192241",
+    "cn": [
+      "test-group",
+    ],
+    "dn": [
+      "cn=test-group,ou=groups,o=alpha,o=root,ou=identities",
+    ],
+    "members": {
+      "uniqueMember": [
+        "346459bf-4159-4c4c-b929-f9ff5acc2f53",
+      ],
+    },
+    "objectclass": [
+      "top",
+      "groupofuniquenames",
+    ],
+    "privileges": {
+      "AgentAdmin": true,
+      "ApplicationModifyAccess": true,
+      "ApplicationReadAccess": true,
+      "ApplicationTypesReadAccess": true,
+      "CacheAdmin": false,
+      "ConditionTypesReadAccess": true,
+      "DecisionCombinersReadAccess": true,
+      "EntitlementRestAccess": false,
+      "FederationAdmin": false,
+      "LogAdmin": false,
+      "LogRead": true,
+      "LogWrite": true,
+      "PolicyAdmin": false,
+      "PrivilegeRestAccess": true,
+      "PrivilegeRestReadAccess": true,
+      "RealmAdmin": false,
+      "RealmReadAccess": true,
+      "ResourceTypeModifyAccess": false,
+      "ResourceTypeReadAccess": false,
+      "SessionPropertyModifyAccess": false,
+      "SubjectAttributesReadAccess": false,
+      "SubjectTypesReadAccess": false,
+    },
+    "realm": "/alpha",
+    "universalid": [
+      "id=test-group,ou=group,o=alpha,ou=services,ou=am-config",
+    ],
+    "username": "test-group",
+  },
+]
+`;
+
+exports[`UserOps readUsers() 1: Read Users 1`] = `
+[
+  {
+    "_id": "9f528ec5-4e5a-4c0b-ac56-74f194c97276",
+    "_rev": "-1",
+    "cn": [
+      "Montgomery Scott",
+    ],
+    "createTimestamp": [
+      "20240108232723Z",
+    ],
+    "dn": [
+      "fr-idm-uuid=9f528ec5-4e5a-4c0b-ac56-74f194c97276,ou=user,o=alpha,o=root,ou=identities",
+    ],
+    "fr-idm-custom-attrs": [
+      "{}",
+    ],
+    "fr-idm-managed-organization-member": [
+      "{"firstResourceCollection":"managed/alpha_user","firstResourceId":"9f528ec5-4e5a-4c0b-ac56-74f194c97276","firstPropertyName":"memberOfOrg","secondResourceCollection":"managed/alpha_organization","secondResourceId":"dfe53b12-798c-4408-839b-fa7fd8ccd672","secondPropertyName":"members","properties":{},"_id":"fd7ec2b5-59c4-4755-8bbe-8a848875ddf5-121714","_rev":"fd7ec2b5-59c4-4755-8bbe-8a848875ddf5-121715"}uid=dfe53b12-798c-4408-839b-fa7fd8ccd672,ou=organization,o=alpha,o=root,ou=identities",
+    ],
+    "fr-idm-managed-user-memberoforgid": [
+      "dfe53b12-798c-4408-839b-fa7fd8ccd672",
+    ],
+    "fr-idm-uuid": [
+      "9f528ec5-4e5a-4c0b-ac56-74f194c97276",
+    ],
+    "givenName": [
+      "Montgomery",
+    ],
+    "inetUserStatus": [
+      "Active",
+    ],
+    "mail": [
+      "mscott@ufa.org",
+    ],
+    "modifyTimestamp": [
+      "20240108232735Z",
+    ],
+    "objectClass": [
+      "iplanet-am-managed-person",
+      "inetuser",
+      "inetOrgPerson",
+      "sunFMSAML2NameIdentifier",
+      "devicePrintProfilesContainer",
+      "fr-ext-attrs",
+      "iplanet-am-user-service",
+      "iPlanetPreferences",
+      "pushDeviceProfilesContainer",
+      "forgerock-am-dashboard-service",
+      "top",
+      "kbaInfoContainer",
+      "person",
+      "organizationalPerson",
+      "oathDeviceProfilesContainer",
+      "sunAMAuthAccountLockout",
+      "webauthnDeviceProfilesContainer",
+      "deviceProfilesContainer",
+      "iplanet-am-auth-configuration-service",
+      "fr-idm-hybrid-obj",
+      "fr-idm-managed-user-explicit",
+    ],
+    "realm": "/alpha",
+    "sn": [
+      "Scott",
+    ],
+    "uid": [
+      "scotty",
+    ],
+    "universalid": [
+      "id=9f528ec5-4e5a-4c0b-ac56-74f194c97276,ou=user,o=alpha,ou=services,ou=am-config",
+    ],
+    "username": "scotty",
+  },
+  {
+    "_id": "58612ba5-a53d-4b3e-9715-1740d397e56e",
+    "_rev": "-1",
+    "cn": [
+      "James Kirk",
+    ],
+    "createTimestamp": [
+      "20240108232406Z",
+    ],
+    "dn": [
+      "fr-idm-uuid=58612ba5-a53d-4b3e-9715-1740d397e56e,ou=user,o=alpha,o=root,ou=identities",
+    ],
+    "fr-idm-custom-attrs": [
+      "{}",
+    ],
+    "fr-idm-preferences": [
+      "{"updates":false,"marketing":false}",
+    ],
+    "fr-idm-uuid": [
+      "58612ba5-a53d-4b3e-9715-1740d397e56e",
+    ],
+    "givenName": [
+      "James",
+    ],
+    "inetUserStatus": [
+      "Active",
+    ],
+    "mail": [
+      "jtkirk@ufp.org",
+    ],
+    "modifyTimestamp": [
+      "20240122164335Z",
+    ],
+    "objectClass": [
+      "iplanet-am-managed-person",
+      "inetuser",
+      "inetOrgPerson",
+      "sunFMSAML2NameIdentifier",
+      "devicePrintProfilesContainer",
+      "fr-ext-attrs",
+      "iplanet-am-user-service",
+      "iPlanetPreferences",
+      "pushDeviceProfilesContainer",
+      "forgerock-am-dashboard-service",
+      "top",
+      "kbaInfoContainer",
+      "person",
+      "organizationalPerson",
+      "oathDeviceProfilesContainer",
+      "sunAMAuthAccountLockout",
+      "webauthnDeviceProfilesContainer",
+      "deviceProfilesContainer",
+      "iplanet-am-auth-configuration-service",
+      "fr-idm-hybrid-obj",
+      "fr-idm-managed-user-explicit",
+    ],
+    "realm": "/alpha",
+    "sn": [
+      "Kirk",
+    ],
+    "uid": [
+      "kirk",
+    ],
+    "universalid": [
+      "id=58612ba5-a53d-4b3e-9715-1740d397e56e,ou=user,o=alpha,ou=services,ou=am-config",
+    ],
+    "username": "kirk",
+  },
+  {
+    "_id": "346459bf-4159-4c4c-b929-f9ff5acc2f53",
+    "_rev": "-1",
+    "cn": [
+      "Test User",
+    ],
+    "createTimestamp": [
+      "20240718171624Z",
+    ],
+    "dn": [
+      "fr-idm-uuid=346459bf-4159-4c4c-b929-f9ff5acc2f53,ou=user,o=alpha,o=root,ou=identities",
+    ],
+    "fr-idm-custom-attrs": [
+      "{"effectiveApplications":[]}",
+    ],
+    "fr-idm-uuid": [
+      "346459bf-4159-4c4c-b929-f9ff5acc2f53",
+    ],
+    "givenName": [
+      "Test",
+    ],
+    "inetUserStatus": [
+      "Active",
+    ],
+    "isMemberOf": [
+      "cn=test-group,ou=groups,o=alpha,o=root,ou=identities",
+    ],
+    "mail": [
+      "test@test.com",
+    ],
+    "modifyTimestamp": [
+      "20240718171625Z",
+    ],
+    "objectClass": [
+      "iplanet-am-managed-person",
+      "inetuser",
+      "inetOrgPerson",
+      "sunFMSAML2NameIdentifier",
+      "devicePrintProfilesContainer",
+      "fr-ext-attrs",
+      "iplanet-am-user-service",
+      "iPlanetPreferences",
+      "pushDeviceProfilesContainer",
+      "forgerock-am-dashboard-service",
+      "top",
+      "kbaInfoContainer",
+      "person",
+      "organizationalPerson",
+      "oathDeviceProfilesContainer",
+      "sunAMAuthAccountLockout",
+      "webauthnDeviceProfilesContainer",
+      "deviceProfilesContainer",
+      "iplanet-am-auth-configuration-service",
+      "fr-idm-hybrid-obj",
+      "fr-idm-managed-user-explicit",
+    ],
+    "realm": "/alpha",
+    "sn": [
+      "User",
+    ],
+    "uid": [
+      "test",
+    ],
+    "universalid": [
+      "id=346459bf-4159-4c4c-b929-f9ff5acc2f53,ou=user,o=alpha,ou=services,ou=am-config",
+    ],
+    "username": "test",
+  },
+  {
+    "_id": "146c2230-9448-4442-b86d-eb4a81a0121d",
+    "_rev": "-1",
+    "cn": [
+      "Scheuber Volker",
+    ],
+    "createTimestamp": [
+      "20231201013952Z",
+    ],
+    "dn": [
+      "fr-idm-uuid=146c2230-9448-4442-b86d-eb4a81a0121d,ou=user,o=alpha,o=root,ou=identities",
+    ],
+    "fr-idm-custom-attrs": [
+      "{}",
+    ],
+    "fr-idm-uuid": [
+      "146c2230-9448-4442-b86d-eb4a81a0121d",
+    ],
+    "givenName": [
+      "Scheuber",
+    ],
+    "inetUserStatus": [
+      "Active",
+    ],
+    "mail": [
+      "vscheuber@gmail.com",
+    ],
+    "modifyTimestamp": [
+      "20231207213130Z",
+    ],
+    "objectClass": [
+      "iplanet-am-managed-person",
+      "inetuser",
+      "inetOrgPerson",
+      "sunFMSAML2NameIdentifier",
+      "devicePrintProfilesContainer",
+      "fr-ext-attrs",
+      "iplanet-am-user-service",
+      "iPlanetPreferences",
+      "pushDeviceProfilesContainer",
+      "forgerock-am-dashboard-service",
+      "top",
+      "kbaInfoContainer",
+      "person",
+      "organizationalPerson",
+      "oathDeviceProfilesContainer",
+      "sunAMAuthAccountLockout",
+      "webauthnDeviceProfilesContainer",
+      "deviceProfilesContainer",
+      "iplanet-am-auth-configuration-service",
+      "fr-idm-hybrid-obj",
+      "fr-idm-managed-user-explicit",
+    ],
+    "realm": "/alpha",
+    "sn": [
+      "Volker",
+    ],
+    "uid": [
+      "vscheuber@gmail.com",
+    ],
+    "universalid": [
+      "id=146c2230-9448-4442-b86d-eb4a81a0121d,ou=user,o=alpha,ou=services,ou=am-config",
+    ],
+    "username": "vscheuber@gmail.com",
+  },
+]
+`;


### PR DESCRIPTION
Adds ability to export and import all users and user groups in addition to user specific configuration. Specifically, it exports the AM user data, but not necessarily the IDM user data as of yet.

Note that this export was added in during development of new imports and exports, but we decided not to include it in the full config export since it is not config but rather data (even if it does contain some configuration). In the future there may be a use for this (see this issue: https://github.com/rockcarver/frodo-cli/issues/296), so I'm leaving it in. The changes here are not necessary for any other PRs.