### PR TITLE
Add Realm Exports and Imports

### DIFF
--- a/src/ops/RealmOps.test.ts
+++ b/src/ops/RealmOps.test.ts
@@ -48,6 +48,19 @@ describe('RealmOps', () => {
     }
   });
 
+  describe('createRealmExportTemplate()', () => {
+    test('0: Method is implemented', async () => {
+      expect(RealmOps.createRealmExportTemplate).toBeDefined();
+    });
+
+    test('1: Create Realm Export Template', async () => {
+      const response = RealmOps.createRealmExportTemplate({ state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+  });
+
   describe('getRealms()', () => {
     test('0: Method is implemented', async () => {
       expect(RealmOps.getRealms).toBeDefined();
@@ -56,6 +69,19 @@ describe('RealmOps', () => {
     test('1: Get Realms', async () => {
       const response = await RealmOps.getRealms({ state });
       expect(response).toMatchSnapshot();
+    });
+  });
+
+  describe('exportRealms()', () => {
+    test('0: Method is implemented', async () => {
+      expect(RealmOps.exportRealms).toBeDefined();
+    });
+
+    test('1: Export Realms', async () => {
+      const response = await RealmOps.exportRealms({ state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
     });
   });
 
@@ -69,6 +95,13 @@ describe('RealmOps', () => {
   describe('updateRealm()', () => {
     test('0: Method is implemented', async () => {
       expect(RealmOps.updateRealm).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('importRealms()', () => {
+    test('0: Method is implemented', async () => {
+      expect(RealmOps.importRealms).toBeDefined();
     });
     //TODO: create tests
   });

--- a/src/test/mock-recordings/RealmOps_3271493436/exportRealms_2583721668/1-Export-Realms_2606094556/recording.har
+++ b/src/test/mock-recordings/RealmOps_3271493436/exportRealms_2583721668/1-Export-Realms_2606094556/recording.har
@@ -1,0 +1,166 @@
+{
+  "log": {
+    "_recordingName": "RealmOps/exportRealms()/1: Export Realms",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "fc71be44855f4e764537c68893e9a626",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b35b65ca-6845-4bef-a6ba-18ee55e39f9d"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1926,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/global-config/realms/?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 331,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 331,
+            "text": "{\"result\":[{\"_id\":\"L2FscGhh\",\"_rev\":\"362268810\",\"parentPath\":\"/\",\"active\":true,\"name\":\"alpha\",\"aliases\":[]},{\"_id\":\"L2JyYXZv\",\"_rev\":\"480875699\",\"parentPath\":\"/\",\"active\":true,\"name\":\"bravo\",\"aliases\":[]}],\"resultCount\":2,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:37:46 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b35b65ca-6845-4bef-a6ba-18ee55e39f9d"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 800,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:37:47.518Z",
+        "time": 203,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 203
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/snapshots/ops/RealmOps.test.js.snap
+++ b/src/test/snapshots/ops/RealmOps.test.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RealmOps createRealmExportTemplate() 1: Create Realm Export Template 1`] = `
+{
+  "meta": Any<Object>,
+  "realm": {},
+}
+`;
+
+exports[`RealmOps exportRealms() 1: Export Realms 1`] = `
+{
+  "meta": Any<Object>,
+  "realm": {
+    "L2FscGhh": {
+      "_id": "L2FscGhh",
+      "_rev": "362268810",
+      "active": true,
+      "aliases": [],
+      "name": "alpha",
+      "parentPath": "/",
+    },
+    "L2JyYXZv": {
+      "_id": "L2JyYXZv",
+      "_rev": "480875699",
+      "active": true,
+      "aliases": [],
+      "name": "bravo",
+      "parentPath": "/",
+    },
+  },
+}
+`;
+
 exports[`RealmOps getRealms() 1: Get Realms 1`] = `
 [
   {


### PR DESCRIPTION
Adds ability to export and import realms for classic deployments. Export works for all deployments, but import works only for classic deployments.

This PR should be merged in prior to the PR named "Update Full Config Export with new Imports and Exports" that updates the full config export/import since that PR will rely on the changes from this PR.