### PR TITLE
Add Server Exports and Imports

### DIFF
--- a/src/api/classic/ServerApi.ts
+++ b/src/api/classic/ServerApi.ts
@@ -1,0 +1,255 @@
+import util from 'util';
+
+import { State } from '../../shared/State';
+import { printMessage } from '../../utils/Console';
+import { IdObjectSkeletonInterface, PagedResult } from '../ApiTypes';
+import { generateAmApi } from '../BaseApi';
+
+const serverURLTemplate = '%s/json/global-config/servers/%s';
+const serversURLTemplate = '%s/json/global-config/servers?_queryFilter=true';
+const propertiesURLTemplate = serverURLTemplate + '/properties/%s';
+const defaultPropertiesURLTemplate =
+  '%s/json/global-config/servers/server-default/properties/%s';
+const propertyTypes = [
+  'advanced',
+  'cts',
+  'directoryConfiguration',
+  'general',
+  'sdk',
+  'security',
+  'session',
+  'uma',
+];
+
+const apiVersion = 'protocol=2.1,resource=1.0';
+
+function getApiConfig() {
+  return {
+    apiVersion,
+  };
+}
+
+export type ServerSkeleton = IdObjectSkeletonInterface & {
+  url: string;
+  siteName: string;
+};
+
+export type ServerPropertiesSkeleton = {
+  advanced: object;
+  cts: object;
+  directoryConfiguration: object;
+  general: object;
+  sdk: object;
+  security: object;
+  session: object;
+  uma: object;
+};
+
+/**
+ * Get server
+ * @param {string} serverId Server id
+ * @returns {Promise<ServerSkeleton>} a promise that resolves to a server object
+ */
+export async function getServer({
+  serverId,
+  state,
+}: {
+  serverId: string;
+  state: State;
+}): Promise<ServerSkeleton> {
+  const urlString = util.format(serverURLTemplate, state.getHost(), serverId);
+  const { data } = await generateAmApi({ resource: getApiConfig(), state }).get(
+    urlString,
+    {
+      withCredentials: true,
+    }
+  );
+  return data;
+}
+
+/**
+ * Get all servers
+ * @returns {Promise<PagedResult<ServerSkeleton[]>>} a promise that resolves to an array of server objects
+ */
+export async function getServers({
+  state,
+}: {
+  state: State;
+}): Promise<PagedResult<ServerSkeleton>> {
+  const urlString = util.format(serversURLTemplate, state.getHost());
+  const { data } = await generateAmApi({
+    resource: getApiConfig(),
+    state,
+  }).get(urlString, {
+    withCredentials: true,
+  });
+  return data;
+}
+
+/**
+ * Get server properties
+ * @param {string} serverId Server id
+ * @returns {Promise<ServerPropertiesSkeleton>} a promise that resolves to a server properties object
+ */
+export async function getServerProperties({
+  serverId,
+  state,
+}: {
+  serverId: string;
+  state: State;
+}): Promise<ServerPropertiesSkeleton> {
+  const properties = {};
+  for (const property of propertyTypes) {
+    const urlString = util.format(
+      propertiesURLTemplate,
+      state.getHost(),
+      serverId,
+      property
+    );
+    try {
+      const { data } = await generateAmApi({
+        resource: getApiConfig(),
+        state,
+      }).get(urlString, {
+        withCredentials: true,
+      });
+      properties[property] = data;
+    } catch (e) {
+      printMessage({
+        message: `Error exporting server properties for server with id '${serverId}' from url '${urlString}': ${e.message}`,
+        type: 'error',
+        state,
+      });
+    }
+  }
+  return properties as ServerPropertiesSkeleton;
+}
+
+/**
+ * Get default server properties
+ * @returns {Promise<ServerPropertiesSkeleton>} a promise that resolves to a server properties object
+ */
+export async function getDefaultServerProperties({
+  state,
+}: {
+  state: State;
+}): Promise<ServerPropertiesSkeleton> {
+  const properties = {} as ServerPropertiesSkeleton;
+  for (const property of propertyTypes) {
+    const urlString = util.format(
+      defaultPropertiesURLTemplate,
+      state.getHost(),
+      property
+    );
+    try {
+      const { data } = await generateAmApi({
+        resource: getApiConfig(),
+        state,
+      }).get(urlString, {
+        withCredentials: true,
+      });
+      properties[property] = data;
+    } catch (e) {
+      printMessage({
+        message: `Error exporting default server properties from url '${urlString}': ${e.message}`,
+        type: 'error',
+        state,
+      });
+    }
+  }
+  return properties;
+}
+
+/**
+ * Creates a server
+ * @param {ServerSkeleton} serverData server object
+ * @returns {Promise<ServerSkeleton>} a promise that resolves to a server object
+ */
+export async function createServer({
+  serverData,
+  state,
+}: {
+  serverData: ServerSkeleton;
+  state;
+}): Promise<ServerSkeleton> {
+  const urlString = util.format(
+    serverURLTemplate,
+    state.getHost(),
+    serverData._id
+  );
+  const { data } = await generateAmApi({
+    resource: getApiConfig(),
+    state,
+  }).put(urlString, serverData, {
+    withCredentials: true,
+  });
+  return data;
+}
+
+/**
+ * Put server properties
+ * @param {string} serverId
+ * @param {ServerPropertiesSkeleton} serverPropertiesData server properties object
+ * @returns {Promise<ServerPropertiesSkeleton>} a promise that resolves to a server properties object
+ */
+export async function putServerProperties({
+  serverId,
+  serverPropertiesData,
+  state,
+}: {
+  serverId;
+  serverPropertiesData: ServerPropertiesSkeleton;
+  state;
+}): Promise<ServerPropertiesSkeleton> {
+  const result = {} as ServerPropertiesSkeleton;
+  for (const [property, propertyData] of Object.entries(serverPropertiesData)) {
+    const urlString = util.format(
+      propertiesURLTemplate,
+      state.getHost(),
+      serverId,
+      property
+    );
+    const { data } = await generateAmApi({
+      resource: getApiConfig(),
+      state,
+    }).put(urlString, propertyData, {
+      withCredentials: true,
+      headers: { 'If-Match': '*' },
+    });
+    result[property] = data;
+  }
+  return result;
+}
+
+/**
+ * Put default server properties
+ * @param {ServerPropertiesSkeleton} defaultServerPropertiesData default server properties object
+ * @returns {Promise<ServerPropertiesSkeleton>} a promise that resolves to a default server properties object
+ */
+export async function putDefaultServerProperties({
+  defaultServerPropertiesData,
+  state,
+}: {
+  defaultServerPropertiesData: ServerPropertiesSkeleton;
+  state;
+}): Promise<ServerPropertiesSkeleton> {
+  const result = {} as ServerPropertiesSkeleton;
+  for (const [property, propertyData] of Object.entries(
+    defaultServerPropertiesData
+  )) {
+    const urlString = util.format(
+      defaultPropertiesURLTemplate,
+      state.getHost(),
+      property
+    );
+    const { data } = await generateAmApi({
+      resource: getApiConfig(),
+      state,
+    }).put(urlString, propertyData, {
+      withCredentials: true,
+      headers: { 'If-Match': '*' },
+    });
+    result[property] = data;
+  }
+  return result;
+}

--- a/src/lib/FrodoLib.ts
+++ b/src/lib/FrodoLib.ts
@@ -8,6 +8,7 @@ import AuthenticationSettingsOps, {
   AuthenticationSettings,
 } from '../ops/AuthenticationSettingsOps';
 import CirclesOfTrustOps, { CirclesOfTrust } from '../ops/CirclesOfTrustOps';
+import ServerOps, { Server } from '../ops/classic/ServerOps';
 import AdminFederationOps, {
   AdminFederation,
 } from '../ops/cloud/AdminFederationOps';
@@ -174,6 +175,7 @@ export type Frodo = {
   };
 
   script: Script;
+  server: Server;
   service: Service;
   session: Session;
 
@@ -332,6 +334,7 @@ const FrodoLib = (config: StateInterface = {}): Frodo => {
     },
 
     script: ScriptOps(state),
+    server: ServerOps(state),
     service: ServiceOps(state),
     session: SessionOps(state),
 

--- a/src/ops/classic/ServerOps.test.ts
+++ b/src/ops/classic/ServerOps.test.ts
@@ -1,0 +1,138 @@
+/**
+ * To record and update snapshots, you must perform 3 steps in order:
+ *
+ * 1. Record API responses
+ *
+ *    Recording requires an available classic deployment, since servers
+ *    can only be accessed in classic. Set FRODO_HOST and FRODO_REALM
+ *    environment variables or alternatively FRODO_DEPLOY=classic
+ *    in order to appropriately record requests to the classic deployment.
+ *
+ *    To record API responses, you must call the test:record script and
+ *    override all the connection state required to connect to the
+ *    env to record from:
+ *
+ *    ATTENTION: For the recording to succeed, you MUST make sure to use a
+ *               user account, not a service account.
+ *
+ *        FRODO_DEBUG=1 FRODO_HOST=frodo-dev npm run test:record ServerOps
+ *
+ *    The above command assumes that you have a connection profile for
+ *    'frodo-dev' on your development machine.
+ *
+ * 2. Update snapshots
+ *
+ *    After recording API responses, you must manually update/create snapshots
+ *    by running:
+ *
+ *        FRODO_DEBUG=1 npm run test:update ServerOps
+ *
+ * 3. Test your changes
+ *
+ *    If 1 and 2 didn't produce any errors, you are ready to run the tests in
+ *    replay mode and make sure they all succeed as well:
+ *
+ *        FRODO_DEBUG=1 npm run test:only ServerOps
+ *
+ * Note: FRODO_DEBUG=1 is optional and enables debug logging for some output
+ * in case things don't function as expected
+ */
+import { autoSetupPolly, setDefaultState } from "../../utils/AutoSetupPolly";
+import { filterRecording } from "../../utils/PollyUtils";
+import * as ServerOps from "./ServerOps";
+import { state } from "../../lib/FrodoLib";
+import Constants from "../../shared/Constants";
+
+const ctx = autoSetupPolly();
+
+describe('ServerOps', () => {
+  beforeEach(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      ctx.polly.server.any().on('beforePersist', (_req, recording) => {
+        filterRecording(recording);
+      });
+    }
+    setDefaultState(Constants.CLASSIC_DEPLOYMENT_TYPE_KEY);
+  });
+
+  describe('createServerExportTemplate()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ServerOps.createServerExportTemplate).toBeDefined();
+    });
+
+    test('1: Create Server Export Template', async () => {
+      const response = ServerOps.createServerExportTemplate({ state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+  });
+
+  describe('readServer()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ServerOps.readServer).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('readServers()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ServerOps.readServers).toBeDefined();
+    });
+
+    test('1: Read Servers', async () => {
+      const response = await ServerOps.readServers({ state });
+      expect(response).toMatchSnapshot();
+    });
+  });
+
+  describe('exportServer()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ServerOps.exportServer).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('exportServers()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ServerOps.exportServers).toBeDefined();
+    });
+
+    test('1: Export Servers without default properties', async () => {
+      const response = await ServerOps.exportServers({ options: { includeDefault: false }, state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+
+    test('2: Export Servers with default properties', async () => {
+      const response = await ServerOps.exportServers({ options: { includeDefault: true }, state });
+      expect(response).toMatchSnapshot({
+        meta: expect.any(Object),
+      });
+    });
+  });
+
+  describe('createServer()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ServerOps.createServer).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+  describe('importFirstServer()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ServerOps.importFirstServer).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+
+  describe('importServers()', () => {
+    test('0: Method is implemented', async () => {
+      expect(ServerOps.importServers).toBeDefined();
+    });
+    //TODO: create tests
+  });
+
+});

--- a/src/ops/classic/ServerOps.ts
+++ b/src/ops/classic/ServerOps.ts
@@ -1,0 +1,563 @@
+import {
+  createServer as _createServer,
+  getDefaultServerProperties,
+  getServer,
+  getServerProperties,
+  getServers,
+  putDefaultServerProperties,
+  putServerProperties,
+  ServerPropertiesSkeleton,
+  ServerSkeleton,
+} from '../../api/classic/ServerApi';
+import { State } from '../../shared/State';
+import {
+  createProgressIndicator,
+  debugMessage,
+  stopProgressIndicator,
+  updateProgressIndicator,
+} from '../../utils/Console';
+import { getMetadata } from '../../utils/ExportImportUtils';
+import { FrodoError } from '../FrodoError';
+import { ExportMetaData } from '../OpsTypes';
+
+export type Server = {
+  /**
+   * Create an empty server export template
+   * @returns {ServerExportInterface} an empty server export template
+   */
+  createServerExportTemplate(): ServerExportInterface;
+  /**
+   * Read server by id
+   * @param {string} serverId Server id
+   * @returns {Promise<ServerSkeleton>} a promise that resolves to a server object
+   */
+  readServer(serverId: string): Promise<ServerSkeleton>;
+  /**
+   * Read server by url
+   * @param {string} serverUrl Server url
+   * @returns {Promise<ServerSkeleton>} a promise that resolves to a server object
+   */
+  readServerByUrl(serverUrl: string): Promise<ServerSkeleton>;
+  /**
+   * Read all servers.
+   * @returns {Promise<ServerSkeleton[]>} a promise that resolves to an array of server objects
+   */
+  readServers(): Promise<ServerSkeleton[]>;
+  /**
+   * Export a single server by id. The response can be saved to file as is.
+   * @param {string} serverId Server id
+   * @param {ServerExportOptions} options Server export options
+   * @returns {Promise<ServerExportInterface>} Promise resolving to a ServerExportInterface object.
+   */
+  exportServer(
+    serverId: string,
+    options: ServerExportOptions
+  ): Promise<ServerExportInterface>;
+  /**
+   * Export a single server by url. The response can be saved to file as is.
+   * @param {string} serverUrl Server url
+   * @param {ServerExportOptions} options Server export options
+   * @returns {Promise<ServerExportInterface>} Promise resolving to a ServerExportInterface object.
+   */
+  exportServerByUrl(
+    serverUrl: string,
+    options: ServerExportOptions
+  ): Promise<ServerExportInterface>;
+  /**
+   * Export all servers. The response can be saved to file as is.
+   * @param {ServerExportOptions} options Server export options
+   * @returns {Promise<ServerExportInterface>} Promise resolving to a ServerExportInterface object.
+   */
+  exportServers(options: ServerExportOptions): Promise<ServerExportInterface>;
+  /**
+   * Creates a server
+   * @param {ServerSkeleton} serverData server object
+   * @returns {Promise<ServerSkeleton>} a promise that resolves to a server object
+   */
+  createServer(serverData: ServerSkeleton): Promise<ServerSkeleton>;
+  /**
+   * Imports the first server from the importData
+   * @param importData server import data
+   * @param options server import options
+   */
+  importFirstServer(
+    importData: ServerExportInterface,
+    options: ServerImportOptions
+  ): Promise<ServerExportInterface>;
+  /**
+   * Imports servers along with their properties
+   * @param {ServerExportInterface} importData server import data
+   * @param {ServerImportOptions} options server import options
+   * @param {string} serverId Optional server id. If supplied, only the server (and its properties) of that id is imported. Takes priority over serverUrl if both are provided.
+   * @param {string} serverUrl Optional server url. If supplied, only the server of that url is imported.
+   * @returns {Promise<ServerExportInterface>} a promise that resolves to a server export object
+   */
+  importServers(
+    importData: ServerExportInterface,
+    options: ServerImportOptions,
+    serverId?: string,
+    serverUrl?: string
+  ): Promise<ServerExportInterface>;
+};
+
+export default (state: State): Server => {
+  return {
+    createServerExportTemplate(): ServerExportInterface {
+      return createServerExportTemplate({ state });
+    },
+    async readServer(serverId: string): Promise<ServerSkeleton> {
+      return readServer({ serverId, state });
+    },
+    async readServerByUrl(serverUrl: string): Promise<ServerSkeleton> {
+      return readServerByUrl({ serverUrl, state });
+    },
+    async readServers(): Promise<ServerSkeleton[]> {
+      return readServers({ state });
+    },
+    async exportServer(
+      serverId: string,
+      options: ServerExportOptions = { includeDefault: false }
+    ): Promise<ServerExportInterface> {
+      return exportServer({ serverId, options, state });
+    },
+    async exportServerByUrl(
+      serverUrl: string,
+      options: ServerExportOptions = { includeDefault: false }
+    ): Promise<ServerExportInterface> {
+      return exportServerByUrl({ options, serverUrl, state });
+    },
+    async exportServers(
+      options: ServerExportOptions = { includeDefault: false }
+    ): Promise<ServerExportInterface> {
+      return exportServers({ options, state });
+    },
+    async createServer(serverData: ServerSkeleton): Promise<ServerSkeleton> {
+      return createServer({
+        serverData,
+        state,
+      });
+    },
+    async importFirstServer(
+      importData: ServerExportInterface,
+      options: ServerImportOptions = {
+        includeDefault: false,
+      }
+    ): Promise<ServerExportInterface> {
+      return importFirstServer({
+        importData,
+        options,
+        state,
+      });
+    },
+    async importServers(
+      importData: ServerExportInterface,
+      options: ServerImportOptions = {
+        includeDefault: false,
+      },
+      serverId?: string,
+      serverUrl?: string
+    ): Promise<ServerExportInterface> {
+      return importServers({
+        importData,
+        options,
+        serverId,
+        serverUrl,
+        state,
+      });
+    },
+  };
+};
+
+/**
+ * Server export options
+ */
+export interface ServerExportOptions {
+  /**
+   * True to export the default server properties, false otherwise
+   */
+  includeDefault: boolean;
+}
+
+/**
+ * Server import options
+ */
+export interface ServerImportOptions {
+  /**
+   * True to import the default server properties, false otherwise
+   */
+  includeDefault: boolean;
+}
+
+export type ServerExportSkeleton = ServerSkeleton & {
+  properties: ServerPropertiesSkeleton;
+};
+
+export interface ServerExportInterface {
+  meta?: ExportMetaData;
+  server: Record<string, ServerExportSkeleton>;
+  defaultProperties: ServerPropertiesSkeleton;
+}
+
+/**
+ * Create an empty server export template
+ * @returns {ServerExportInterface} an empty server export template
+ */
+export function createServerExportTemplate({
+  state,
+}: {
+  state: State;
+}): ServerExportInterface {
+  return {
+    meta: getMetadata({ state }),
+    server: {},
+    defaultProperties: {} as ServerPropertiesSkeleton,
+  };
+}
+
+/**
+ * Read server by id
+ * @param {string} serverId Server id
+ * @returns {Promise<ServerSkeleton>} a promise that resolves to a server object
+ */
+export async function readServer({
+  serverId,
+  state,
+}: {
+  serverId: string;
+  state: State;
+}): Promise<ServerSkeleton> {
+  try {
+    return getServer({ serverId, state });
+  } catch (error) {
+    throw new FrodoError(`Error reading server ${serverId}`, error);
+  }
+}
+
+/**
+ * Read server by url
+ * @param {string} serverUrl Server url
+ * @returns {Promise<ServerSkeleton>} a promise that resolves to a server object
+ */
+export async function readServerByUrl({
+  serverUrl,
+  state,
+}: {
+  serverUrl: string;
+  state: State;
+}): Promise<ServerSkeleton> {
+  try {
+    const servers = await readServers({ state });
+    const found = servers.filter((server) => server.url.includes(serverUrl));
+    if (found.length === 1) {
+      return found[0];
+    }
+    if (found.length > 1) {
+      throw new Error(`Multiple servers with the url '${serverUrl}' found!`);
+    }
+    throw new Error(`Server '${serverUrl}' not found!`);
+  } catch (error) {
+    throw new FrodoError(`Error reading server ${serverUrl}`, error);
+  }
+}
+
+/**
+ * Read all servers.
+ * @returns {Promise<ServerSkeleton[]>} a promise that resolves to an array of server objects
+ */
+export async function readServers({
+  state,
+}: {
+  state: State;
+}): Promise<ServerSkeleton[]> {
+  try {
+    debugMessage({
+      message: `ServerOps.readServers: start`,
+      state,
+    });
+    const { result } = await getServers({ state });
+    debugMessage({ message: `ServerOps.readServers: end`, state });
+    return result;
+  } catch (error) {
+    throw new FrodoError(`Error reading servers`, error);
+  }
+}
+
+/**
+ * Export a single server by id. The response can be saved to file as is.
+ * @param {string} serverId Server id
+ * @param {ServerExportOptions} options Server export options
+ * @returns {Promise<ServerExportInterface>} Promise resolving to a ServerExportInterface object.
+ */
+export async function exportServer({
+  serverId,
+  options = {
+    includeDefault: false,
+  },
+  state,
+}: {
+  serverId: string;
+  options: ServerExportOptions;
+  state: State;
+}): Promise<ServerExportInterface> {
+  try {
+    const server = (await readServer({
+      serverId,
+      state,
+    })) as ServerExportSkeleton;
+    server.properties = await getServerProperties({ serverId, state });
+    const exportData = createServerExportTemplate({ state });
+    exportData.server[serverId] = server as ServerExportSkeleton;
+    if (options.includeDefault) {
+      exportData.defaultProperties = await getDefaultServerProperties({
+        state,
+      });
+    }
+    return exportData;
+  } catch (error) {
+    throw new FrodoError(`Error exporting server ${serverId}`, error);
+  }
+}
+
+/**
+ * Export a single server by url. The response can be saved to file as is.
+ * @param {string} serverUrl Server url
+ * @param {ServerExportOptions} options Server export options
+ * @returns {Promise<ServerExportInterface>} Promise resolving to a ServerExportInterface object.
+ */
+export async function exportServerByUrl({
+  serverUrl,
+  options = {
+    includeDefault: false,
+  },
+  state,
+}: {
+  serverUrl: string;
+  options: ServerExportOptions;
+  state: State;
+}): Promise<ServerExportInterface> {
+  try {
+    const server = (await readServerByUrl({
+      serverUrl,
+      state,
+    })) as ServerExportSkeleton;
+    server.properties = await getServerProperties({
+      serverId: server._id,
+      state,
+    });
+    const exportData = createServerExportTemplate({ state });
+    exportData.server[server._id] = server as ServerExportSkeleton;
+    if (options.includeDefault) {
+      exportData.defaultProperties = await getDefaultServerProperties({
+        state,
+      });
+    }
+    return exportData;
+  } catch (error) {
+    throw new FrodoError(`Error exporting server ${serverUrl}`, error);
+  }
+}
+
+/**
+ * Export all servers. The response can be saved to file as is.
+ * @param {ServerExportOptions} options Server export options
+ * @returns {Promise<ServerExportInterface>} Promise resolving to a ServerExportInterface object.
+ */
+export async function exportServers({
+  options = {
+    includeDefault: false,
+  },
+  state,
+}: {
+  options: ServerExportOptions;
+  state: State;
+}): Promise<ServerExportInterface> {
+  let indicatorId: string;
+  try {
+    debugMessage({ message: `ServerOps.exportServers: start`, state });
+    const exportData = createServerExportTemplate({ state });
+    const servers = await readServers({ state });
+    indicatorId = createProgressIndicator({
+      total: servers.length,
+      message: 'Exporting servers...',
+      state,
+    });
+    for (const server of servers) {
+      updateProgressIndicator({
+        id: indicatorId,
+        message: `Exporting server ${server.url}`,
+        state,
+      });
+      server.properties = await getServerProperties({
+        serverId: server._id,
+        state,
+      });
+      exportData.server[server._id] = server as ServerExportSkeleton;
+    }
+    if (options.includeDefault) {
+      exportData.defaultProperties = await getDefaultServerProperties({
+        state,
+      });
+    }
+    stopProgressIndicator({
+      id: indicatorId,
+      message: `Exported ${servers.length} servers.`,
+      state,
+    });
+    debugMessage({ message: `ServerOps.exportServers: end`, state });
+    return exportData;
+  } catch (error) {
+    stopProgressIndicator({
+      id: indicatorId,
+      message: `Error exporting servers.`,
+      status: 'fail',
+      state,
+    });
+    throw new FrodoError(`Error reading servers`, error);
+  }
+}
+
+/**
+ * Creates a server
+ * @param {ServerSkeleton} serverData server object
+ * @returns {Promise<ServerSkeleton>} a promise that resolves to a server object
+ */
+export async function createServer({
+  serverData,
+  state,
+}: {
+  serverData: ServerSkeleton;
+  state;
+}): Promise<ServerSkeleton> {
+  try {
+    return await _createServer({ serverData, state });
+  } catch (error) {
+    throw new FrodoError(
+      `Error creating server with id '${serverData._id}' and URL '${serverData.url}'`,
+      error
+    );
+  }
+}
+
+/**
+ * Import first server
+ * @param {ServerExportInterface} importData import data
+ * @param {ServerImportOptions} options import options
+ * @returns {Promise<ServerExportInterface>} a promise that resolves to a server export object
+ */
+export async function importFirstServer({
+  importData,
+  options = {
+    includeDefault: true,
+  },
+  state,
+}: {
+  importData: ServerExportInterface;
+  options?: ServerImportOptions;
+  state: State;
+}): Promise<ServerExportInterface> {
+  debugMessage({ message: `ServerOps.importFirstServer: start`, state });
+  const response = createServerExportTemplate({ state });
+  delete response.meta;
+  const server = Object.values(importData.server)[0];
+  if (!server) {
+    throw new FrodoError(`No servers found in import data!`);
+  }
+  importServers({
+    serverId: server._id,
+    importData,
+    options,
+    state,
+  });
+  debugMessage({ message: `ServerOps.importFirstServer: end`, state });
+  return response;
+}
+
+/**
+ * Imports servers along with their properties
+ * @param {string} serverId Optional server id. If supplied, only the server (and its properties) of that id is imported. Takes priority over serverUrl if both are provided.
+ * @param {string} serverUrl Optional server url. If supplied, only the server of that url is imported.
+ * @param {ServerExportInterface} importData server import data
+ * @param {ServerImportOptions} options server import options
+ * @returns {Promise<ServerExportInterface>} a promise that resolves to a server export object
+ */
+export async function importServers({
+  serverId,
+  serverUrl,
+  importData,
+  options = {
+    includeDefault: false,
+  },
+  state,
+}: {
+  serverId?: string;
+  serverUrl?: string;
+  importData: ServerExportInterface;
+  options: ServerImportOptions;
+  state;
+}): Promise<ServerExportInterface> {
+  const errors = [];
+  try {
+    debugMessage({ message: `ServerOps.importServers: start`, state });
+    const response = createServerExportTemplate({ state });
+    delete response.meta;
+    for (const server of Object.values(importData.server)) {
+      const serverProperties = server.properties;
+      delete server.properties;
+      try {
+        if (
+          (serverId && server._id !== serverId) ||
+          (serverUrl && server.url !== serverUrl)
+        ) {
+          continue;
+        }
+        // Attempt to create server in case it doesn't exist
+        let serverResult;
+        try {
+          serverResult = await _createServer({
+            serverData: server,
+            state,
+          });
+        } catch (e) {
+          // If server exists, ignore the error
+          if (
+            e.response?.status !== 400 ||
+            e.response?.data?.message !== 'Update not supported'
+          ) {
+            throw new FrodoError(
+              `Error creating server with id '${server._id}' and URL '${server.url}'`,
+              e
+            );
+          }
+          serverResult = server;
+        }
+        // Import server properties
+        serverResult.properties = await putServerProperties({
+          serverId: server._id,
+          serverPropertiesData: serverProperties,
+          state,
+        });
+        response.server[server._id] = serverResult;
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    // Import default server properties
+    if (options.includeDefault) {
+      response.defaultProperties = await putDefaultServerProperties({
+        defaultServerPropertiesData: importData.defaultProperties,
+        state,
+      });
+    }
+    if (errors.length > 0) {
+      throw new FrodoError(`Error importing servers`, errors);
+    }
+    debugMessage({ message: `ServerOps.importServers: end`, state });
+    return response;
+  } catch (error) {
+    // re-throw previously caught errors
+    if (errors.length > 0) {
+      throw error;
+    }
+    throw new FrodoError(`Error importing servers`, error);
+  }
+}

--- a/src/test/mock-recordings/ServerOps_696203346/exportServers_262800030/1-Export-Servers-without-default-properties_3320583742/recording.har
+++ b/src/test/mock-recordings/ServerOps_696203346/exportServers_262800030/1-Export-Servers-without-default-properties_3320583742/recording.har
@@ -1,0 +1,3390 @@
+{
+  "log": {
+    "_recordingName": "ServerOps/exportServers()/1: Export Servers without default properties",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "76b32eba382ec9176be262a1048cdec2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 383,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 383,
+            "text": "{\"result\":[{\"_id\":\"01\",\"_rev\":\"-931963190\",\"url\":\"http://localhost:8080/am\",\"siteName\":null},{\"_id\":\"03\",\"_rev\":\"-931738263\",\"url\":\"http://localhost:8081/am\",\"siteName\":null},{\"_id\":\"04\",\"_rev\":\"-931739121\",\"url\":\"http://localhost:8082/am\",\"siteName\":null}],\"resultCount\":3,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "383"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.420Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "a881d34fa69200f99adfc9e71e2a6c6b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/advanced"
+        },
+        "response": {
+          "bodySize": 646,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 646,
+            "text": "{\"_id\":\"01/properties/advanced\",\"_rev\":\"1998658293\",\"com.sun.identity.urlconnection.useCache\":false,\"com.iplanet.am.serverMode\":true,\"com.sun.identity.sm.sms_object_class_name\":\"com.sun.identity.sm.SmsWrapperObject\",\"org.forgerock.embedded.dsadminport\":\"4444\",\"com.sun.embedded.sync.servers\":\"on\",\"com.sun.embedded.replicationport\":\"\",\"com.iplanet.security.SSLSocketFactoryImpl\":\"com.sun.identity.shared.ldap.factory.JSSESocketFactory\",\"com.sun.identity.common.systemtimerpool.size\":\"3\",\"bootstrap.file\":\"/home/prestonhales/.openamcfg/AMConfig_usr_local_tomcat_webapps_am_\",\"com.iplanet.am.lbcookie.value\":\"01\",\"opensso.protocol.handler.pkgs\":\"\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1998658293\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "646"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.427Z",
+        "time": 22,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 22
+        }
+      },
+      {
+        "_id": "097a8e6e4f3f8f245fbbd6c8ce7576c4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/cts"
+        },
+        "response": {
+          "bodySize": 1198,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1198,
+            "text": "{\"_id\":\"01/properties/cts\",\"_rev\":\"920580190\",\"amconfig.org.forgerock.services.cts.store.common.section\":{\"org.forgerock.services.cts.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.cts.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.max.connections\":{\"value\":\"100\",\"inherited\":true},\"org.forgerock.services.cts.store.page.size\":{\"value\":\"0\",\"inherited\":true},\"org.forgerock.services.cts.store.vlv.page.size\":{\"value\":\"1000\",\"inherited\":true}},\"amconfig.org.forgerock.services.cts.store.external.section\":{\"org.forgerock.services.cts.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.cts.store.heartbeat\":{\"value\":\"10\",\"inherited\":true},\"org.forgerock.services.cts.store.affinity.enabled\":{\"value\":null,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"920580190\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1198"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.455Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "2de9af30586fa3ef0c876107923ffdce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 587,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/directoryConfiguration"
+        },
+        "response": {
+          "bodySize": 438,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 438,
+            "text": "{\"_id\":\"01/properties/directoryConfiguration\",\"_rev\":\"465754882\",\"directoryConfiguration\":{\"minConnectionPool\":1,\"maxConnectionPool\":10,\"mtlsEnabled\":false,\"mtlsAlias\":\"\",\"mtlsKeyStoreFile\":\"\",\"mtlsKeyStoreType\":null,\"mtlsKeyStorePasswordFile\":\"\",\"mtlsKeyPasswordFile\":\"\",\"bindDn\":\"cn=Directory Manager\",\"bindPassword\":null},\"directoryServers\":[{\"hostName\":\"localhost\",\"serverName\":\"Server1\",\"connectionType\":\"SSL\",\"portNumber\":\"50636\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"465754882\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "438"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.463Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "636cd7d41bb569a7d80cd609812779c4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/general"
+        },
+        "response": {
+          "bodySize": 911,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 911,
+            "text": "{\"_id\":\"01/properties/general\",\"_rev\":\"116018532\",\"amconfig.header.site\":{\"singleChoiceSite\":\"[Empty]\"},\"amconfig.header.installdir\":{\"com.iplanet.services.configpath\":{\"value\":\"/home/prestonhales/am\",\"inherited\":false},\"com.iplanet.am.locale\":{\"value\":\"en_US\",\"inherited\":false},\"com.sun.identity.client.notification.url\":{\"value\":\"%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice\",\"inherited\":true},\"com.iplanet.am.util.xml.validating\":{\"value\":\"off\",\"inherited\":true}},\"amconfig.header.debug\":{\"com.iplanet.services.debug.level\":{\"value\":\"warning\",\"inherited\":false},\"com.sun.services.debug.mergeall\":{\"value\":\"off\",\"inherited\":false},\"com.iplanet.services.debug.directory\":{\"value\":\"%BASE_DIR%/var/debug\",\"inherited\":true}},\"amconfig.header.mailserver\":{\"com.iplanet.am.smtphost\":{\"value\":\"localhost\",\"inherited\":true},\"com.iplanet.am.smtpport\":{\"value\":\"25\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"116018532\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "911"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.470Z",
+        "time": 4,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4
+        }
+      },
+      {
+        "_id": "1ef913d2a189c841927fa13a131df3af",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/sdk"
+        },
+        "response": {
+          "bodySize": 1309,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1309,
+            "text": "{\"_id\":\"01/properties/sdk\",\"_rev\":\"2030263514\",\"amconfig.header.datastore\":{\"com.sun.identity.sm.enableDataStoreNotification\":{\"value\":true,\"inherited\":false},\"com.sun.identity.sm.notification.threadpool.size\":{\"value\":\"1\",\"inherited\":true}},\"amconfig.header.eventservice\":{\"com.iplanet.am.event.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.event.connection.delay.between.retries\":{\"value\":\"3000\",\"inherited\":true},\"com.iplanet.am.event.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true},\"com.sun.am.event.connection.disable.list\":{\"value\":\"aci,um\",\"inherited\":false}},\"amconfig.header.ldapconnection\":{\"com.iplanet.am.ldap.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.ldap.connection.delay.between.retries\":{\"value\":\"1000\",\"inherited\":true},\"com.iplanet.am.ldap.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":false}},\"amconfig.header.cachingreplica\":{\"com.iplanet.am.sdk.cache.maxSize\":{\"value\":\"10000\",\"inherited\":true}},\"amconfig.header.sdktimetoliveconfig\":{\"com.iplanet.am.sdk.cache.entry.expire.enabled\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.user.expire.time\":{\"value\":\"15\",\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.default.expire.time\":{\"value\":\"30\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"2030263514\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1309"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.478Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "dc0ffe73364c49fd72ece588ee23207e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/security"
+        },
+        "response": {
+          "bodySize": 4197,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4197,
+            "text": "{\"_id\":\"01/properties/security\",\"_rev\":\"692941387\",\"amconfig.header.encryption\":{\"am.encryption.pwd\":{\"value\":\"efSYcwIhr7uKH30rgciGTVTFzb63LhYu\",\"inherited\":false},\"com.iplanet.security.encryptor\":{\"value\":\"com.iplanet.services.util.JCEEncryption\",\"inherited\":true},\"com.iplanet.security.SecureRandomFactoryImpl\":{\"value\":\"com.iplanet.am.util.SecureRandomFactoryImpl\",\"inherited\":true},\"am.encryption.secret.enabled\":{\"value\":false,\"inherited\":true},\"am.encryption.secret.alias\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreFile\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreType\":{\"value\":\"JCEKS\",\"inherited\":true},\"am.encryption.secret.keystorePass\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keyPass\":{\"value\":null,\"inherited\":true}},\"amconfig.header.validation\":{\"com.iplanet.services.comm.server.pllrequest.maxContentLength\":{\"value\":\"16384\",\"inherited\":true},\"com.iplanet.am.clientIPCheckEnabled\":{\"value\":false,\"inherited\":true}},\"amconfig.header.cookie\":{\"com.iplanet.am.cookie.name\":{\"value\":\"iPlanetDirectoryPro\",\"inherited\":true},\"com.iplanet.am.cookie.secure\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.cookie.encode\":{\"value\":false,\"inherited\":true}},\"amconfig.header.securitykey\":{\"com.sun.identity.saml.xmlsig.keystore\":{\"value\":\"%BASE_DIR%/security/keystores/keystore.jceks\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storetype\":{\"value\":\"JCEKS\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storepass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.storepass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.keypass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.keypass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.certalias\":{\"value\":\"test\",\"inherited\":true}},\"amconfig.header.crlcache\":{\"com.sun.identity.crl.cache.directory.host\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.port\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.ssl\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.mtlsenabled\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.user\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.password\":{\"value\":null,\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchlocs\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchattr\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.ocsp.check\":{\"com.sun.identity.authentication.ocspCheck\":{\"value\":false,\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.url\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.nickname\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.deserialisationwhitelist\":{\"openam.deserialisation.classes.whitelist\":{\"value\":\"com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"692941387\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4197"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.485Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "b591cc4dc8949e995f0c298ba20e27ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/session"
+        },
+        "response": {
+          "bodySize": 915,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 915,
+            "text": "{\"_id\":\"01/properties/session\",\"_rev\":\"1187593890\",\"amconfig.header.sessionthresholds\":{\"org.forgerock.openam.session.service.access.persistence.caching.maxsize\":{\"value\":\"5000\",\"inherited\":true},\"com.iplanet.am.session.invalidsessionmaxtime\":{\"value\":\"3\",\"inherited\":true}},\"amconfig.header.sessionlogging\":{\"com.iplanet.am.stats.interval\":{\"value\":\"60\",\"inherited\":true},\"com.iplanet.services.stats.state\":{\"value\":\"file\",\"inherited\":true},\"com.iplanet.services.stats.directory\":{\"value\":\"%BASE_DIR%/var/stats\",\"inherited\":true},\"com.sun.am.session.enableHostLookUp\":{\"value\":false,\"inherited\":true}},\"amconfig.header.sessionnotification\":{\"com.iplanet.am.notification.threadpool.size\":{\"value\":\"10\",\"inherited\":true},\"com.iplanet.am.notification.threadpool.threshold\":{\"value\":\"5000\",\"inherited\":true}},\"amconfig.header.sessionvalidation\":{\"com.sun.am.session.caseInsensitiveDN\":{\"value\":true,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1187593890\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "915"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.493Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "af92a95f6908f2418301347c072b8792",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/uma"
+        },
+        "response": {
+          "bodySize": 4122,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4122,
+            "text": "{\"_id\":\"01/properties/uma\",\"_rev\":\"1126968974\",\"amconfig.org.forgerock.services.resourcesets.store.common.section\":{\"org.forgerock.services.resourcesets.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.resourcesets.store.external.section\":{\"org.forgerock.services.resourcesets.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.resourcesets.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.common.section\":{\"org.forgerock.services.umaaudit.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.external.section\":{\"org.forgerock.services.umaaudit.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.umaaudit.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.common.section\":{\"org.forgerock.services.uma.pendingrequests.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.external.section\":{\"org.forgerock.services.uma.pendingrequests.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.common.section\":{\"org.forgerock.services.uma.labels.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.max.connections\":{\"value\":\"2\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.external.section\":{\"org.forgerock.services.uma.labels.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.labels.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1126968974\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4122"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.500Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "57c0bda7be05bee3f75d473bf9838919",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/advanced"
+        },
+        "response": {
+          "bodySize": 88,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 88,
+            "text": "{\"_id\":\"03/properties/advanced\",\"_rev\":\"133638345\",\"com.iplanet.am.lbcookie.value\":\"03\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"133638345\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "88"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 483,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.508Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "2e2a078a0b525824f0ba0e8d24e4cadc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/cts"
+        },
+        "response": {
+          "bodySize": 1199,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1199,
+            "text": "{\"_id\":\"03/properties/cts\",\"_rev\":\"1597466663\",\"amconfig.org.forgerock.services.cts.store.common.section\":{\"org.forgerock.services.cts.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.cts.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.max.connections\":{\"value\":\"100\",\"inherited\":true},\"org.forgerock.services.cts.store.page.size\":{\"value\":\"0\",\"inherited\":true},\"org.forgerock.services.cts.store.vlv.page.size\":{\"value\":\"1000\",\"inherited\":true}},\"amconfig.org.forgerock.services.cts.store.external.section\":{\"org.forgerock.services.cts.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.cts.store.heartbeat\":{\"value\":\"10\",\"inherited\":true},\"org.forgerock.services.cts.store.affinity.enabled\":{\"value\":null,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1597466663\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1199"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.515Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "2adbcd3aee2e99502460f798e06539d3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 587,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/directoryConfiguration"
+        },
+        "response": {
+          "bodySize": 439,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 439,
+            "text": "{\"_id\":\"03/properties/directoryConfiguration\",\"_rev\":\"1465113540\",\"directoryConfiguration\":{\"minConnectionPool\":1,\"maxConnectionPool\":10,\"mtlsEnabled\":false,\"mtlsAlias\":\"\",\"mtlsKeyStoreFile\":\"\",\"mtlsKeyStoreType\":null,\"mtlsKeyStorePasswordFile\":\"\",\"mtlsKeyPasswordFile\":\"\",\"bindDn\":\"cn=Directory Manager\",\"bindPassword\":null},\"directoryServers\":[{\"hostName\":\"localhost\",\"serverName\":\"Server1\",\"connectionType\":\"SSL\",\"portNumber\":\"50636\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1465113540\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "439"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.525Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "a2cb229b8b8bac3797a39a3a633110ac",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/general"
+        },
+        "response": {
+          "bodySize": 895,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 895,
+            "text": "{\"_id\":\"03/properties/general\",\"_rev\":\"2025051123\",\"amconfig.header.site\":{\"singleChoiceSite\":\"[Empty]\"},\"amconfig.header.installdir\":{\"com.iplanet.services.configpath\":{\"value\":\"%BASE_DIR%\",\"inherited\":true},\"com.iplanet.am.locale\":{\"value\":\"en_US\",\"inherited\":true},\"com.sun.identity.client.notification.url\":{\"value\":\"%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice\",\"inherited\":true},\"com.iplanet.am.util.xml.validating\":{\"value\":\"off\",\"inherited\":true}},\"amconfig.header.debug\":{\"com.iplanet.services.debug.level\":{\"value\":\"error\",\"inherited\":true},\"com.sun.services.debug.mergeall\":{\"value\":\"off\",\"inherited\":true},\"com.iplanet.services.debug.directory\":{\"value\":\"%BASE_DIR%/var/debug\",\"inherited\":true}},\"amconfig.header.mailserver\":{\"com.iplanet.am.smtphost\":{\"value\":\"localhost\",\"inherited\":true},\"com.iplanet.am.smtpport\":{\"value\":\"25\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"2025051123\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "895"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.531Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "acc4748ee21e0fd541c38a7c241560da",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/sdk"
+        },
+        "response": {
+          "bodySize": 1309,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1309,
+            "text": "{\"_id\":\"03/properties/sdk\",\"_rev\":\"433248219\",\"amconfig.header.datastore\":{\"com.sun.identity.sm.enableDataStoreNotification\":{\"value\":false,\"inherited\":true},\"com.sun.identity.sm.notification.threadpool.size\":{\"value\":\"1\",\"inherited\":true}},\"amconfig.header.eventservice\":{\"com.iplanet.am.event.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.event.connection.delay.between.retries\":{\"value\":\"3000\",\"inherited\":true},\"com.iplanet.am.event.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true},\"com.sun.am.event.connection.disable.list\":{\"value\":\"aci,um,sm\",\"inherited\":true}},\"amconfig.header.ldapconnection\":{\"com.iplanet.am.ldap.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.ldap.connection.delay.between.retries\":{\"value\":\"1000\",\"inherited\":true},\"com.iplanet.am.ldap.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true}},\"amconfig.header.cachingreplica\":{\"com.iplanet.am.sdk.cache.maxSize\":{\"value\":\"10000\",\"inherited\":true}},\"amconfig.header.sdktimetoliveconfig\":{\"com.iplanet.am.sdk.cache.entry.expire.enabled\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.user.expire.time\":{\"value\":\"15\",\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.default.expire.time\":{\"value\":\"30\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"433248219\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1309"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.537Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "5c0735d74f97624f3ded9b8c5844ea75",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/security"
+        },
+        "response": {
+          "bodySize": 4176,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4176,
+            "text": "{\"_id\":\"03/properties/security\",\"_rev\":\"718869184\",\"amconfig.header.encryption\":{\"am.encryption.pwd\":{\"value\":\"@AM_ENC_PWD@\",\"inherited\":true},\"com.iplanet.security.encryptor\":{\"value\":\"com.iplanet.services.util.JCEEncryption\",\"inherited\":true},\"com.iplanet.security.SecureRandomFactoryImpl\":{\"value\":\"com.iplanet.am.util.SecureRandomFactoryImpl\",\"inherited\":true},\"am.encryption.secret.enabled\":{\"value\":false,\"inherited\":true},\"am.encryption.secret.alias\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreFile\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreType\":{\"value\":\"JCEKS\",\"inherited\":true},\"am.encryption.secret.keystorePass\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keyPass\":{\"value\":null,\"inherited\":true}},\"amconfig.header.validation\":{\"com.iplanet.services.comm.server.pllrequest.maxContentLength\":{\"value\":\"16384\",\"inherited\":true},\"com.iplanet.am.clientIPCheckEnabled\":{\"value\":false,\"inherited\":true}},\"amconfig.header.cookie\":{\"com.iplanet.am.cookie.name\":{\"value\":\"iPlanetDirectoryPro\",\"inherited\":true},\"com.iplanet.am.cookie.secure\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.cookie.encode\":{\"value\":false,\"inherited\":true}},\"amconfig.header.securitykey\":{\"com.sun.identity.saml.xmlsig.keystore\":{\"value\":\"%BASE_DIR%/security/keystores/keystore.jceks\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storetype\":{\"value\":\"JCEKS\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storepass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.storepass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.keypass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.keypass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.certalias\":{\"value\":\"test\",\"inherited\":true}},\"amconfig.header.crlcache\":{\"com.sun.identity.crl.cache.directory.host\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.port\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.ssl\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.mtlsenabled\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.user\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.password\":{\"value\":null,\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchlocs\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchattr\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.ocsp.check\":{\"com.sun.identity.authentication.ocspCheck\":{\"value\":false,\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.url\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.nickname\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.deserialisationwhitelist\":{\"openam.deserialisation.classes.whitelist\":{\"value\":\"com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"718869184\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4176"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.544Z",
+        "time": 4,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4
+        }
+      },
+      {
+        "_id": "6a4566581f6951ad4099be6fd8116ec7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/session"
+        },
+        "response": {
+          "bodySize": 915,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 915,
+            "text": "{\"_id\":\"03/properties/session\",\"_rev\":\"1267016628\",\"amconfig.header.sessionthresholds\":{\"org.forgerock.openam.session.service.access.persistence.caching.maxsize\":{\"value\":\"5000\",\"inherited\":true},\"com.iplanet.am.session.invalidsessionmaxtime\":{\"value\":\"3\",\"inherited\":true}},\"amconfig.header.sessionlogging\":{\"com.iplanet.am.stats.interval\":{\"value\":\"60\",\"inherited\":true},\"com.iplanet.services.stats.state\":{\"value\":\"file\",\"inherited\":true},\"com.iplanet.services.stats.directory\":{\"value\":\"%BASE_DIR%/var/stats\",\"inherited\":true},\"com.sun.am.session.enableHostLookUp\":{\"value\":false,\"inherited\":true}},\"amconfig.header.sessionnotification\":{\"com.iplanet.am.notification.threadpool.size\":{\"value\":\"10\",\"inherited\":true},\"com.iplanet.am.notification.threadpool.threshold\":{\"value\":\"5000\",\"inherited\":true}},\"amconfig.header.sessionvalidation\":{\"com.sun.am.session.caseInsensitiveDN\":{\"value\":true,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1267016628\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "915"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.552Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "202ba7777ba99af0adab283397eb1807",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/uma"
+        },
+        "response": {
+          "bodySize": 4121,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4121,
+            "text": "{\"_id\":\"03/properties/uma\",\"_rev\":\"302025085\",\"amconfig.org.forgerock.services.resourcesets.store.common.section\":{\"org.forgerock.services.resourcesets.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.resourcesets.store.external.section\":{\"org.forgerock.services.resourcesets.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.resourcesets.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.common.section\":{\"org.forgerock.services.umaaudit.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.external.section\":{\"org.forgerock.services.umaaudit.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.umaaudit.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.common.section\":{\"org.forgerock.services.uma.pendingrequests.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.external.section\":{\"org.forgerock.services.uma.pendingrequests.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.common.section\":{\"org.forgerock.services.uma.labels.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.max.connections\":{\"value\":\"2\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.external.section\":{\"org.forgerock.services.uma.labels.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.labels.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"302025085\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4121"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.558Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "c90d696d0f5790885ea99c76ee1b2b29",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/advanced"
+        },
+        "response": {
+          "bodySize": 89,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 89,
+            "text": "{\"_id\":\"04/properties/advanced\",\"_rev\":\"1053589086\",\"com.iplanet.am.lbcookie.value\":\"04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1053589086\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "89"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.565Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "acba719b27e4600cd525c5e43d82bead",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/cts"
+        },
+        "response": {
+          "bodySize": 1199,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1199,
+            "text": "{\"_id\":\"04/properties/cts\",\"_rev\":\"1094254838\",\"amconfig.org.forgerock.services.cts.store.common.section\":{\"org.forgerock.services.cts.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.cts.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.max.connections\":{\"value\":\"100\",\"inherited\":true},\"org.forgerock.services.cts.store.page.size\":{\"value\":\"0\",\"inherited\":true},\"org.forgerock.services.cts.store.vlv.page.size\":{\"value\":\"1000\",\"inherited\":true}},\"amconfig.org.forgerock.services.cts.store.external.section\":{\"org.forgerock.services.cts.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.cts.store.heartbeat\":{\"value\":\"10\",\"inherited\":true},\"org.forgerock.services.cts.store.affinity.enabled\":{\"value\":null,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1094254838\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1199"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.570Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "f0ae244389fb259f64bded7b90f20999",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 587,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/directoryConfiguration"
+        },
+        "response": {
+          "bodySize": 439,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 439,
+            "text": "{\"_id\":\"04/properties/directoryConfiguration\",\"_rev\":\"1832703833\",\"directoryConfiguration\":{\"minConnectionPool\":1,\"maxConnectionPool\":10,\"mtlsEnabled\":false,\"mtlsAlias\":\"\",\"mtlsKeyStoreFile\":\"\",\"mtlsKeyStoreType\":null,\"mtlsKeyStorePasswordFile\":\"\",\"mtlsKeyPasswordFile\":\"\",\"bindDn\":\"cn=Directory Manager\",\"bindPassword\":null},\"directoryServers\":[{\"hostName\":\"localhost\",\"serverName\":\"Server1\",\"connectionType\":\"SSL\",\"portNumber\":\"50636\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1832703833\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "439"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.577Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "d79528004eb47b289e1ec8c8e373c9e4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/general"
+        },
+        "response": {
+          "bodySize": 895,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 895,
+            "text": "{\"_id\":\"04/properties/general\",\"_rev\":\"1575973778\",\"amconfig.header.site\":{\"singleChoiceSite\":\"[Empty]\"},\"amconfig.header.installdir\":{\"com.iplanet.services.configpath\":{\"value\":\"%BASE_DIR%\",\"inherited\":true},\"com.iplanet.am.locale\":{\"value\":\"en_US\",\"inherited\":true},\"com.sun.identity.client.notification.url\":{\"value\":\"%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice\",\"inherited\":true},\"com.iplanet.am.util.xml.validating\":{\"value\":\"off\",\"inherited\":true}},\"amconfig.header.debug\":{\"com.iplanet.services.debug.level\":{\"value\":\"error\",\"inherited\":true},\"com.sun.services.debug.mergeall\":{\"value\":\"off\",\"inherited\":true},\"com.iplanet.services.debug.directory\":{\"value\":\"%BASE_DIR%/var/debug\",\"inherited\":true}},\"amconfig.header.mailserver\":{\"com.iplanet.am.smtphost\":{\"value\":\"localhost\",\"inherited\":true},\"com.iplanet.am.smtpport\":{\"value\":\"25\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1575973778\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "895"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.583Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "39c6616b0d9c6b956eb5a835961dc1be",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/sdk"
+        },
+        "response": {
+          "bodySize": 1309,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1309,
+            "text": "{\"_id\":\"04/properties/sdk\",\"_rev\":\"855243985\",\"amconfig.header.datastore\":{\"com.sun.identity.sm.enableDataStoreNotification\":{\"value\":false,\"inherited\":true},\"com.sun.identity.sm.notification.threadpool.size\":{\"value\":\"1\",\"inherited\":true}},\"amconfig.header.eventservice\":{\"com.iplanet.am.event.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.event.connection.delay.between.retries\":{\"value\":\"3000\",\"inherited\":true},\"com.iplanet.am.event.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true},\"com.sun.am.event.connection.disable.list\":{\"value\":\"aci,um,sm\",\"inherited\":true}},\"amconfig.header.ldapconnection\":{\"com.iplanet.am.ldap.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.ldap.connection.delay.between.retries\":{\"value\":\"1000\",\"inherited\":true},\"com.iplanet.am.ldap.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true}},\"amconfig.header.cachingreplica\":{\"com.iplanet.am.sdk.cache.maxSize\":{\"value\":\"10000\",\"inherited\":true}},\"amconfig.header.sdktimetoliveconfig\":{\"com.iplanet.am.sdk.cache.entry.expire.enabled\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.user.expire.time\":{\"value\":\"15\",\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.default.expire.time\":{\"value\":\"30\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"855243985\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1309"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.589Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "5fd751d7a58a40c5cae9a6b3e5b5a191",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/security"
+        },
+        "response": {
+          "bodySize": 4177,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4177,
+            "text": "{\"_id\":\"04/properties/security\",\"_rev\":\"1595470427\",\"amconfig.header.encryption\":{\"am.encryption.pwd\":{\"value\":\"@AM_ENC_PWD@\",\"inherited\":true},\"com.iplanet.security.encryptor\":{\"value\":\"com.iplanet.services.util.JCEEncryption\",\"inherited\":true},\"com.iplanet.security.SecureRandomFactoryImpl\":{\"value\":\"com.iplanet.am.util.SecureRandomFactoryImpl\",\"inherited\":true},\"am.encryption.secret.enabled\":{\"value\":false,\"inherited\":true},\"am.encryption.secret.alias\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreFile\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreType\":{\"value\":\"JCEKS\",\"inherited\":true},\"am.encryption.secret.keystorePass\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keyPass\":{\"value\":null,\"inherited\":true}},\"amconfig.header.validation\":{\"com.iplanet.services.comm.server.pllrequest.maxContentLength\":{\"value\":\"16384\",\"inherited\":true},\"com.iplanet.am.clientIPCheckEnabled\":{\"value\":false,\"inherited\":true}},\"amconfig.header.cookie\":{\"com.iplanet.am.cookie.name\":{\"value\":\"iPlanetDirectoryPro\",\"inherited\":true},\"com.iplanet.am.cookie.secure\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.cookie.encode\":{\"value\":false,\"inherited\":true}},\"amconfig.header.securitykey\":{\"com.sun.identity.saml.xmlsig.keystore\":{\"value\":\"%BASE_DIR%/security/keystores/keystore.jceks\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storetype\":{\"value\":\"JCEKS\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storepass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.storepass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.keypass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.keypass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.certalias\":{\"value\":\"test\",\"inherited\":true}},\"amconfig.header.crlcache\":{\"com.sun.identity.crl.cache.directory.host\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.port\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.ssl\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.mtlsenabled\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.user\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.password\":{\"value\":null,\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchlocs\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchattr\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.ocsp.check\":{\"com.sun.identity.authentication.ocspCheck\":{\"value\":false,\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.url\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.nickname\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.deserialisationwhitelist\":{\"openam.deserialisation.classes.whitelist\":{\"value\":\"com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1595470427\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4177"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.596Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "480f802b104643aa04fa93d0c56e0290",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/session"
+        },
+        "response": {
+          "bodySize": 915,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 915,
+            "text": "{\"_id\":\"04/properties/session\",\"_rev\":\"1363852188\",\"amconfig.header.sessionthresholds\":{\"org.forgerock.openam.session.service.access.persistence.caching.maxsize\":{\"value\":\"5000\",\"inherited\":true},\"com.iplanet.am.session.invalidsessionmaxtime\":{\"value\":\"3\",\"inherited\":true}},\"amconfig.header.sessionlogging\":{\"com.iplanet.am.stats.interval\":{\"value\":\"60\",\"inherited\":true},\"com.iplanet.services.stats.state\":{\"value\":\"file\",\"inherited\":true},\"com.iplanet.services.stats.directory\":{\"value\":\"%BASE_DIR%/var/stats\",\"inherited\":true},\"com.sun.am.session.enableHostLookUp\":{\"value\":false,\"inherited\":true}},\"amconfig.header.sessionnotification\":{\"com.iplanet.am.notification.threadpool.size\":{\"value\":\"10\",\"inherited\":true},\"com.iplanet.am.notification.threadpool.threshold\":{\"value\":\"5000\",\"inherited\":true}},\"amconfig.header.sessionvalidation\":{\"com.sun.am.session.caseInsensitiveDN\":{\"value\":true,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1363852188\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "915"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.603Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "896d1b036e99334f57ddeb7b23c5aaec",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/uma"
+        },
+        "response": {
+          "bodySize": 4122,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4122,
+            "text": "{\"_id\":\"04/properties/uma\",\"_rev\":\"1699700672\",\"amconfig.org.forgerock.services.resourcesets.store.common.section\":{\"org.forgerock.services.resourcesets.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.resourcesets.store.external.section\":{\"org.forgerock.services.resourcesets.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.resourcesets.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.common.section\":{\"org.forgerock.services.umaaudit.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.external.section\":{\"org.forgerock.services.umaaudit.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.umaaudit.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.common.section\":{\"org.forgerock.services.uma.pendingrequests.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.external.section\":{\"org.forgerock.services.uma.pendingrequests.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.common.section\":{\"org.forgerock.services.uma.labels.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.max.connections\":{\"value\":\"2\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.external.section\":{\"org.forgerock.services.uma.labels.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.labels.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1699700672\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4122"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.609Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/ServerOps_696203346/exportServers_262800030/1-Export-Servers_1478643340/recording.har
+++ b/src/test/mock-recordings/ServerOps_696203346/exportServers_262800030/1-Export-Servers_1478643340/recording.har
@@ -1,0 +1,1230 @@
+{
+  "log": {
+    "_recordingName": "ServerOps/exportServers()/1: Export Servers",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "76b32eba382ec9176be262a1048cdec2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6cc83927-85e5-4e0b-af21-af427e71defd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 566,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 219,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 219,
+            "text": "{\"result\":[{\"_id\":\"01\",\"_rev\":\"-931963190\",\"url\":\"http://localhost:8080/am\",\"siteName\":null}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "219"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:39:11 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:39:11.763Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "a881d34fa69200f99adfc9e71e2a6c6b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6cc83927-85e5-4e0b-af21-af427e71defd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 571,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/advanced"
+        },
+        "response": {
+          "bodySize": 645,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 645,
+            "text": "{\"_id\":\"01/properties/advanced\",\"_rev\":\"182486506\",\"com.sun.identity.urlconnection.useCache\":false,\"com.iplanet.am.serverMode\":true,\"com.sun.identity.sm.sms_object_class_name\":\"com.sun.identity.sm.SmsWrapperObject\",\"org.forgerock.embedded.dsadminport\":\"4444\",\"com.sun.embedded.sync.servers\":\"on\",\"com.sun.embedded.replicationport\":\"\",\"com.iplanet.security.SSLSocketFactoryImpl\":\"com.sun.identity.shared.ldap.factory.JSSESocketFactory\",\"com.sun.identity.common.systemtimerpool.size\":\"3\",\"bootstrap.file\":\"/home/prestonhales/.openamcfg/AMConfig_usr_local_tomcat_webapps_am_\",\"com.iplanet.am.lbcookie.value\":\"01\",\"opensso.protocol.handler.pkgs\":\"\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"182486506\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "645"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:39:11 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:39:11.775Z",
+        "time": 58,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 58
+        }
+      },
+      {
+        "_id": "097a8e6e4f3f8f245fbbd6c8ce7576c4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6cc83927-85e5-4e0b-af21-af427e71defd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 566,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/cts"
+        },
+        "response": {
+          "bodySize": 1199,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1199,
+            "text": "{\"_id\":\"01/properties/cts\",\"_rev\":\"1594391749\",\"amconfig.org.forgerock.services.cts.store.common.section\":{\"org.forgerock.services.cts.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.cts.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.max.connections\":{\"value\":\"100\",\"inherited\":true},\"org.forgerock.services.cts.store.page.size\":{\"value\":\"0\",\"inherited\":true},\"org.forgerock.services.cts.store.vlv.page.size\":{\"value\":\"1000\",\"inherited\":true}},\"amconfig.org.forgerock.services.cts.store.external.section\":{\"org.forgerock.services.cts.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.cts.store.heartbeat\":{\"value\":\"10\",\"inherited\":true},\"org.forgerock.services.cts.store.affinity.enabled\":{\"value\":null,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1594391749\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1199"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:39:11 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:39:11.844Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "2de9af30586fa3ef0c876107923ffdce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6cc83927-85e5-4e0b-af21-af427e71defd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 585,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/directoryConfiguration"
+        },
+        "response": {
+          "bodySize": 339,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 339,
+            "text": "{\"_id\":\"01/properties/directoryConfiguration\",\"_rev\":\"951033738\",\"directoryConfiguration\":{\"minConnectionPool\":1,\"maxConnectionPool\":10,\"mtlsEnabled\":false,\"mtlsAlias\":null,\"bindDn\":\"cn=Directory Manager\",\"bindPassword\":null},\"directoryServers\":[{\"hostName\":\"localhost\",\"serverName\":\"Server1\",\"connectionType\":\"SSL\",\"portNumber\":\"50636\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"951033738\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "339"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:39:11 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:39:11.862Z",
+        "time": 4,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4
+        }
+      },
+      {
+        "_id": "636cd7d41bb569a7d80cd609812779c4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6cc83927-85e5-4e0b-af21-af427e71defd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 570,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/general"
+        },
+        "response": {
+          "bodySize": 910,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 910,
+            "text": "{\"_id\":\"01/properties/general\",\"_rev\":\"1646268186\",\"amconfig.header.site\":{\"singleChoiceSite\":\"[Empty]\"},\"amconfig.header.installdir\":{\"com.iplanet.services.configpath\":{\"value\":\"/home/prestonhales/am\",\"inherited\":false},\"com.iplanet.am.locale\":{\"value\":\"en_US\",\"inherited\":false},\"com.sun.identity.client.notification.url\":{\"value\":\"%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice\",\"inherited\":true},\"com.iplanet.am.util.xml.validating\":{\"value\":\"off\",\"inherited\":true}},\"amconfig.header.debug\":{\"com.iplanet.services.debug.level\":{\"value\":\"error\",\"inherited\":false},\"com.sun.services.debug.mergeall\":{\"value\":\"off\",\"inherited\":false},\"com.iplanet.services.debug.directory\":{\"value\":\"%BASE_DIR%/var/debug\",\"inherited\":true}},\"amconfig.header.mailserver\":{\"com.iplanet.am.smtphost\":{\"value\":\"localhost\",\"inherited\":true},\"com.iplanet.am.smtpport\":{\"value\":\"25\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1646268186\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "910"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:39:11 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:39:11.875Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "1ef913d2a189c841927fa13a131df3af",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6cc83927-85e5-4e0b-af21-af427e71defd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 566,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/sdk"
+        },
+        "response": {
+          "bodySize": 1309,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1309,
+            "text": "{\"_id\":\"01/properties/sdk\",\"_rev\":\"1522547308\",\"amconfig.header.datastore\":{\"com.sun.identity.sm.enableDataStoreNotification\":{\"value\":true,\"inherited\":false},\"com.sun.identity.sm.notification.threadpool.size\":{\"value\":\"1\",\"inherited\":true}},\"amconfig.header.eventservice\":{\"com.iplanet.am.event.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.event.connection.delay.between.retries\":{\"value\":\"3000\",\"inherited\":true},\"com.iplanet.am.event.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true},\"com.sun.am.event.connection.disable.list\":{\"value\":\"aci,um\",\"inherited\":false}},\"amconfig.header.ldapconnection\":{\"com.iplanet.am.ldap.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.ldap.connection.delay.between.retries\":{\"value\":\"1000\",\"inherited\":true},\"com.iplanet.am.ldap.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":false}},\"amconfig.header.cachingreplica\":{\"com.iplanet.am.sdk.cache.maxSize\":{\"value\":\"10000\",\"inherited\":true}},\"amconfig.header.sdktimetoliveconfig\":{\"com.iplanet.am.sdk.cache.entry.expire.enabled\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.user.expire.time\":{\"value\":\"15\",\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.default.expire.time\":{\"value\":\"30\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1522547308\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1309"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:39:11 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:39:11.887Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "dc0ffe73364c49fd72ece588ee23207e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6cc83927-85e5-4e0b-af21-af427e71defd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 571,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/security"
+        },
+        "response": {
+          "bodySize": 4198,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4198,
+            "text": "{\"_id\":\"01/properties/security\",\"_rev\":\"1347550750\",\"amconfig.header.encryption\":{\"am.encryption.pwd\":{\"value\":\"efSYcwIhr7uKH30rgciGTVTFzb63LhYu\",\"inherited\":false},\"com.iplanet.security.encryptor\":{\"value\":\"com.iplanet.services.util.JCEEncryption\",\"inherited\":true},\"com.iplanet.security.SecureRandomFactoryImpl\":{\"value\":\"com.iplanet.am.util.SecureRandomFactoryImpl\",\"inherited\":true},\"am.encryption.secret.enabled\":{\"value\":false,\"inherited\":true},\"am.encryption.secret.alias\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreFile\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreType\":{\"value\":\"JCEKS\",\"inherited\":true},\"am.encryption.secret.keystorePass\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keyPass\":{\"value\":null,\"inherited\":true}},\"amconfig.header.validation\":{\"com.iplanet.services.comm.server.pllrequest.maxContentLength\":{\"value\":\"16384\",\"inherited\":true},\"com.iplanet.am.clientIPCheckEnabled\":{\"value\":false,\"inherited\":true}},\"amconfig.header.cookie\":{\"com.iplanet.am.cookie.name\":{\"value\":\"iPlanetDirectoryPro\",\"inherited\":true},\"com.iplanet.am.cookie.secure\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.cookie.encode\":{\"value\":false,\"inherited\":true}},\"amconfig.header.securitykey\":{\"com.sun.identity.saml.xmlsig.keystore\":{\"value\":\"%BASE_DIR%/security/keystores/keystore.jceks\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storetype\":{\"value\":\"JCEKS\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storepass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.storepass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.keypass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.keypass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.certalias\":{\"value\":\"test\",\"inherited\":true}},\"amconfig.header.crlcache\":{\"com.sun.identity.crl.cache.directory.host\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.port\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.ssl\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.mtlsenabled\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.user\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.password\":{\"value\":null,\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchlocs\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchattr\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.ocsp.check\":{\"com.sun.identity.authentication.ocspCheck\":{\"value\":false,\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.url\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.nickname\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.deserialisationwhitelist\":{\"openam.deserialisation.classes.whitelist\":{\"value\":\"com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1347550750\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4198"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:39:11 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:39:11.906Z",
+        "time": 8,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 8
+        }
+      },
+      {
+        "_id": "b591cc4dc8949e995f0c298ba20e27ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6cc83927-85e5-4e0b-af21-af427e71defd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 570,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/session"
+        },
+        "response": {
+          "bodySize": 915,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 915,
+            "text": "{\"_id\":\"01/properties/session\",\"_rev\":\"1443954878\",\"amconfig.header.sessionthresholds\":{\"org.forgerock.openam.session.service.access.persistence.caching.maxsize\":{\"value\":\"5000\",\"inherited\":true},\"com.iplanet.am.session.invalidsessionmaxtime\":{\"value\":\"3\",\"inherited\":true}},\"amconfig.header.sessionlogging\":{\"com.iplanet.am.stats.interval\":{\"value\":\"60\",\"inherited\":true},\"com.iplanet.services.stats.state\":{\"value\":\"file\",\"inherited\":true},\"com.iplanet.services.stats.directory\":{\"value\":\"%BASE_DIR%/var/stats\",\"inherited\":true},\"com.sun.am.session.enableHostLookUp\":{\"value\":false,\"inherited\":true}},\"amconfig.header.sessionnotification\":{\"com.iplanet.am.notification.threadpool.size\":{\"value\":\"10\",\"inherited\":true},\"com.iplanet.am.notification.threadpool.threshold\":{\"value\":\"5000\",\"inherited\":true}},\"amconfig.header.sessionvalidation\":{\"com.sun.am.session.caseInsensitiveDN\":{\"value\":true,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1443954878\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "915"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:39:11 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:39:11.923Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "af92a95f6908f2418301347c072b8792",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6cc83927-85e5-4e0b-af21-af427e71defd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 566,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/uma"
+        },
+        "response": {
+          "bodySize": 4121,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4121,
+            "text": "{\"_id\":\"01/properties/uma\",\"_rev\":\"398747605\",\"amconfig.org.forgerock.services.resourcesets.store.common.section\":{\"org.forgerock.services.resourcesets.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.resourcesets.store.external.section\":{\"org.forgerock.services.resourcesets.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.resourcesets.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.common.section\":{\"org.forgerock.services.umaaudit.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.external.section\":{\"org.forgerock.services.umaaudit.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.umaaudit.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.common.section\":{\"org.forgerock.services.uma.pendingrequests.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.external.section\":{\"org.forgerock.services.uma.pendingrequests.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.common.section\":{\"org.forgerock.services.uma.labels.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.max.connections\":{\"value\":\"2\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.external.section\":{\"org.forgerock.services.uma.labels.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.labels.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"398747605\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4121"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 18:39:11 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T18:39:11.938Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/ServerOps_696203346/exportServers_262800030/2-Export-Servers-with-default-properties_4191424791/recording.har
+++ b/src/test/mock-recordings/ServerOps_696203346/exportServers_262800030/2-Export-Servers-with-default-properties_4191424791/recording.har
@@ -1,0 +1,4466 @@
+{
+  "log": {
+    "_recordingName": "ServerOps/exportServers()/2: Export Servers with default properties",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "76b32eba382ec9176be262a1048cdec2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 383,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 383,
+            "text": "{\"result\":[{\"_id\":\"01\",\"_rev\":\"-931963190\",\"url\":\"http://localhost:8080/am\",\"siteName\":null},{\"_id\":\"03\",\"_rev\":\"-931738263\",\"url\":\"http://localhost:8081/am\",\"siteName\":null},{\"_id\":\"04\",\"_rev\":\"-931739121\",\"url\":\"http://localhost:8082/am\",\"siteName\":null}],\"resultCount\":3,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "383"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.627Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "a881d34fa69200f99adfc9e71e2a6c6b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/advanced"
+        },
+        "response": {
+          "bodySize": 645,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 645,
+            "text": "{\"_id\":\"01/properties/advanced\",\"_rev\":\"640350433\",\"com.sun.identity.urlconnection.useCache\":false,\"com.iplanet.am.serverMode\":true,\"com.sun.identity.sm.sms_object_class_name\":\"com.sun.identity.sm.SmsWrapperObject\",\"org.forgerock.embedded.dsadminport\":\"4444\",\"com.sun.embedded.sync.servers\":\"on\",\"com.sun.embedded.replicationport\":\"\",\"com.iplanet.security.SSLSocketFactoryImpl\":\"com.sun.identity.shared.ldap.factory.JSSESocketFactory\",\"com.sun.identity.common.systemtimerpool.size\":\"3\",\"bootstrap.file\":\"/home/prestonhales/.openamcfg/AMConfig_usr_local_tomcat_webapps_am_\",\"com.iplanet.am.lbcookie.value\":\"01\",\"opensso.protocol.handler.pkgs\":\"\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"640350433\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "645"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.634Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "097a8e6e4f3f8f245fbbd6c8ce7576c4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/cts"
+        },
+        "response": {
+          "bodySize": 1199,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1199,
+            "text": "{\"_id\":\"01/properties/cts\",\"_rev\":\"1870095637\",\"amconfig.org.forgerock.services.cts.store.common.section\":{\"org.forgerock.services.cts.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.cts.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.max.connections\":{\"value\":\"100\",\"inherited\":true},\"org.forgerock.services.cts.store.page.size\":{\"value\":\"0\",\"inherited\":true},\"org.forgerock.services.cts.store.vlv.page.size\":{\"value\":\"1000\",\"inherited\":true}},\"amconfig.org.forgerock.services.cts.store.external.section\":{\"org.forgerock.services.cts.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.cts.store.heartbeat\":{\"value\":\"10\",\"inherited\":true},\"org.forgerock.services.cts.store.affinity.enabled\":{\"value\":null,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1870095637\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1199"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.640Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "2de9af30586fa3ef0c876107923ffdce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 587,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/directoryConfiguration"
+        },
+        "response": {
+          "bodySize": 438,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 438,
+            "text": "{\"_id\":\"01/properties/directoryConfiguration\",\"_rev\":\"977014447\",\"directoryConfiguration\":{\"minConnectionPool\":1,\"maxConnectionPool\":10,\"mtlsEnabled\":false,\"mtlsAlias\":\"\",\"mtlsKeyStoreFile\":\"\",\"mtlsKeyStoreType\":null,\"mtlsKeyStorePasswordFile\":\"\",\"mtlsKeyPasswordFile\":\"\",\"bindDn\":\"cn=Directory Manager\",\"bindPassword\":null},\"directoryServers\":[{\"hostName\":\"localhost\",\"serverName\":\"Server1\",\"connectionType\":\"SSL\",\"portNumber\":\"50636\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"977014447\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "438"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.646Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "636cd7d41bb569a7d80cd609812779c4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/general"
+        },
+        "response": {
+          "bodySize": 911,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 911,
+            "text": "{\"_id\":\"01/properties/general\",\"_rev\":\"572685106\",\"amconfig.header.site\":{\"singleChoiceSite\":\"[Empty]\"},\"amconfig.header.installdir\":{\"com.iplanet.services.configpath\":{\"value\":\"/home/prestonhales/am\",\"inherited\":false},\"com.iplanet.am.locale\":{\"value\":\"en_US\",\"inherited\":false},\"com.sun.identity.client.notification.url\":{\"value\":\"%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice\",\"inherited\":true},\"com.iplanet.am.util.xml.validating\":{\"value\":\"off\",\"inherited\":true}},\"amconfig.header.debug\":{\"com.iplanet.services.debug.level\":{\"value\":\"warning\",\"inherited\":false},\"com.sun.services.debug.mergeall\":{\"value\":\"off\",\"inherited\":false},\"com.iplanet.services.debug.directory\":{\"value\":\"%BASE_DIR%/var/debug\",\"inherited\":true}},\"amconfig.header.mailserver\":{\"com.iplanet.am.smtphost\":{\"value\":\"localhost\",\"inherited\":true},\"com.iplanet.am.smtpport\":{\"value\":\"25\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"572685106\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "911"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.652Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "1ef913d2a189c841927fa13a131df3af",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/sdk"
+        },
+        "response": {
+          "bodySize": 1309,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1309,
+            "text": "{\"_id\":\"01/properties/sdk\",\"_rev\":\"2084420578\",\"amconfig.header.datastore\":{\"com.sun.identity.sm.enableDataStoreNotification\":{\"value\":true,\"inherited\":false},\"com.sun.identity.sm.notification.threadpool.size\":{\"value\":\"1\",\"inherited\":true}},\"amconfig.header.eventservice\":{\"com.iplanet.am.event.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.event.connection.delay.between.retries\":{\"value\":\"3000\",\"inherited\":true},\"com.iplanet.am.event.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true},\"com.sun.am.event.connection.disable.list\":{\"value\":\"aci,um\",\"inherited\":false}},\"amconfig.header.ldapconnection\":{\"com.iplanet.am.ldap.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.ldap.connection.delay.between.retries\":{\"value\":\"1000\",\"inherited\":true},\"com.iplanet.am.ldap.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":false}},\"amconfig.header.cachingreplica\":{\"com.iplanet.am.sdk.cache.maxSize\":{\"value\":\"10000\",\"inherited\":true}},\"amconfig.header.sdktimetoliveconfig\":{\"com.iplanet.am.sdk.cache.entry.expire.enabled\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.user.expire.time\":{\"value\":\"15\",\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.default.expire.time\":{\"value\":\"30\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"2084420578\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1309"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.658Z",
+        "time": 5,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5
+        }
+      },
+      {
+        "_id": "dc0ffe73364c49fd72ece588ee23207e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/security"
+        },
+        "response": {
+          "bodySize": 4198,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4198,
+            "text": "{\"_id\":\"01/properties/security\",\"_rev\":\"1471168313\",\"amconfig.header.encryption\":{\"am.encryption.pwd\":{\"value\":\"efSYcwIhr7uKH30rgciGTVTFzb63LhYu\",\"inherited\":false},\"com.iplanet.security.encryptor\":{\"value\":\"com.iplanet.services.util.JCEEncryption\",\"inherited\":true},\"com.iplanet.security.SecureRandomFactoryImpl\":{\"value\":\"com.iplanet.am.util.SecureRandomFactoryImpl\",\"inherited\":true},\"am.encryption.secret.enabled\":{\"value\":false,\"inherited\":true},\"am.encryption.secret.alias\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreFile\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreType\":{\"value\":\"JCEKS\",\"inherited\":true},\"am.encryption.secret.keystorePass\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keyPass\":{\"value\":null,\"inherited\":true}},\"amconfig.header.validation\":{\"com.iplanet.services.comm.server.pllrequest.maxContentLength\":{\"value\":\"16384\",\"inherited\":true},\"com.iplanet.am.clientIPCheckEnabled\":{\"value\":false,\"inherited\":true}},\"amconfig.header.cookie\":{\"com.iplanet.am.cookie.name\":{\"value\":\"iPlanetDirectoryPro\",\"inherited\":true},\"com.iplanet.am.cookie.secure\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.cookie.encode\":{\"value\":false,\"inherited\":true}},\"amconfig.header.securitykey\":{\"com.sun.identity.saml.xmlsig.keystore\":{\"value\":\"%BASE_DIR%/security/keystores/keystore.jceks\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storetype\":{\"value\":\"JCEKS\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storepass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.storepass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.keypass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.keypass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.certalias\":{\"value\":\"test\",\"inherited\":true}},\"amconfig.header.crlcache\":{\"com.sun.identity.crl.cache.directory.host\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.port\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.ssl\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.mtlsenabled\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.user\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.password\":{\"value\":null,\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchlocs\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchattr\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.ocsp.check\":{\"com.sun.identity.authentication.ocspCheck\":{\"value\":false,\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.url\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.nickname\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.deserialisationwhitelist\":{\"openam.deserialisation.classes.whitelist\":{\"value\":\"com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1471168313\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4198"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.668Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "b591cc4dc8949e995f0c298ba20e27ee",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/session"
+        },
+        "response": {
+          "bodySize": 914,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 914,
+            "text": "{\"_id\":\"01/properties/session\",\"_rev\":\"448395666\",\"amconfig.header.sessionthresholds\":{\"org.forgerock.openam.session.service.access.persistence.caching.maxsize\":{\"value\":\"5000\",\"inherited\":true},\"com.iplanet.am.session.invalidsessionmaxtime\":{\"value\":\"3\",\"inherited\":true}},\"amconfig.header.sessionlogging\":{\"com.iplanet.am.stats.interval\":{\"value\":\"60\",\"inherited\":true},\"com.iplanet.services.stats.state\":{\"value\":\"file\",\"inherited\":true},\"com.iplanet.services.stats.directory\":{\"value\":\"%BASE_DIR%/var/stats\",\"inherited\":true},\"com.sun.am.session.enableHostLookUp\":{\"value\":false,\"inherited\":true}},\"amconfig.header.sessionnotification\":{\"com.iplanet.am.notification.threadpool.size\":{\"value\":\"10\",\"inherited\":true},\"com.iplanet.am.notification.threadpool.threshold\":{\"value\":\"5000\",\"inherited\":true}},\"amconfig.header.sessionvalidation\":{\"com.sun.am.session.caseInsensitiveDN\":{\"value\":true,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"448395666\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "914"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.674Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "af92a95f6908f2418301347c072b8792",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/01/properties/uma"
+        },
+        "response": {
+          "bodySize": 4121,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4121,
+            "text": "{\"_id\":\"01/properties/uma\",\"_rev\":\"252658597\",\"amconfig.org.forgerock.services.resourcesets.store.common.section\":{\"org.forgerock.services.resourcesets.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.resourcesets.store.external.section\":{\"org.forgerock.services.resourcesets.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.resourcesets.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.common.section\":{\"org.forgerock.services.umaaudit.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.external.section\":{\"org.forgerock.services.umaaudit.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.umaaudit.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.common.section\":{\"org.forgerock.services.uma.pendingrequests.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.external.section\":{\"org.forgerock.services.uma.pendingrequests.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.common.section\":{\"org.forgerock.services.uma.labels.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.max.connections\":{\"value\":\"2\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.external.section\":{\"org.forgerock.services.uma.labels.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.labels.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"252658597\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4121"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.680Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "57c0bda7be05bee3f75d473bf9838919",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/advanced"
+        },
+        "response": {
+          "bodySize": 89,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 89,
+            "text": "{\"_id\":\"03/properties/advanced\",\"_rev\":\"1124473215\",\"com.iplanet.am.lbcookie.value\":\"03\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1124473215\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "89"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.687Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "2e2a078a0b525824f0ba0e8d24e4cadc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/cts"
+        },
+        "response": {
+          "bodySize": 1198,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1198,
+            "text": "{\"_id\":\"03/properties/cts\",\"_rev\":\"195487139\",\"amconfig.org.forgerock.services.cts.store.common.section\":{\"org.forgerock.services.cts.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.cts.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.max.connections\":{\"value\":\"100\",\"inherited\":true},\"org.forgerock.services.cts.store.page.size\":{\"value\":\"0\",\"inherited\":true},\"org.forgerock.services.cts.store.vlv.page.size\":{\"value\":\"1000\",\"inherited\":true}},\"amconfig.org.forgerock.services.cts.store.external.section\":{\"org.forgerock.services.cts.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.cts.store.heartbeat\":{\"value\":\"10\",\"inherited\":true},\"org.forgerock.services.cts.store.affinity.enabled\":{\"value\":null,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"195487139\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1198"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.692Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "2adbcd3aee2e99502460f798e06539d3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 587,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/directoryConfiguration"
+        },
+        "response": {
+          "bodySize": 438,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 438,
+            "text": "{\"_id\":\"03/properties/directoryConfiguration\",\"_rev\":\"815965393\",\"directoryConfiguration\":{\"minConnectionPool\":1,\"maxConnectionPool\":10,\"mtlsEnabled\":false,\"mtlsAlias\":\"\",\"mtlsKeyStoreFile\":\"\",\"mtlsKeyStoreType\":null,\"mtlsKeyStorePasswordFile\":\"\",\"mtlsKeyPasswordFile\":\"\",\"bindDn\":\"cn=Directory Manager\",\"bindPassword\":null},\"directoryServers\":[{\"hostName\":\"localhost\",\"serverName\":\"Server1\",\"connectionType\":\"SSL\",\"portNumber\":\"50636\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"815965393\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "438"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.698Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "a2cb229b8b8bac3797a39a3a633110ac",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/general"
+        },
+        "response": {
+          "bodySize": 894,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 894,
+            "text": "{\"_id\":\"03/properties/general\",\"_rev\":\"604966163\",\"amconfig.header.site\":{\"singleChoiceSite\":\"[Empty]\"},\"amconfig.header.installdir\":{\"com.iplanet.services.configpath\":{\"value\":\"%BASE_DIR%\",\"inherited\":true},\"com.iplanet.am.locale\":{\"value\":\"en_US\",\"inherited\":true},\"com.sun.identity.client.notification.url\":{\"value\":\"%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice\",\"inherited\":true},\"com.iplanet.am.util.xml.validating\":{\"value\":\"off\",\"inherited\":true}},\"amconfig.header.debug\":{\"com.iplanet.services.debug.level\":{\"value\":\"error\",\"inherited\":true},\"com.sun.services.debug.mergeall\":{\"value\":\"off\",\"inherited\":true},\"com.iplanet.services.debug.directory\":{\"value\":\"%BASE_DIR%/var/debug\",\"inherited\":true}},\"amconfig.header.mailserver\":{\"com.iplanet.am.smtphost\":{\"value\":\"localhost\",\"inherited\":true},\"com.iplanet.am.smtpport\":{\"value\":\"25\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"604966163\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "894"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.703Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "acc4748ee21e0fd541c38a7c241560da",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/sdk"
+        },
+        "response": {
+          "bodySize": 1310,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1310,
+            "text": "{\"_id\":\"03/properties/sdk\",\"_rev\":\"1466168525\",\"amconfig.header.datastore\":{\"com.sun.identity.sm.enableDataStoreNotification\":{\"value\":false,\"inherited\":true},\"com.sun.identity.sm.notification.threadpool.size\":{\"value\":\"1\",\"inherited\":true}},\"amconfig.header.eventservice\":{\"com.iplanet.am.event.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.event.connection.delay.between.retries\":{\"value\":\"3000\",\"inherited\":true},\"com.iplanet.am.event.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true},\"com.sun.am.event.connection.disable.list\":{\"value\":\"aci,um,sm\",\"inherited\":true}},\"amconfig.header.ldapconnection\":{\"com.iplanet.am.ldap.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.ldap.connection.delay.between.retries\":{\"value\":\"1000\",\"inherited\":true},\"com.iplanet.am.ldap.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true}},\"amconfig.header.cachingreplica\":{\"com.iplanet.am.sdk.cache.maxSize\":{\"value\":\"10000\",\"inherited\":true}},\"amconfig.header.sdktimetoliveconfig\":{\"com.iplanet.am.sdk.cache.entry.expire.enabled\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.user.expire.time\":{\"value\":\"15\",\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.default.expire.time\":{\"value\":\"30\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1466168525\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1310"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.709Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "5c0735d74f97624f3ded9b8c5844ea75",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/security"
+        },
+        "response": {
+          "bodySize": 4177,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4177,
+            "text": "{\"_id\":\"03/properties/security\",\"_rev\":\"1200017169\",\"amconfig.header.encryption\":{\"am.encryption.pwd\":{\"value\":\"@AM_ENC_PWD@\",\"inherited\":true},\"com.iplanet.security.encryptor\":{\"value\":\"com.iplanet.services.util.JCEEncryption\",\"inherited\":true},\"com.iplanet.security.SecureRandomFactoryImpl\":{\"value\":\"com.iplanet.am.util.SecureRandomFactoryImpl\",\"inherited\":true},\"am.encryption.secret.enabled\":{\"value\":false,\"inherited\":true},\"am.encryption.secret.alias\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreFile\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreType\":{\"value\":\"JCEKS\",\"inherited\":true},\"am.encryption.secret.keystorePass\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keyPass\":{\"value\":null,\"inherited\":true}},\"amconfig.header.validation\":{\"com.iplanet.services.comm.server.pllrequest.maxContentLength\":{\"value\":\"16384\",\"inherited\":true},\"com.iplanet.am.clientIPCheckEnabled\":{\"value\":false,\"inherited\":true}},\"amconfig.header.cookie\":{\"com.iplanet.am.cookie.name\":{\"value\":\"iPlanetDirectoryPro\",\"inherited\":true},\"com.iplanet.am.cookie.secure\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.cookie.encode\":{\"value\":false,\"inherited\":true}},\"amconfig.header.securitykey\":{\"com.sun.identity.saml.xmlsig.keystore\":{\"value\":\"%BASE_DIR%/security/keystores/keystore.jceks\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storetype\":{\"value\":\"JCEKS\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storepass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.storepass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.keypass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.keypass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.certalias\":{\"value\":\"test\",\"inherited\":true}},\"amconfig.header.crlcache\":{\"com.sun.identity.crl.cache.directory.host\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.port\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.ssl\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.mtlsenabled\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.user\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.password\":{\"value\":null,\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchlocs\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchattr\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.ocsp.check\":{\"com.sun.identity.authentication.ocspCheck\":{\"value\":false,\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.url\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.nickname\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.deserialisationwhitelist\":{\"openam.deserialisation.classes.whitelist\":{\"value\":\"com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1200017169\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4177"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.716Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "6a4566581f6951ad4099be6fd8116ec7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/session"
+        },
+        "response": {
+          "bodySize": 915,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 915,
+            "text": "{\"_id\":\"03/properties/session\",\"_rev\":\"1755281159\",\"amconfig.header.sessionthresholds\":{\"org.forgerock.openam.session.service.access.persistence.caching.maxsize\":{\"value\":\"5000\",\"inherited\":true},\"com.iplanet.am.session.invalidsessionmaxtime\":{\"value\":\"3\",\"inherited\":true}},\"amconfig.header.sessionlogging\":{\"com.iplanet.am.stats.interval\":{\"value\":\"60\",\"inherited\":true},\"com.iplanet.services.stats.state\":{\"value\":\"file\",\"inherited\":true},\"com.iplanet.services.stats.directory\":{\"value\":\"%BASE_DIR%/var/stats\",\"inherited\":true},\"com.sun.am.session.enableHostLookUp\":{\"value\":false,\"inherited\":true}},\"amconfig.header.sessionnotification\":{\"com.iplanet.am.notification.threadpool.size\":{\"value\":\"10\",\"inherited\":true},\"com.iplanet.am.notification.threadpool.threshold\":{\"value\":\"5000\",\"inherited\":true}},\"amconfig.header.sessionvalidation\":{\"com.sun.am.session.caseInsensitiveDN\":{\"value\":true,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1755281159\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "915"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.723Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "202ba7777ba99af0adab283397eb1807",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/03/properties/uma"
+        },
+        "response": {
+          "bodySize": 4122,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4122,
+            "text": "{\"_id\":\"03/properties/uma\",\"_rev\":\"1003517163\",\"amconfig.org.forgerock.services.resourcesets.store.common.section\":{\"org.forgerock.services.resourcesets.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.resourcesets.store.external.section\":{\"org.forgerock.services.resourcesets.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.resourcesets.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.common.section\":{\"org.forgerock.services.umaaudit.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.external.section\":{\"org.forgerock.services.umaaudit.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.umaaudit.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.common.section\":{\"org.forgerock.services.uma.pendingrequests.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.external.section\":{\"org.forgerock.services.uma.pendingrequests.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.common.section\":{\"org.forgerock.services.uma.labels.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.max.connections\":{\"value\":\"2\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.external.section\":{\"org.forgerock.services.uma.labels.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.labels.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1003517163\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4122"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.728Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "c90d696d0f5790885ea99c76ee1b2b29",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/advanced"
+        },
+        "response": {
+          "bodySize": 89,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 89,
+            "text": "{\"_id\":\"04/properties/advanced\",\"_rev\":\"2014426080\",\"com.iplanet.am.lbcookie.value\":\"04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"2014426080\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "89"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.735Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "acba719b27e4600cd525c5e43d82bead",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/cts"
+        },
+        "response": {
+          "bodySize": 1198,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1198,
+            "text": "{\"_id\":\"04/properties/cts\",\"_rev\":\"845265500\",\"amconfig.org.forgerock.services.cts.store.common.section\":{\"org.forgerock.services.cts.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.cts.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.max.connections\":{\"value\":\"100\",\"inherited\":true},\"org.forgerock.services.cts.store.page.size\":{\"value\":\"0\",\"inherited\":true},\"org.forgerock.services.cts.store.vlv.page.size\":{\"value\":\"1000\",\"inherited\":true}},\"amconfig.org.forgerock.services.cts.store.external.section\":{\"org.forgerock.services.cts.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.cts.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.cts.store.heartbeat\":{\"value\":\"10\",\"inherited\":true},\"org.forgerock.services.cts.store.affinity.enabled\":{\"value\":null,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"845265500\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1198"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.741Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "f0ae244389fb259f64bded7b90f20999",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 587,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/directoryConfiguration"
+        },
+        "response": {
+          "bodySize": 438,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 438,
+            "text": "{\"_id\":\"04/properties/directoryConfiguration\",\"_rev\":\"141426662\",\"directoryConfiguration\":{\"minConnectionPool\":1,\"maxConnectionPool\":10,\"mtlsEnabled\":false,\"mtlsAlias\":\"\",\"mtlsKeyStoreFile\":\"\",\"mtlsKeyStoreType\":null,\"mtlsKeyStorePasswordFile\":\"\",\"mtlsKeyPasswordFile\":\"\",\"bindDn\":\"cn=Directory Manager\",\"bindPassword\":null},\"directoryServers\":[{\"hostName\":\"localhost\",\"serverName\":\"Server1\",\"connectionType\":\"SSL\",\"portNumber\":\"50636\"}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"141426662\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "438"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.747Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "d79528004eb47b289e1ec8c8e373c9e4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/general"
+        },
+        "response": {
+          "bodySize": 894,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 894,
+            "text": "{\"_id\":\"04/properties/general\",\"_rev\":\"565723329\",\"amconfig.header.site\":{\"singleChoiceSite\":\"[Empty]\"},\"amconfig.header.installdir\":{\"com.iplanet.services.configpath\":{\"value\":\"%BASE_DIR%\",\"inherited\":true},\"com.iplanet.am.locale\":{\"value\":\"en_US\",\"inherited\":true},\"com.sun.identity.client.notification.url\":{\"value\":\"%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice\",\"inherited\":true},\"com.iplanet.am.util.xml.validating\":{\"value\":\"off\",\"inherited\":true}},\"amconfig.header.debug\":{\"com.iplanet.services.debug.level\":{\"value\":\"error\",\"inherited\":true},\"com.sun.services.debug.mergeall\":{\"value\":\"off\",\"inherited\":true},\"com.iplanet.services.debug.directory\":{\"value\":\"%BASE_DIR%/var/debug\",\"inherited\":true}},\"amconfig.header.mailserver\":{\"com.iplanet.am.smtphost\":{\"value\":\"localhost\",\"inherited\":true},\"com.iplanet.am.smtpport\":{\"value\":\"25\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"565723329\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "894"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.753Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "39c6616b0d9c6b956eb5a835961dc1be",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/sdk"
+        },
+        "response": {
+          "bodySize": 1310,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1310,
+            "text": "{\"_id\":\"04/properties/sdk\",\"_rev\":\"1506563030\",\"amconfig.header.datastore\":{\"com.sun.identity.sm.enableDataStoreNotification\":{\"value\":false,\"inherited\":true},\"com.sun.identity.sm.notification.threadpool.size\":{\"value\":\"1\",\"inherited\":true}},\"amconfig.header.eventservice\":{\"com.iplanet.am.event.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.event.connection.delay.between.retries\":{\"value\":\"3000\",\"inherited\":true},\"com.iplanet.am.event.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true},\"com.sun.am.event.connection.disable.list\":{\"value\":\"aci,um,sm\",\"inherited\":true}},\"amconfig.header.ldapconnection\":{\"com.iplanet.am.ldap.connection.num.retries\":{\"value\":\"3\",\"inherited\":true},\"com.iplanet.am.ldap.connection.delay.between.retries\":{\"value\":\"1000\",\"inherited\":true},\"com.iplanet.am.ldap.connection.ldap.error.codes.retries\":{\"value\":\"80,81,91\",\"inherited\":true}},\"amconfig.header.cachingreplica\":{\"com.iplanet.am.sdk.cache.maxSize\":{\"value\":\"10000\",\"inherited\":true}},\"amconfig.header.sdktimetoliveconfig\":{\"com.iplanet.am.sdk.cache.entry.expire.enabled\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.user.expire.time\":{\"value\":\"15\",\"inherited\":true},\"com.iplanet.am.sdk.cache.entry.default.expire.time\":{\"value\":\"30\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1506563030\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1310"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.759Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "5fd751d7a58a40c5cae9a6b3e5b5a191",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/security"
+        },
+        "response": {
+          "bodySize": 4177,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4177,
+            "text": "{\"_id\":\"04/properties/security\",\"_rev\":\"1381545338\",\"amconfig.header.encryption\":{\"am.encryption.pwd\":{\"value\":\"@AM_ENC_PWD@\",\"inherited\":true},\"com.iplanet.security.encryptor\":{\"value\":\"com.iplanet.services.util.JCEEncryption\",\"inherited\":true},\"com.iplanet.security.SecureRandomFactoryImpl\":{\"value\":\"com.iplanet.am.util.SecureRandomFactoryImpl\",\"inherited\":true},\"am.encryption.secret.enabled\":{\"value\":false,\"inherited\":true},\"am.encryption.secret.alias\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreFile\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keystoreType\":{\"value\":\"JCEKS\",\"inherited\":true},\"am.encryption.secret.keystorePass\":{\"value\":null,\"inherited\":true},\"am.encryption.secret.keyPass\":{\"value\":null,\"inherited\":true}},\"amconfig.header.validation\":{\"com.iplanet.services.comm.server.pllrequest.maxContentLength\":{\"value\":\"16384\",\"inherited\":true},\"com.iplanet.am.clientIPCheckEnabled\":{\"value\":false,\"inherited\":true}},\"amconfig.header.cookie\":{\"com.iplanet.am.cookie.name\":{\"value\":\"iPlanetDirectoryPro\",\"inherited\":true},\"com.iplanet.am.cookie.secure\":{\"value\":false,\"inherited\":true},\"com.iplanet.am.cookie.encode\":{\"value\":false,\"inherited\":true}},\"amconfig.header.securitykey\":{\"com.sun.identity.saml.xmlsig.keystore\":{\"value\":\"%BASE_DIR%/security/keystores/keystore.jceks\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storetype\":{\"value\":\"JCEKS\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.storepass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.storepass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.keypass\":{\"value\":\"%BASE_DIR%/security/secrets/default/.keypass\",\"inherited\":true},\"com.sun.identity.saml.xmlsig.certalias\":{\"value\":\"test\",\"inherited\":true}},\"amconfig.header.crlcache\":{\"com.sun.identity.crl.cache.directory.host\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.port\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.ssl\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.mtlsenabled\":{\"value\":false,\"inherited\":true},\"com.sun.identity.crl.cache.directory.user\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.password\":{\"value\":null,\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchlocs\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.crl.cache.directory.searchattr\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.ocsp.check\":{\"com.sun.identity.authentication.ocspCheck\":{\"value\":false,\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.url\":{\"value\":\"\",\"inherited\":true},\"com.sun.identity.authentication.ocsp.responder.nickname\":{\"value\":\"\",\"inherited\":true}},\"amconfig.header.deserialisationwhitelist\":{\"openam.deserialisation.classes.whitelist\":{\"value\":\"com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1381545338\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4177"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.766Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "480f802b104643aa04fa93d0c56e0290",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/session"
+        },
+        "response": {
+          "bodySize": 914,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 914,
+            "text": "{\"_id\":\"04/properties/session\",\"_rev\":\"857545830\",\"amconfig.header.sessionthresholds\":{\"org.forgerock.openam.session.service.access.persistence.caching.maxsize\":{\"value\":\"5000\",\"inherited\":true},\"com.iplanet.am.session.invalidsessionmaxtime\":{\"value\":\"3\",\"inherited\":true}},\"amconfig.header.sessionlogging\":{\"com.iplanet.am.stats.interval\":{\"value\":\"60\",\"inherited\":true},\"com.iplanet.services.stats.state\":{\"value\":\"file\",\"inherited\":true},\"com.iplanet.services.stats.directory\":{\"value\":\"%BASE_DIR%/var/stats\",\"inherited\":true},\"com.sun.am.session.enableHostLookUp\":{\"value\":false,\"inherited\":true}},\"amconfig.header.sessionnotification\":{\"com.iplanet.am.notification.threadpool.size\":{\"value\":\"10\",\"inherited\":true},\"com.iplanet.am.notification.threadpool.threshold\":{\"value\":\"5000\",\"inherited\":true}},\"amconfig.header.sessionvalidation\":{\"com.sun.am.session.caseInsensitiveDN\":{\"value\":true,\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"857545830\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "914"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.773Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "896d1b036e99334f57ddeb7b23c5aaec",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/04/properties/uma"
+        },
+        "response": {
+          "bodySize": 4121,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 4121,
+            "text": "{\"_id\":\"04/properties/uma\",\"_rev\":\"801752679\",\"amconfig.org.forgerock.services.resourcesets.store.common.section\":{\"org.forgerock.services.resourcesets.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.resourcesets.store.external.section\":{\"org.forgerock.services.resourcesets.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.resourcesets.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.resourcesets.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.common.section\":{\"org.forgerock.services.umaaudit.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.umaaudit.store.external.section\":{\"org.forgerock.services.umaaudit.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.umaaudit.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.umaaudit.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.common.section\":{\"org.forgerock.services.uma.pendingrequests.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.max.connections\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.pendingrequests.store.external.section\":{\"org.forgerock.services.uma.pendingrequests.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.pendingrequests.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.common.section\":{\"org.forgerock.services.uma.labels.store.location\":{\"value\":\"default\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.root.suffix\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.max.connections\":{\"value\":\"2\",\"inherited\":true}},\"amconfig.org.forgerock.services.uma.labels.store.external.section\":{\"org.forgerock.services.uma.labels.store.ssl.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.mtls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.starttls.enabled\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.directory.name\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.loginid\":{\"value\":\"\",\"inherited\":true},\"org.forgerock.services.uma.labels.store.password\":{\"value\":null,\"inherited\":true},\"org.forgerock.services.uma.labels.store.heartbeat\":{\"value\":\"10\",\"inherited\":true}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"801752679\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "4121"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.778Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "e622d264a11687d1d2818e6e640bd74f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 585,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/server-default/properties/advanced"
+        },
+        "response": {
+          "bodySize": 11880,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 11880,
+            "text": "{\"_id\":\"null/properties/advanced\",\"_rev\":\"1247243006\",\"com.iplanet.am.directory.ssl.enabled\":false,\"openam.auth.distAuthCookieName\":\"AMDistAuthCookie\",\"org.forgerock.services.default.store.max.connections\":\"\",\"org.forgerock.openam.ldap.dncache.expire.time\":\"0\",\"org.forgerock.openam.smtp.system.socket.write.timeout\":\"10000\",\"com.sun.identity.webcontainer\":\"WEB_CONTAINER\",\"com.sun.identity.security.checkcaller\":false,\"org.forgerock.services.cts.store.ttlsupport.exclusionlist\":\"\",\"org.forgerock.openam.ldap.keepalive.search.base\":\"\",\"org.forgerock.openam.idrepo.ldapv3.proxyauth.passwordreset.adminRequest\":\"isAdminPasswordChangeRequest\",\"openam.authentication.ignore_goto_during_logout\":false,\"com.sun.identity.saml.xmlsig.signatureprovider.class\":\"@XML_SIGNATURE_PROVIDER@\",\"openam.retained.http.request.headers\":\"X-DSAMEVersion\",\"com.sun.identity.url.readTimeout\":\"30000\",\"org.forgerock.openam.introspect.token.query.param.allowed\":false,\"openam.forbidden.to.copy.headers\":\"connection\",\"com.iplanet.am.lbcookie.value\":\"00\",\"com.sun.identity.plugin.log.class\":\"@LOG_PROVIDER_CLASS@\",\"com.iplanet.am.session.httpSession.enabled\":\"true\",\"com.sun.identity.saml.xmlsig.passwordDecoder\":\"@PASSWORD_DECODER_CLASS@\",\"org.forgerock.openam.scripting.maxinterpreterstackdepth\":\"10000\",\"com.iplanet.am.session.client.polling.enable\":false,\"com.iplanet.am.profile.port\":\"%SERVER_PORT%\",\"com.sun.identity.authentication.uniqueCookieName\":\"sunIdentityServerAuthNServer\",\"org.forgerock.openam.httpclienthandler.system.clients.pool.ttl\":\"-1\",\"com.iplanet.am.profile.host\":\"%SERVER_HOST%\",\"org.forgerock.openam.smtp.system.socket.read.timeout\":\"10000\",\"org.forgerock.openam.encryption.key.digest\":\"SHA1\",\"org.forgerock.openam.session.stateless.signing.allownone\":false,\"org.forgerock.openam.encryption.key.size\":\"128\",\"com.iplanet.am.logstatus\":\"ACTIVE\",\"org.forgerock.am.auth.trees.authenticate.identified.identity\":true,\"com.iplanet.am.jssproxy.trustAllServerCerts\":false,\"com.sun.identity.plugin.monitoring.saml2.class\":\"@MONSAML2_PROVIDER_CLASS@\",\"com.iplanet.am.installdir\":\"%BASE_DIR%\",\"org.forgerock.openam.trees.ids.cache.size\":\"50\",\"org.forgerock.openam.authentication.forceAuth.enabled\":false,\"org.forgerock.openam.httpclienthandler.system.proxy.uri\":\"\",\"com.sun.identity.jss.donotInstallAtHighestPriority\":true,\"org.forgerock.openam.idrepo.ldapv3.passwordpolicy.allowDiagnosticMessage\":false,\"com.sun.identity.enableUniqueSSOTokenCookie\":false,\"org.forgerock.services.cts.store.ttlsupport.enabled\":false,\"com.iplanet.am.serverMode\":true,\"org.forgerock.openam.timerpool.shutdown.retry.multiplier\":\"1.5\",\"dynamic.datastore.creation.enabled\":false,\"com.sun.identity.am.cookie.check\":false,\"org.forgerock.openam.core.resource.lookup.cache.enabled\":true,\"securidHelper.ports\":\"58943\",\"org.forgerock.openam.ldap.keepalive.search.filter\":\"(objectClass=*)\",\"org.forgerock.openam.saml2.authenticatorlookup.skewAllowance\":\"60\",\"org.forgerock.openam.url.connectTimeout\":\"1000\",\"com.sun.identity.plugin.monitoring.agent.class\":\"@MONAGENT_PROVIDER_CLASS@\",\"com.iplanet.am.buildVersion\":\"ForgeRock Access Management 7.5.0\",\"com.sun.identity.cookie.httponly\":true,\"org.forgerock.openam.sso.providers.list\":\"org.forgerock.openidconnect.ssoprovider.OpenIdConnectSSOProvider\",\"com.iplanet.am.pcookie.name\":\"DProPCookie\",\"com.sun.identity.policy.Policy.policy_evaluation_weights\":\"10:10:10\",\"org.forgerock.openam.secrets.special.user.passwords.format\":\"ENCRYPTED_PLAIN\",\"openam.auth.session_property_upgrader\":\"org.forgerock.openam.authentication.service.DefaultSessionPropertyUpgrader\",\"com.iplanet.am.session.client.polling.period\":\"180\",\"org.forgerock.openam.httpclienthandler.system.clients.connection.timeout\":\"10 seconds\",\"com.sun.identity.authentication.super.user\":\"uid=amAdmin,ou=People,%ROOT_SUFFIX%\",\"com.sun.identity.saml.xmlsig.keyprovider.class\":\"@XMLSIG_KEY_PROVIDER@\",\"org.forgerock.openam.timerpool.shutdown.retry.interval\":\"15000\",\"org.forgerock.services.openid.request.object.lifespan\":\"120000\",\"org.forgerock.am.auth.node.otp.inSharedState\":false,\"org.forgerock.openam.trees.consumedstatedata.cache.size\":\"15\",\"org.forgerock.openam.httpclienthandler.system.proxy.password\":null,\"org.forgerock.openam.showServletTraceInBrowser\":false,\"org.forgerock.openam.oauth2.checkIssuerForIdTokenInfo\":true,\"com.iplanet.am.version\":\"ForgeRock Access Management 7.5.0 Build 89116d59a1ebe73ed1931dd3649adb7f217cd06b (2024-March-28 16:00)\",\"com.iplanet.am.cookie.c66Encode\":true,\"org.forgerock.openam.radius.server.context.cache.size\":\"5000\",\"com.iplanet.am.jssproxy.checkSubjectAltName\":false,\"com.sun.identity.server.fqdnMap[hello]\":\"hello\",\"com.sun.am.event.notification.expire.time\":\"5\",\"com.sun.identity.server.fqdnMap[openam-frodo-dev.classic.com]\":\"openam-frodo-dev.classic.com\",\"org.forgerock.openam.httpclienthandler.system.clients.max.connections\":\"64\",\"openam.auth.version.header.enabled\":false,\"org.forgerock.openam.timerpool.shutdown.retry.limit\":\"3\",\"openam.serviceattributevalidator.classes.whitelist\":\"org.forgerock.openam.auth.nodes.validators.GreaterThanZeroValidator,org.forgerock.openam.auth.nodes.validators.HMACKeyLengthValidator,org.forgerock.openam.auth.nodes.validators.HmacSigningKeyValidator,org.forgerock.openam.auth.nodes.validators.PercentageValidator,org.forgerock.openam.auth.nodes.validators.QueryFilterValidator,org.forgerock.openam.auth.nodes.validators.SessionPropertyNameValidator,org.forgerock.openam.auth.nodes.validators.SessionPropertyValidator,org.forgerock.openam.auth.nodes.framework.validators.NodeValueValidator,org.forgerock.openam.audit.validation.PositiveIntegerValidator,org.forgerock.openam.authentication.modules.fr.oath.validators.AlphaNumericValidator,org.forgerock.openam.authentication.modules.fr.oath.validators.CodeLengthValidator,org.forgerock.openam.authentication.modules.persistentcookie.validation.SigningKeyValidator,com.sun.identity.common.configuration.DuplicateKeyMapValueValidator,com.sun.identity.common.configuration.AgentClientIpModeValueValidator,com.sun.identity.common.configuration.FilterModeValueValidator,com.sun.identity.common.configuration.GlobalMapValueValidator,com.sun.identity.common.configuration.ListValueValidator,com.sun.identity.common.configuration.MapValueValidator,com.sun.identity.common.configuration.ServerPropertyValidator,com.sun.identity.policy.ResourceComparatorValidator,com.sun.identity.sm.EmailValidator,com.sun.identity.sm.IPAddressValidator,com.sun.identity.sm.RequiredValueValidator,com.sun.identity.sm.ServerIDValidator,com.sun.identity.sm.SiteIDValidator,org.forgerock.openam.sm.validation.Base64EncodedBinaryValidator,org.forgerock.openam.sm.validation.BlankValueValidator,org.forgerock.openam.sm.validation.DurationValidator,org.forgerock.openam.sm.validation.EndpointValidator,org.forgerock.openam.sm.validation.HostnameValidator,org.forgerock.openam.sm.validation.PortValidator,org.forgerock.openam.sm.validation.SecretIdValidator,org.forgerock.openam.sm.validation.StatelessSessionSigningAlgorithmValidator,org.forgerock.openam.sm.validation.StringMapValidator,org.forgerock.openam.sm.validation.URLValidator,org.forgerock.openam.selfservice.config.KeyAliasValidator,org.forgerock.openam.sm.validation.UniqueIndexedValuesValidator,org.forgerock.openam.webhook.HttpHeaderValidator,org.forgerock.oauth2.core.ClientRedirectUriValidator\",\"org.forgerock.openam.core.sms.placeholder_api_enabled\":\"OFF\",\"org.forgerock.openam.session.service.persistence.deleteAsynchronously\":true,\"org.forgerock.openam.ldap.heartbeat.timeout\":\"10\",\"com.iplanet.security.SSLSocketFactoryImpl\":\"com.sun.identity.shared.ldap.factory.JSSESocketFactory\",\"com.sun.identity.session.repository.enableAttributeCompression\":false,\"org.forgerock.openam.httpclienthandler.system.nonProxyHosts\":\"localhost,127.*,[::1],0.0.0.0,[::0]\",\"org.forgerock.am.auth.chains.authindexuser.strict\":true,\"org.forgerock.security.entitlement.enforce.realm\":true,\"org.forgerock.allow.http.client.debug\":false,\"org.forgerock.openam.auth.transactionauth.returnErrorOnAuthFailure\":false,\"org.forgerock.openam.httpclienthandler.system.clients.retry.failed.requests.enabled\":true,\"org.forgerock.openam.authLevel.excludeRequiredOrRequisite\":false,\"org.forgerock.openam.redirecturlvalidator.maxUrlLength\":\"2000\",\"org.forgerock.openam.secrets.special.user.secret.refresh.seconds\":\"900\",\"com.iplanet.am.session.agentSessionIdleTime\":\"1440\",\"org.forgerock.openam.idm.attribute.names.lower.case\":false,\"org.forgerock.openam.ldap.secure.protocol.version\":\"TLSv1.3,TLSv1.2\",\"com.sun.identity.server.fqdnMap[openam]\":\"openam\",\"com.sun.identity.authentication.special.users\":\"cn=dsameuser,ou=DSAME Users,%ROOT_SUFFIX%|cn=amService-UrlAccessAgent,ou=DSAME Users,%ROOT_SUFFIX%\",\"org.forgerock.openam.httpclienthandler.system.clients.reuse.connections.enabled\":true,\"com.sun.identity.plugin.configuration.class\":\"@CONFIGURATION_PROVIDER_CLASS@\",\"com.iplanet.am.buildDate\":\"2024-March-28 16:00\",\"org.forgerock.openam.console.autocomplete.enabled\":true,\"com.sun.identity.monitoring\":\"off\",\"org.forgerock.openidconnect.ssoprovider.maxcachesize\":\"5000\",\"org.forgerock.openam.httpclienthandler.system.clients.response.timeout\":\"10 seconds\",\"org.forgerock.openam.request.max.bytes.entity.size\":\"1048576\",\"openam.session.case.sensitive.uuid\":false,\"com.sun.identity.cookie.samesite\":\"off\",\"org.forgerock.openam.xui.user.session.validation.enabled\":true,\"com.sun.identity.authentication.multiple.tabs.used\":false,\"openam.auth.destroy_session_after_upgrade\":true,\"org.forgerock.openam.session.stateless.encryption.method\":\"A128CBC-HS256\",\"com.sun.identity.plugin.session.class\":\"@SESSION_PROVIDER_CLASS@\",\"com.sun.identity.authentication.setCookieToAllDomains\":true,\"com.sun.identity.server.fqdnMap[localhost]\":\"localhost\",\"com.sun.identity.server.fqdnMap[secondDNS]\":\"secondDNS\",\"org.forgerock.services.cts.store.reaper.enabled\":true,\"org.forgerock.openam.httpclienthandler.system.proxy.username\":\"\",\"com.sun.identity.auth.cookieName\":\"AMAuthCookie\",\"com.sun.embedded.sync.servers\":\"on\",\"com.iplanet.am.daemons\":\"securid\",\"com.iplanet.am.jssproxy.resolveIPAddress\":false,\"openam.oauth2.client.jwt.encryption.algorithm.allow.list\":\"RSA-OAEP,RSA-OAEP-256,ECDH-ES\",\"com.sun.identity.policy.resultsCacheResourceCap\":\"20\",\"org.forgerock.openam.slf4j.enableTraceInMessage\":false,\"com.iplanet.am.buildRevision\":\"89116d59a1ebe73ed1931dd3649adb7f217cd06b\",\"com.sun.identity.policy.resultsCacheMaxSize\":\"10000\",\"com.sun.identity.sm.cache.ttl.enable\":false,\"com.sun.identity.session.repository.enableCompression\":false,\"org.forgerock.openam.session.stateless.rsa.padding\":\"RSA-OAEP-256\",\"com.sun.identity.server.fqdnMap[dnsfirst]\":\"dnsfirst\",\"openam.forbidden.to.copy.request.headers\":\"connection\",\"org.forgerock.openam.notifications.agents.enabled\":true,\"com.iplanet.am.jssproxy.SSLTrustHostList\":\"\",\"org.forgerock.openam.devices.recovery.use_insecure_storage\":false,\"com.sun.identity.sm.cache.ttl\":\"30\",\"org.forgerock.openam.audit.identity.activity.events.blacklist\":\"AM-ACCESS-ATTEMPT,AM-IDENTITY-CHANGE,AM-GROUP-CHANGE\",\"org.forgerock.openam.smtp.system.connect.timeout\":\"10000\",\"org.forgerock.openam.encryption.key.iterations\":\"10000\",\"openam.cdm.default.charset\":\"UTF-8\",\"com.sun.identity.session.repository.enableEncryption\":false,\"org.forgerock.security.oauth2.enforce.sub.claim.uniqueness\":true,\"org.forgerock.services.default.store.min.connections\":\"\",\"com.sun.identity.password.deploymentDescriptor\":\"%SERVER_URI%\",\"com.sun.identity.monitoring.local.conn.server.url\":\"service:jmx:rmi://\",\"com.sun.identity.plugin.datastore.class.default\":\"@DATASTORE_PROVIDER_CLASS@\",\"com.iplanet.am.lbcookie.name\":\"amlbcookie\",\"org.forgerock.openam.audit.additionalSuccessStatusCodesEnabled\":true,\"openam.oauth2.client.jwt.unreasonable.lifetime.limit.minutes\":\"30\",\"org.forgerock.openam.httpclienthandler.system.proxy.enabled\":false,\"openam.retained.http.headers\":\"X-DSAMEVersion\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1247243006\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.784Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "db874776b6ddc4cab171e9d5ad3a86be",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 580,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/server-default/properties/cts"
+        },
+        "response": {
+          "bodySize": 791,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 791,
+            "text": "{\"_id\":\"null/properties/cts\",\"_rev\":\"78019458\",\"amconfig.org.forgerock.services.cts.store.common.section\":{\"org.forgerock.services.cts.store.location\":\"default\",\"org.forgerock.services.cts.store.root.suffix\":\"\",\"org.forgerock.services.cts.store.max.connections\":\"100\",\"org.forgerock.services.cts.store.page.size\":\"0\",\"org.forgerock.services.cts.store.vlv.page.size\":\"1000\"},\"amconfig.org.forgerock.services.cts.store.external.section\":{\"org.forgerock.services.cts.store.ssl.enabled\":\"\",\"org.forgerock.services.cts.store.mtls.enabled\":\"\",\"org.forgerock.services.cts.store.starttls.enabled\":\"\",\"org.forgerock.services.cts.store.directory.name\":\"\",\"org.forgerock.services.cts.store.loginid\":\"\",\"org.forgerock.services.cts.store.password\":null,\"org.forgerock.services.cts.store.heartbeat\":\"10\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"78019458\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "791"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 483,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.791Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "c93f015ddf74f429eced0549ef6aeafa",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 599,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/server-default/properties/directoryConfiguration"
+        },
+        "response": {
+          "bodySize": 107,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 107,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"Unrecognised server properties section directoryConfiguration\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "107"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 465,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.797Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "2d165ac1899dcae019eaa8fb6069be95",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/server-default/properties/general"
+        },
+        "response": {
+          "bodySize": 597,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 597,
+            "text": "{\"_id\":\"null/properties/general\",\"_rev\":\"6642759\",\"amconfig.header.installdir\":{\"com.iplanet.services.configpath\":\"%BASE_DIR%\",\"com.iplanet.am.locale\":\"en_US\",\"com.sun.identity.client.notification.url\":\"%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice\",\"com.iplanet.am.util.xml.validating\":\"off\"},\"amconfig.header.debug\":{\"com.iplanet.services.debug.level\":\"error\",\"com.sun.services.debug.mergeall\":\"off\",\"com.iplanet.services.debug.directory\":\"%BASE_DIR%/var/debug\"},\"amconfig.header.mailserver\":{\"com.iplanet.am.smtphost\":\"localhost\",\"com.iplanet.am.smtpport\":\"25\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"6642759\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "597"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 482,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.823Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "341075ec107a360d509c9417c6af2818",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 580,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/server-default/properties/sdk"
+        },
+        "response": {
+          "bodySize": 961,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 961,
+            "text": "{\"_id\":\"null/properties/sdk\",\"_rev\":\"1846611054\",\"amconfig.header.datastore\":{\"com.sun.identity.sm.enableDataStoreNotification\":false,\"com.sun.identity.sm.notification.threadpool.size\":\"1\"},\"amconfig.header.eventservice\":{\"com.iplanet.am.event.connection.num.retries\":\"3\",\"com.iplanet.am.event.connection.delay.between.retries\":\"3000\",\"com.iplanet.am.event.connection.ldap.error.codes.retries\":\"80,81,91\",\"com.sun.am.event.connection.disable.list\":\"aci,um,sm\"},\"amconfig.header.ldapconnection\":{\"com.iplanet.am.ldap.connection.num.retries\":\"3\",\"com.iplanet.am.ldap.connection.delay.between.retries\":\"1000\",\"com.iplanet.am.ldap.connection.ldap.error.codes.retries\":\"80,81,91\"},\"amconfig.header.cachingreplica\":{\"com.iplanet.am.sdk.cache.maxSize\":\"10000\"},\"amconfig.header.sdktimetoliveconfig\":{\"com.iplanet.am.sdk.cache.entry.expire.enabled\":false,\"com.iplanet.am.sdk.cache.entry.user.expire.time\":\"15\",\"com.iplanet.am.sdk.cache.entry.default.expire.time\":\"30\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1846611054\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "961"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.831Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "c1517199158e2db3b6509ac8d51ad7fc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 585,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/server-default/properties/security"
+        },
+        "response": {
+          "bodySize": 3190,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 3190,
+            "text": "{\"_id\":\"null/properties/security\",\"_rev\":\"1962770591\",\"amconfig.header.encryption\":{\"am.encryption.pwd\":\"@AM_ENC_PWD@\",\"com.iplanet.security.encryptor\":\"com.iplanet.services.util.JCEEncryption\",\"com.iplanet.security.SecureRandomFactoryImpl\":\"com.iplanet.am.util.SecureRandomFactoryImpl\",\"am.encryption.secret.enabled\":false,\"am.encryption.secret.keystoreType\":\"JCEKS\"},\"amconfig.header.validation\":{\"com.iplanet.services.comm.server.pllrequest.maxContentLength\":\"16384\",\"com.iplanet.am.clientIPCheckEnabled\":false},\"amconfig.header.cookie\":{\"com.iplanet.am.cookie.name\":\"iPlanetDirectoryPro\",\"com.iplanet.am.cookie.secure\":false,\"com.iplanet.am.cookie.encode\":false},\"amconfig.header.securitykey\":{\"com.sun.identity.saml.xmlsig.keystore\":\"%BASE_DIR%/security/keystores/keystore.jceks\",\"com.sun.identity.saml.xmlsig.storetype\":\"JCEKS\",\"com.sun.identity.saml.xmlsig.storepass\":\"%BASE_DIR%/security/secrets/default/.storepass\",\"com.sun.identity.saml.xmlsig.keypass\":\"%BASE_DIR%/security/secrets/default/.keypass\",\"com.sun.identity.saml.xmlsig.certalias\":\"test\"},\"amconfig.header.crlcache\":{\"com.sun.identity.crl.cache.directory.host\":\"\",\"com.sun.identity.crl.cache.directory.port\":\"\",\"com.sun.identity.crl.cache.directory.ssl\":false,\"com.sun.identity.crl.cache.directory.mtlsenabled\":false,\"com.sun.identity.crl.cache.directory.user\":\"\",\"com.sun.identity.crl.cache.directory.password\":null,\"com.sun.identity.crl.cache.directory.searchlocs\":\"\",\"com.sun.identity.crl.cache.directory.searchattr\":\"\"},\"amconfig.header.ocsp.check\":{\"com.sun.identity.authentication.ocspCheck\":false,\"com.sun.identity.authentication.ocsp.responder.url\":\"\",\"com.sun.identity.authentication.ocsp.responder.nickname\":\"\"},\"amconfig.header.deserialisationwhitelist\":{\"openam.deserialisation.classes.whitelist\":\"com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1962770591\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "3190"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.839Z",
+        "time": 4,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4
+        }
+      },
+      {
+        "_id": "f25f59cd8c87b00fe97dc737bae572a7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/server-default/properties/session"
+        },
+        "response": {
+          "bodySize": 673,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 673,
+            "text": "{\"_id\":\"null/properties/session\",\"_rev\":\"875396629\",\"amconfig.header.sessionthresholds\":{\"org.forgerock.openam.session.service.access.persistence.caching.maxsize\":\"5000\",\"com.iplanet.am.session.invalidsessionmaxtime\":\"3\"},\"amconfig.header.sessionlogging\":{\"com.iplanet.am.stats.interval\":\"60\",\"com.iplanet.services.stats.state\":\"file\",\"com.iplanet.services.stats.directory\":\"%BASE_DIR%/var/stats\",\"com.sun.am.session.enableHostLookUp\":false},\"amconfig.header.sessionnotification\":{\"com.iplanet.am.notification.threadpool.size\":\"10\",\"com.iplanet.am.notification.threadpool.threshold\":\"5000\"},\"amconfig.header.sessionvalidation\":{\"com.sun.am.session.caseInsensitiveDN\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"875396629\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "673"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 484,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.847Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "040321953539e88019711b33160bb408",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 580,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers/server-default/properties/uma"
+        },
+        "response": {
+          "bodySize": 3043,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 3043,
+            "text": "{\"_id\":\"null/properties/uma\",\"_rev\":\"342218910\",\"amconfig.org.forgerock.services.resourcesets.store.common.section\":{\"org.forgerock.services.resourcesets.store.location\":\"default\",\"org.forgerock.services.resourcesets.store.root.suffix\":\"\",\"org.forgerock.services.resourcesets.store.max.connections\":\"10\"},\"amconfig.org.forgerock.services.resourcesets.store.external.section\":{\"org.forgerock.services.resourcesets.store.ssl.enabled\":\"\",\"org.forgerock.services.resourcesets.store.mtls.enabled\":\"\",\"org.forgerock.services.resourcesets.store.starttls.enabled\":\"\",\"org.forgerock.services.resourcesets.store.directory.name\":\"\",\"org.forgerock.services.resourcesets.store.loginid\":\"\",\"org.forgerock.services.resourcesets.store.password\":null,\"org.forgerock.services.resourcesets.store.heartbeat\":\"10\"},\"amconfig.org.forgerock.services.umaaudit.store.common.section\":{\"org.forgerock.services.umaaudit.store.location\":\"default\",\"org.forgerock.services.umaaudit.store.root.suffix\":\"\",\"org.forgerock.services.umaaudit.store.max.connections\":\"10\"},\"amconfig.org.forgerock.services.umaaudit.store.external.section\":{\"org.forgerock.services.umaaudit.store.ssl.enabled\":\"\",\"org.forgerock.services.umaaudit.store.mtls.enabled\":\"\",\"org.forgerock.services.umaaudit.store.starttls.enabled\":\"\",\"org.forgerock.services.umaaudit.store.directory.name\":\"\",\"org.forgerock.services.umaaudit.store.loginid\":\"\",\"org.forgerock.services.umaaudit.store.password\":null,\"org.forgerock.services.umaaudit.store.heartbeat\":\"10\"},\"amconfig.org.forgerock.services.uma.pendingrequests.store.common.section\":{\"org.forgerock.services.uma.pendingrequests.store.location\":\"default\",\"org.forgerock.services.uma.pendingrequests.store.root.suffix\":\"\",\"org.forgerock.services.uma.pendingrequests.store.max.connections\":\"10\"},\"amconfig.org.forgerock.services.uma.pendingrequests.store.external.section\":{\"org.forgerock.services.uma.pendingrequests.store.ssl.enabled\":\"\",\"org.forgerock.services.uma.pendingrequests.store.mtls.enabled\":\"\",\"org.forgerock.services.uma.pendingrequests.store.starttls.enabled\":\"\",\"org.forgerock.services.uma.pendingrequests.store.directory.name\":\"\",\"org.forgerock.services.uma.pendingrequests.store.loginid\":\"\",\"org.forgerock.services.uma.pendingrequests.store.password\":null,\"org.forgerock.services.uma.pendingrequests.store.heartbeat\":\"10\"},\"amconfig.org.forgerock.services.uma.labels.store.common.section\":{\"org.forgerock.services.uma.labels.store.location\":\"default\",\"org.forgerock.services.uma.labels.store.root.suffix\":\"\",\"org.forgerock.services.uma.labels.store.max.connections\":\"2\"},\"amconfig.org.forgerock.services.uma.labels.store.external.section\":{\"org.forgerock.services.uma.labels.store.ssl.enabled\":\"\",\"org.forgerock.services.uma.labels.store.mtls.enabled\":\"\",\"org.forgerock.services.uma.labels.store.starttls.enabled\":\"\",\"org.forgerock.services.uma.labels.store.directory.name\":\"\",\"org.forgerock.services.uma.labels.store.loginid\":\"\",\"org.forgerock.services.uma.labels.store.password\":null,\"org.forgerock.services.uma.labels.store.heartbeat\":\"10\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"342218910\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "3043"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 485,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.853Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/ServerOps_696203346/readServers_2505677272/1-Read-Servers_2574574570/recording.har
+++ b/src/test/mock-recordings/ServerOps_696203346/readServers_2505677272/1-Read-Servers_2574574570/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "ServerOps/readServers()/1: Read Servers",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "76b32eba382ec9176be262a1048cdec2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-6b1edd39-36d4-4b5b-911f-cb4367c2be16"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/servers?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 383,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 383,
+            "text": "{\"result\":[{\"_id\":\"01\",\"_rev\":\"-931963190\",\"url\":\"http://localhost:8080/am\",\"siteName\":null},{\"_id\":\"03\",\"_rev\":\"-931738263\",\"url\":\"http://localhost:8081/am\",\"siteName\":null},{\"_id\":\"04\",\"_rev\":\"-931739121\",\"url\":\"http://localhost:8082/am\",\"siteName\":null}],\"resultCount\":3,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "383"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 09 Sep 2024 22:20:25 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-09-09T22:20:25.399Z",
+        "time": 8,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 8
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/snapshots/ops/classic/ServerOps.test.js.snap
+++ b/src/test/snapshots/ops/classic/ServerOps.test.js.snap
@@ -1,0 +1,3912 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ServerOps createServerExportTemplate() 1: Create Server Export Template 1`] = `
+{
+  "defaultProperties": {},
+  "meta": Any<Object>,
+  "server": {},
+}
+`;
+
+exports[`ServerOps exportServers() 1: Export Servers without default properties 1`] = `
+{
+  "defaultProperties": {},
+  "meta": Any<Object>,
+  "server": {
+    "01": {
+      "_id": "01",
+      "_rev": "-931963190",
+      "properties": {
+        "advanced": {
+          "_id": "01/properties/advanced",
+          "_rev": "1998658293",
+          "bootstrap.file": "/home/prestonhales/.openamcfg/AMConfig_usr_local_tomcat_webapps_am_",
+          "com.iplanet.am.lbcookie.value": "01",
+          "com.iplanet.am.serverMode": true,
+          "com.iplanet.security.SSLSocketFactoryImpl": "com.sun.identity.shared.ldap.factory.JSSESocketFactory",
+          "com.sun.embedded.replicationport": "",
+          "com.sun.embedded.sync.servers": "on",
+          "com.sun.identity.common.systemtimerpool.size": "3",
+          "com.sun.identity.sm.sms_object_class_name": "com.sun.identity.sm.SmsWrapperObject",
+          "com.sun.identity.urlconnection.useCache": false,
+          "opensso.protocol.handler.pkgs": "",
+          "org.forgerock.embedded.dsadminport": "4444",
+        },
+        "cts": {
+          "_id": "01/properties/cts",
+          "_rev": "920580190",
+          "amconfig.org.forgerock.services.cts.store.common.section": {
+            "org.forgerock.services.cts.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.cts.store.max.connections": {
+              "inherited": true,
+              "value": "100",
+            },
+            "org.forgerock.services.cts.store.page.size": {
+              "inherited": true,
+              "value": "0",
+            },
+            "org.forgerock.services.cts.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.vlv.page.size": {
+              "inherited": true,
+              "value": "1000",
+            },
+          },
+          "amconfig.org.forgerock.services.cts.store.external.section": {
+            "org.forgerock.services.cts.store.affinity.enabled": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.cts.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+        "directoryConfiguration": {
+          "_id": "01/properties/directoryConfiguration",
+          "_rev": "465754882",
+          "directoryConfiguration": {
+            "bindDn": "cn=Directory Manager",
+            "bindPassword": null,
+            "maxConnectionPool": 10,
+            "minConnectionPool": 1,
+            "mtlsAlias": "",
+            "mtlsEnabled": false,
+            "mtlsKeyPasswordFile": "",
+            "mtlsKeyStoreFile": "",
+            "mtlsKeyStorePasswordFile": "",
+            "mtlsKeyStoreType": null,
+          },
+          "directoryServers": [
+            {
+              "connectionType": "SSL",
+              "hostName": "localhost",
+              "portNumber": "50636",
+              "serverName": "Server1",
+            },
+          ],
+        },
+        "general": {
+          "_id": "01/properties/general",
+          "_rev": "116018532",
+          "amconfig.header.debug": {
+            "com.iplanet.services.debug.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/debug",
+            },
+            "com.iplanet.services.debug.level": {
+              "inherited": false,
+              "value": "warning",
+            },
+            "com.sun.services.debug.mergeall": {
+              "inherited": false,
+              "value": "off",
+            },
+          },
+          "amconfig.header.installdir": {
+            "com.iplanet.am.locale": {
+              "inherited": false,
+              "value": "en_US",
+            },
+            "com.iplanet.am.util.xml.validating": {
+              "inherited": true,
+              "value": "off",
+            },
+            "com.iplanet.services.configpath": {
+              "inherited": false,
+              "value": "/home/prestonhales/am",
+            },
+            "com.sun.identity.client.notification.url": {
+              "inherited": true,
+              "value": "%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice",
+            },
+          },
+          "amconfig.header.mailserver": {
+            "com.iplanet.am.smtphost": {
+              "inherited": true,
+              "value": "localhost",
+            },
+            "com.iplanet.am.smtpport": {
+              "inherited": true,
+              "value": "25",
+            },
+          },
+          "amconfig.header.site": {
+            "singleChoiceSite": "[Empty]",
+          },
+        },
+        "sdk": {
+          "_id": "01/properties/sdk",
+          "_rev": "2030263514",
+          "amconfig.header.cachingreplica": {
+            "com.iplanet.am.sdk.cache.maxSize": {
+              "inherited": true,
+              "value": "10000",
+            },
+          },
+          "amconfig.header.datastore": {
+            "com.sun.identity.sm.enableDataStoreNotification": {
+              "inherited": false,
+              "value": true,
+            },
+            "com.sun.identity.sm.notification.threadpool.size": {
+              "inherited": true,
+              "value": "1",
+            },
+          },
+          "amconfig.header.eventservice": {
+            "com.iplanet.am.event.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "3000",
+            },
+            "com.iplanet.am.event.connection.ldap.error.codes.retries": {
+              "inherited": true,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.event.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+            "com.sun.am.event.connection.disable.list": {
+              "inherited": false,
+              "value": "aci,um",
+            },
+          },
+          "amconfig.header.ldapconnection": {
+            "com.iplanet.am.ldap.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "1000",
+            },
+            "com.iplanet.am.ldap.connection.ldap.error.codes.retries": {
+              "inherited": false,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.ldap.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+          },
+          "amconfig.header.sdktimetoliveconfig": {
+            "com.iplanet.am.sdk.cache.entry.default.expire.time": {
+              "inherited": true,
+              "value": "30",
+            },
+            "com.iplanet.am.sdk.cache.entry.expire.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.sdk.cache.entry.user.expire.time": {
+              "inherited": true,
+              "value": "15",
+            },
+          },
+        },
+        "security": {
+          "_id": "01/properties/security",
+          "_rev": "692941387",
+          "amconfig.header.cookie": {
+            "com.iplanet.am.cookie.encode": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.cookie.name": {
+              "inherited": true,
+              "value": "iPlanetDirectoryPro",
+            },
+            "com.iplanet.am.cookie.secure": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.crlcache": {
+            "com.sun.identity.crl.cache.directory.host": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.mtlsenabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "com.sun.identity.crl.cache.directory.port": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchattr": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchlocs": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.ssl": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.user": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.header.deserialisationwhitelist": {
+            "openam.deserialisation.classes.whitelist": {
+              "inherited": true,
+              "value": "com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction",
+            },
+          },
+          "amconfig.header.encryption": {
+            "am.encryption.pwd": {
+              "inherited": false,
+              "value": "efSYcwIhr7uKH30rgciGTVTFzb63LhYu",
+            },
+            "am.encryption.secret.alias": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "am.encryption.secret.keyPass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreFile": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystorePass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreType": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+            "com.iplanet.security.SecureRandomFactoryImpl": {
+              "inherited": true,
+              "value": "com.iplanet.am.util.SecureRandomFactoryImpl",
+            },
+            "com.iplanet.security.encryptor": {
+              "inherited": true,
+              "value": "com.iplanet.services.util.JCEEncryption",
+            },
+          },
+          "amconfig.header.ocsp.check": {
+            "com.sun.identity.authentication.ocsp.responder.nickname": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocsp.responder.url": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocspCheck": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.securitykey": {
+            "com.sun.identity.saml.xmlsig.certalias": {
+              "inherited": true,
+              "value": "test",
+            },
+            "com.sun.identity.saml.xmlsig.keypass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.keypass",
+            },
+            "com.sun.identity.saml.xmlsig.keystore": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/keystores/keystore.jceks",
+            },
+            "com.sun.identity.saml.xmlsig.storepass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.storepass",
+            },
+            "com.sun.identity.saml.xmlsig.storetype": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+          },
+          "amconfig.header.validation": {
+            "com.iplanet.am.clientIPCheckEnabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.services.comm.server.pllrequest.maxContentLength": {
+              "inherited": true,
+              "value": "16384",
+            },
+          },
+        },
+        "session": {
+          "_id": "01/properties/session",
+          "_rev": "1187593890",
+          "amconfig.header.sessionlogging": {
+            "com.iplanet.am.stats.interval": {
+              "inherited": true,
+              "value": "60",
+            },
+            "com.iplanet.services.stats.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/stats",
+            },
+            "com.iplanet.services.stats.state": {
+              "inherited": true,
+              "value": "file",
+            },
+            "com.sun.am.session.enableHostLookUp": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.sessionnotification": {
+            "com.iplanet.am.notification.threadpool.size": {
+              "inherited": true,
+              "value": "10",
+            },
+            "com.iplanet.am.notification.threadpool.threshold": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionthresholds": {
+            "com.iplanet.am.session.invalidsessionmaxtime": {
+              "inherited": true,
+              "value": "3",
+            },
+            "org.forgerock.openam.session.service.access.persistence.caching.maxsize": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionvalidation": {
+            "com.sun.am.session.caseInsensitiveDN": {
+              "inherited": true,
+              "value": true,
+            },
+          },
+        },
+        "uma": {
+          "_id": "01/properties/uma",
+          "_rev": "1126968974",
+          "amconfig.org.forgerock.services.resourcesets.store.common.section": {
+            "org.forgerock.services.resourcesets.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.resourcesets.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.resourcesets.store.external.section": {
+            "org.forgerock.services.resourcesets.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.resourcesets.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.common.section": {
+            "org.forgerock.services.uma.labels.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.labels.store.max.connections": {
+              "inherited": true,
+              "value": "2",
+            },
+            "org.forgerock.services.uma.labels.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.external.section": {
+            "org.forgerock.services.uma.labels.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.labels.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.labels.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.common.section": {
+            "org.forgerock.services.uma.pendingrequests.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.external.section": {
+            "org.forgerock.services.uma.pendingrequests.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.pendingrequests.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.common.section": {
+            "org.forgerock.services.umaaudit.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.umaaudit.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.external.section": {
+            "org.forgerock.services.umaaudit.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.umaaudit.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+      },
+      "siteName": null,
+      "url": "http://localhost:8080/am",
+    },
+    "03": {
+      "_id": "03",
+      "_rev": "-931738263",
+      "properties": {
+        "advanced": {
+          "_id": "03/properties/advanced",
+          "_rev": "133638345",
+          "com.iplanet.am.lbcookie.value": "03",
+        },
+        "cts": {
+          "_id": "03/properties/cts",
+          "_rev": "1597466663",
+          "amconfig.org.forgerock.services.cts.store.common.section": {
+            "org.forgerock.services.cts.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.cts.store.max.connections": {
+              "inherited": true,
+              "value": "100",
+            },
+            "org.forgerock.services.cts.store.page.size": {
+              "inherited": true,
+              "value": "0",
+            },
+            "org.forgerock.services.cts.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.vlv.page.size": {
+              "inherited": true,
+              "value": "1000",
+            },
+          },
+          "amconfig.org.forgerock.services.cts.store.external.section": {
+            "org.forgerock.services.cts.store.affinity.enabled": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.cts.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+        "directoryConfiguration": {
+          "_id": "03/properties/directoryConfiguration",
+          "_rev": "1465113540",
+          "directoryConfiguration": {
+            "bindDn": "cn=Directory Manager",
+            "bindPassword": null,
+            "maxConnectionPool": 10,
+            "minConnectionPool": 1,
+            "mtlsAlias": "",
+            "mtlsEnabled": false,
+            "mtlsKeyPasswordFile": "",
+            "mtlsKeyStoreFile": "",
+            "mtlsKeyStorePasswordFile": "",
+            "mtlsKeyStoreType": null,
+          },
+          "directoryServers": [
+            {
+              "connectionType": "SSL",
+              "hostName": "localhost",
+              "portNumber": "50636",
+              "serverName": "Server1",
+            },
+          ],
+        },
+        "general": {
+          "_id": "03/properties/general",
+          "_rev": "2025051123",
+          "amconfig.header.debug": {
+            "com.iplanet.services.debug.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/debug",
+            },
+            "com.iplanet.services.debug.level": {
+              "inherited": true,
+              "value": "error",
+            },
+            "com.sun.services.debug.mergeall": {
+              "inherited": true,
+              "value": "off",
+            },
+          },
+          "amconfig.header.installdir": {
+            "com.iplanet.am.locale": {
+              "inherited": true,
+              "value": "en_US",
+            },
+            "com.iplanet.am.util.xml.validating": {
+              "inherited": true,
+              "value": "off",
+            },
+            "com.iplanet.services.configpath": {
+              "inherited": true,
+              "value": "%BASE_DIR%",
+            },
+            "com.sun.identity.client.notification.url": {
+              "inherited": true,
+              "value": "%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice",
+            },
+          },
+          "amconfig.header.mailserver": {
+            "com.iplanet.am.smtphost": {
+              "inherited": true,
+              "value": "localhost",
+            },
+            "com.iplanet.am.smtpport": {
+              "inherited": true,
+              "value": "25",
+            },
+          },
+          "amconfig.header.site": {
+            "singleChoiceSite": "[Empty]",
+          },
+        },
+        "sdk": {
+          "_id": "03/properties/sdk",
+          "_rev": "433248219",
+          "amconfig.header.cachingreplica": {
+            "com.iplanet.am.sdk.cache.maxSize": {
+              "inherited": true,
+              "value": "10000",
+            },
+          },
+          "amconfig.header.datastore": {
+            "com.sun.identity.sm.enableDataStoreNotification": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.sm.notification.threadpool.size": {
+              "inherited": true,
+              "value": "1",
+            },
+          },
+          "amconfig.header.eventservice": {
+            "com.iplanet.am.event.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "3000",
+            },
+            "com.iplanet.am.event.connection.ldap.error.codes.retries": {
+              "inherited": true,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.event.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+            "com.sun.am.event.connection.disable.list": {
+              "inherited": true,
+              "value": "aci,um,sm",
+            },
+          },
+          "amconfig.header.ldapconnection": {
+            "com.iplanet.am.ldap.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "1000",
+            },
+            "com.iplanet.am.ldap.connection.ldap.error.codes.retries": {
+              "inherited": true,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.ldap.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+          },
+          "amconfig.header.sdktimetoliveconfig": {
+            "com.iplanet.am.sdk.cache.entry.default.expire.time": {
+              "inherited": true,
+              "value": "30",
+            },
+            "com.iplanet.am.sdk.cache.entry.expire.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.sdk.cache.entry.user.expire.time": {
+              "inherited": true,
+              "value": "15",
+            },
+          },
+        },
+        "security": {
+          "_id": "03/properties/security",
+          "_rev": "718869184",
+          "amconfig.header.cookie": {
+            "com.iplanet.am.cookie.encode": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.cookie.name": {
+              "inherited": true,
+              "value": "iPlanetDirectoryPro",
+            },
+            "com.iplanet.am.cookie.secure": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.crlcache": {
+            "com.sun.identity.crl.cache.directory.host": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.mtlsenabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "com.sun.identity.crl.cache.directory.port": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchattr": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchlocs": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.ssl": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.user": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.header.deserialisationwhitelist": {
+            "openam.deserialisation.classes.whitelist": {
+              "inherited": true,
+              "value": "com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction",
+            },
+          },
+          "amconfig.header.encryption": {
+            "am.encryption.pwd": {
+              "inherited": true,
+              "value": "@AM_ENC_PWD@",
+            },
+            "am.encryption.secret.alias": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "am.encryption.secret.keyPass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreFile": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystorePass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreType": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+            "com.iplanet.security.SecureRandomFactoryImpl": {
+              "inherited": true,
+              "value": "com.iplanet.am.util.SecureRandomFactoryImpl",
+            },
+            "com.iplanet.security.encryptor": {
+              "inherited": true,
+              "value": "com.iplanet.services.util.JCEEncryption",
+            },
+          },
+          "amconfig.header.ocsp.check": {
+            "com.sun.identity.authentication.ocsp.responder.nickname": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocsp.responder.url": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocspCheck": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.securitykey": {
+            "com.sun.identity.saml.xmlsig.certalias": {
+              "inherited": true,
+              "value": "test",
+            },
+            "com.sun.identity.saml.xmlsig.keypass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.keypass",
+            },
+            "com.sun.identity.saml.xmlsig.keystore": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/keystores/keystore.jceks",
+            },
+            "com.sun.identity.saml.xmlsig.storepass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.storepass",
+            },
+            "com.sun.identity.saml.xmlsig.storetype": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+          },
+          "amconfig.header.validation": {
+            "com.iplanet.am.clientIPCheckEnabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.services.comm.server.pllrequest.maxContentLength": {
+              "inherited": true,
+              "value": "16384",
+            },
+          },
+        },
+        "session": {
+          "_id": "03/properties/session",
+          "_rev": "1267016628",
+          "amconfig.header.sessionlogging": {
+            "com.iplanet.am.stats.interval": {
+              "inherited": true,
+              "value": "60",
+            },
+            "com.iplanet.services.stats.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/stats",
+            },
+            "com.iplanet.services.stats.state": {
+              "inherited": true,
+              "value": "file",
+            },
+            "com.sun.am.session.enableHostLookUp": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.sessionnotification": {
+            "com.iplanet.am.notification.threadpool.size": {
+              "inherited": true,
+              "value": "10",
+            },
+            "com.iplanet.am.notification.threadpool.threshold": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionthresholds": {
+            "com.iplanet.am.session.invalidsessionmaxtime": {
+              "inherited": true,
+              "value": "3",
+            },
+            "org.forgerock.openam.session.service.access.persistence.caching.maxsize": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionvalidation": {
+            "com.sun.am.session.caseInsensitiveDN": {
+              "inherited": true,
+              "value": true,
+            },
+          },
+        },
+        "uma": {
+          "_id": "03/properties/uma",
+          "_rev": "302025085",
+          "amconfig.org.forgerock.services.resourcesets.store.common.section": {
+            "org.forgerock.services.resourcesets.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.resourcesets.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.resourcesets.store.external.section": {
+            "org.forgerock.services.resourcesets.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.resourcesets.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.common.section": {
+            "org.forgerock.services.uma.labels.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.labels.store.max.connections": {
+              "inherited": true,
+              "value": "2",
+            },
+            "org.forgerock.services.uma.labels.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.external.section": {
+            "org.forgerock.services.uma.labels.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.labels.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.labels.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.common.section": {
+            "org.forgerock.services.uma.pendingrequests.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.external.section": {
+            "org.forgerock.services.uma.pendingrequests.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.pendingrequests.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.common.section": {
+            "org.forgerock.services.umaaudit.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.umaaudit.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.external.section": {
+            "org.forgerock.services.umaaudit.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.umaaudit.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+      },
+      "siteName": null,
+      "url": "http://localhost:8081/am",
+    },
+    "04": {
+      "_id": "04",
+      "_rev": "-931739121",
+      "properties": {
+        "advanced": {
+          "_id": "04/properties/advanced",
+          "_rev": "1053589086",
+          "com.iplanet.am.lbcookie.value": "04",
+        },
+        "cts": {
+          "_id": "04/properties/cts",
+          "_rev": "1094254838",
+          "amconfig.org.forgerock.services.cts.store.common.section": {
+            "org.forgerock.services.cts.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.cts.store.max.connections": {
+              "inherited": true,
+              "value": "100",
+            },
+            "org.forgerock.services.cts.store.page.size": {
+              "inherited": true,
+              "value": "0",
+            },
+            "org.forgerock.services.cts.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.vlv.page.size": {
+              "inherited": true,
+              "value": "1000",
+            },
+          },
+          "amconfig.org.forgerock.services.cts.store.external.section": {
+            "org.forgerock.services.cts.store.affinity.enabled": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.cts.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+        "directoryConfiguration": {
+          "_id": "04/properties/directoryConfiguration",
+          "_rev": "1832703833",
+          "directoryConfiguration": {
+            "bindDn": "cn=Directory Manager",
+            "bindPassword": null,
+            "maxConnectionPool": 10,
+            "minConnectionPool": 1,
+            "mtlsAlias": "",
+            "mtlsEnabled": false,
+            "mtlsKeyPasswordFile": "",
+            "mtlsKeyStoreFile": "",
+            "mtlsKeyStorePasswordFile": "",
+            "mtlsKeyStoreType": null,
+          },
+          "directoryServers": [
+            {
+              "connectionType": "SSL",
+              "hostName": "localhost",
+              "portNumber": "50636",
+              "serverName": "Server1",
+            },
+          ],
+        },
+        "general": {
+          "_id": "04/properties/general",
+          "_rev": "1575973778",
+          "amconfig.header.debug": {
+            "com.iplanet.services.debug.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/debug",
+            },
+            "com.iplanet.services.debug.level": {
+              "inherited": true,
+              "value": "error",
+            },
+            "com.sun.services.debug.mergeall": {
+              "inherited": true,
+              "value": "off",
+            },
+          },
+          "amconfig.header.installdir": {
+            "com.iplanet.am.locale": {
+              "inherited": true,
+              "value": "en_US",
+            },
+            "com.iplanet.am.util.xml.validating": {
+              "inherited": true,
+              "value": "off",
+            },
+            "com.iplanet.services.configpath": {
+              "inherited": true,
+              "value": "%BASE_DIR%",
+            },
+            "com.sun.identity.client.notification.url": {
+              "inherited": true,
+              "value": "%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice",
+            },
+          },
+          "amconfig.header.mailserver": {
+            "com.iplanet.am.smtphost": {
+              "inherited": true,
+              "value": "localhost",
+            },
+            "com.iplanet.am.smtpport": {
+              "inherited": true,
+              "value": "25",
+            },
+          },
+          "amconfig.header.site": {
+            "singleChoiceSite": "[Empty]",
+          },
+        },
+        "sdk": {
+          "_id": "04/properties/sdk",
+          "_rev": "855243985",
+          "amconfig.header.cachingreplica": {
+            "com.iplanet.am.sdk.cache.maxSize": {
+              "inherited": true,
+              "value": "10000",
+            },
+          },
+          "amconfig.header.datastore": {
+            "com.sun.identity.sm.enableDataStoreNotification": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.sm.notification.threadpool.size": {
+              "inherited": true,
+              "value": "1",
+            },
+          },
+          "amconfig.header.eventservice": {
+            "com.iplanet.am.event.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "3000",
+            },
+            "com.iplanet.am.event.connection.ldap.error.codes.retries": {
+              "inherited": true,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.event.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+            "com.sun.am.event.connection.disable.list": {
+              "inherited": true,
+              "value": "aci,um,sm",
+            },
+          },
+          "amconfig.header.ldapconnection": {
+            "com.iplanet.am.ldap.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "1000",
+            },
+            "com.iplanet.am.ldap.connection.ldap.error.codes.retries": {
+              "inherited": true,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.ldap.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+          },
+          "amconfig.header.sdktimetoliveconfig": {
+            "com.iplanet.am.sdk.cache.entry.default.expire.time": {
+              "inherited": true,
+              "value": "30",
+            },
+            "com.iplanet.am.sdk.cache.entry.expire.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.sdk.cache.entry.user.expire.time": {
+              "inherited": true,
+              "value": "15",
+            },
+          },
+        },
+        "security": {
+          "_id": "04/properties/security",
+          "_rev": "1595470427",
+          "amconfig.header.cookie": {
+            "com.iplanet.am.cookie.encode": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.cookie.name": {
+              "inherited": true,
+              "value": "iPlanetDirectoryPro",
+            },
+            "com.iplanet.am.cookie.secure": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.crlcache": {
+            "com.sun.identity.crl.cache.directory.host": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.mtlsenabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "com.sun.identity.crl.cache.directory.port": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchattr": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchlocs": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.ssl": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.user": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.header.deserialisationwhitelist": {
+            "openam.deserialisation.classes.whitelist": {
+              "inherited": true,
+              "value": "com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction",
+            },
+          },
+          "amconfig.header.encryption": {
+            "am.encryption.pwd": {
+              "inherited": true,
+              "value": "@AM_ENC_PWD@",
+            },
+            "am.encryption.secret.alias": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "am.encryption.secret.keyPass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreFile": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystorePass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreType": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+            "com.iplanet.security.SecureRandomFactoryImpl": {
+              "inherited": true,
+              "value": "com.iplanet.am.util.SecureRandomFactoryImpl",
+            },
+            "com.iplanet.security.encryptor": {
+              "inherited": true,
+              "value": "com.iplanet.services.util.JCEEncryption",
+            },
+          },
+          "amconfig.header.ocsp.check": {
+            "com.sun.identity.authentication.ocsp.responder.nickname": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocsp.responder.url": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocspCheck": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.securitykey": {
+            "com.sun.identity.saml.xmlsig.certalias": {
+              "inherited": true,
+              "value": "test",
+            },
+            "com.sun.identity.saml.xmlsig.keypass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.keypass",
+            },
+            "com.sun.identity.saml.xmlsig.keystore": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/keystores/keystore.jceks",
+            },
+            "com.sun.identity.saml.xmlsig.storepass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.storepass",
+            },
+            "com.sun.identity.saml.xmlsig.storetype": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+          },
+          "amconfig.header.validation": {
+            "com.iplanet.am.clientIPCheckEnabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.services.comm.server.pllrequest.maxContentLength": {
+              "inherited": true,
+              "value": "16384",
+            },
+          },
+        },
+        "session": {
+          "_id": "04/properties/session",
+          "_rev": "1363852188",
+          "amconfig.header.sessionlogging": {
+            "com.iplanet.am.stats.interval": {
+              "inherited": true,
+              "value": "60",
+            },
+            "com.iplanet.services.stats.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/stats",
+            },
+            "com.iplanet.services.stats.state": {
+              "inherited": true,
+              "value": "file",
+            },
+            "com.sun.am.session.enableHostLookUp": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.sessionnotification": {
+            "com.iplanet.am.notification.threadpool.size": {
+              "inherited": true,
+              "value": "10",
+            },
+            "com.iplanet.am.notification.threadpool.threshold": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionthresholds": {
+            "com.iplanet.am.session.invalidsessionmaxtime": {
+              "inherited": true,
+              "value": "3",
+            },
+            "org.forgerock.openam.session.service.access.persistence.caching.maxsize": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionvalidation": {
+            "com.sun.am.session.caseInsensitiveDN": {
+              "inherited": true,
+              "value": true,
+            },
+          },
+        },
+        "uma": {
+          "_id": "04/properties/uma",
+          "_rev": "1699700672",
+          "amconfig.org.forgerock.services.resourcesets.store.common.section": {
+            "org.forgerock.services.resourcesets.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.resourcesets.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.resourcesets.store.external.section": {
+            "org.forgerock.services.resourcesets.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.resourcesets.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.common.section": {
+            "org.forgerock.services.uma.labels.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.labels.store.max.connections": {
+              "inherited": true,
+              "value": "2",
+            },
+            "org.forgerock.services.uma.labels.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.external.section": {
+            "org.forgerock.services.uma.labels.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.labels.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.labels.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.common.section": {
+            "org.forgerock.services.uma.pendingrequests.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.external.section": {
+            "org.forgerock.services.uma.pendingrequests.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.pendingrequests.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.common.section": {
+            "org.forgerock.services.umaaudit.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.umaaudit.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.external.section": {
+            "org.forgerock.services.umaaudit.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.umaaudit.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+      },
+      "siteName": null,
+      "url": "http://localhost:8082/am",
+    },
+  },
+}
+`;
+
+exports[`ServerOps exportServers() 2: Export Servers with default properties 1`] = `
+{
+  "defaultProperties": {
+    "advanced": {
+      "_id": "null/properties/advanced",
+      "_rev": "1247243006",
+      "com.iplanet.am.buildDate": "2024-March-28 16:00",
+      "com.iplanet.am.buildRevision": "89116d59a1ebe73ed1931dd3649adb7f217cd06b",
+      "com.iplanet.am.buildVersion": "ForgeRock Access Management 7.5.0",
+      "com.iplanet.am.cookie.c66Encode": true,
+      "com.iplanet.am.daemons": "securid",
+      "com.iplanet.am.directory.ssl.enabled": false,
+      "com.iplanet.am.installdir": "%BASE_DIR%",
+      "com.iplanet.am.jssproxy.SSLTrustHostList": "",
+      "com.iplanet.am.jssproxy.checkSubjectAltName": false,
+      "com.iplanet.am.jssproxy.resolveIPAddress": false,
+      "com.iplanet.am.jssproxy.trustAllServerCerts": false,
+      "com.iplanet.am.lbcookie.name": "amlbcookie",
+      "com.iplanet.am.lbcookie.value": "00",
+      "com.iplanet.am.logstatus": "ACTIVE",
+      "com.iplanet.am.pcookie.name": "DProPCookie",
+      "com.iplanet.am.profile.host": "%SERVER_HOST%",
+      "com.iplanet.am.profile.port": "%SERVER_PORT%",
+      "com.iplanet.am.serverMode": true,
+      "com.iplanet.am.session.agentSessionIdleTime": "1440",
+      "com.iplanet.am.session.client.polling.enable": false,
+      "com.iplanet.am.session.client.polling.period": "180",
+      "com.iplanet.am.session.httpSession.enabled": "true",
+      "com.iplanet.am.version": "ForgeRock Access Management 7.5.0 Build 89116d59a1ebe73ed1931dd3649adb7f217cd06b (2024-March-28 16:00)",
+      "com.iplanet.security.SSLSocketFactoryImpl": "com.sun.identity.shared.ldap.factory.JSSESocketFactory",
+      "com.sun.am.event.notification.expire.time": "5",
+      "com.sun.embedded.sync.servers": "on",
+      "com.sun.identity.am.cookie.check": false,
+      "com.sun.identity.auth.cookieName": "AMAuthCookie",
+      "com.sun.identity.authentication.multiple.tabs.used": false,
+      "com.sun.identity.authentication.setCookieToAllDomains": true,
+      "com.sun.identity.authentication.special.users": "cn=dsameuser,ou=DSAME Users,%ROOT_SUFFIX%|cn=amService-UrlAccessAgent,ou=DSAME Users,%ROOT_SUFFIX%",
+      "com.sun.identity.authentication.super.user": "uid=amAdmin,ou=People,%ROOT_SUFFIX%",
+      "com.sun.identity.authentication.uniqueCookieName": "sunIdentityServerAuthNServer",
+      "com.sun.identity.cookie.httponly": true,
+      "com.sun.identity.cookie.samesite": "off",
+      "com.sun.identity.enableUniqueSSOTokenCookie": false,
+      "com.sun.identity.jss.donotInstallAtHighestPriority": true,
+      "com.sun.identity.monitoring": "off",
+      "com.sun.identity.monitoring.local.conn.server.url": "service:jmx:rmi://",
+      "com.sun.identity.password.deploymentDescriptor": "%SERVER_URI%",
+      "com.sun.identity.plugin.configuration.class": "@CONFIGURATION_PROVIDER_CLASS@",
+      "com.sun.identity.plugin.datastore.class.default": "@DATASTORE_PROVIDER_CLASS@",
+      "com.sun.identity.plugin.log.class": "@LOG_PROVIDER_CLASS@",
+      "com.sun.identity.plugin.monitoring.agent.class": "@MONAGENT_PROVIDER_CLASS@",
+      "com.sun.identity.plugin.monitoring.saml2.class": "@MONSAML2_PROVIDER_CLASS@",
+      "com.sun.identity.plugin.session.class": "@SESSION_PROVIDER_CLASS@",
+      "com.sun.identity.policy.Policy.policy_evaluation_weights": "10:10:10",
+      "com.sun.identity.policy.resultsCacheMaxSize": "10000",
+      "com.sun.identity.policy.resultsCacheResourceCap": "20",
+      "com.sun.identity.saml.xmlsig.keyprovider.class": "@XMLSIG_KEY_PROVIDER@",
+      "com.sun.identity.saml.xmlsig.passwordDecoder": "@PASSWORD_DECODER_CLASS@",
+      "com.sun.identity.saml.xmlsig.signatureprovider.class": "@XML_SIGNATURE_PROVIDER@",
+      "com.sun.identity.security.checkcaller": false,
+      "com.sun.identity.server.fqdnMap[dnsfirst]": "dnsfirst",
+      "com.sun.identity.server.fqdnMap[hello]": "hello",
+      "com.sun.identity.server.fqdnMap[localhost]": "localhost",
+      "com.sun.identity.server.fqdnMap[openam-frodo-dev.classic.com]": "openam-frodo-dev.classic.com",
+      "com.sun.identity.server.fqdnMap[openam]": "openam",
+      "com.sun.identity.server.fqdnMap[secondDNS]": "secondDNS",
+      "com.sun.identity.session.repository.enableAttributeCompression": false,
+      "com.sun.identity.session.repository.enableCompression": false,
+      "com.sun.identity.session.repository.enableEncryption": false,
+      "com.sun.identity.sm.cache.ttl": "30",
+      "com.sun.identity.sm.cache.ttl.enable": false,
+      "com.sun.identity.url.readTimeout": "30000",
+      "com.sun.identity.webcontainer": "WEB_CONTAINER",
+      "dynamic.datastore.creation.enabled": false,
+      "openam.auth.destroy_session_after_upgrade": true,
+      "openam.auth.distAuthCookieName": "AMDistAuthCookie",
+      "openam.auth.session_property_upgrader": "org.forgerock.openam.authentication.service.DefaultSessionPropertyUpgrader",
+      "openam.auth.version.header.enabled": false,
+      "openam.authentication.ignore_goto_during_logout": false,
+      "openam.cdm.default.charset": "UTF-8",
+      "openam.forbidden.to.copy.headers": "connection",
+      "openam.forbidden.to.copy.request.headers": "connection",
+      "openam.oauth2.client.jwt.encryption.algorithm.allow.list": "RSA-OAEP,RSA-OAEP-256,ECDH-ES",
+      "openam.oauth2.client.jwt.unreasonable.lifetime.limit.minutes": "30",
+      "openam.retained.http.headers": "X-DSAMEVersion",
+      "openam.retained.http.request.headers": "X-DSAMEVersion",
+      "openam.serviceattributevalidator.classes.whitelist": "org.forgerock.openam.auth.nodes.validators.GreaterThanZeroValidator,org.forgerock.openam.auth.nodes.validators.HMACKeyLengthValidator,org.forgerock.openam.auth.nodes.validators.HmacSigningKeyValidator,org.forgerock.openam.auth.nodes.validators.PercentageValidator,org.forgerock.openam.auth.nodes.validators.QueryFilterValidator,org.forgerock.openam.auth.nodes.validators.SessionPropertyNameValidator,org.forgerock.openam.auth.nodes.validators.SessionPropertyValidator,org.forgerock.openam.auth.nodes.framework.validators.NodeValueValidator,org.forgerock.openam.audit.validation.PositiveIntegerValidator,org.forgerock.openam.authentication.modules.fr.oath.validators.AlphaNumericValidator,org.forgerock.openam.authentication.modules.fr.oath.validators.CodeLengthValidator,org.forgerock.openam.authentication.modules.persistentcookie.validation.SigningKeyValidator,com.sun.identity.common.configuration.DuplicateKeyMapValueValidator,com.sun.identity.common.configuration.AgentClientIpModeValueValidator,com.sun.identity.common.configuration.FilterModeValueValidator,com.sun.identity.common.configuration.GlobalMapValueValidator,com.sun.identity.common.configuration.ListValueValidator,com.sun.identity.common.configuration.MapValueValidator,com.sun.identity.common.configuration.ServerPropertyValidator,com.sun.identity.policy.ResourceComparatorValidator,com.sun.identity.sm.EmailValidator,com.sun.identity.sm.IPAddressValidator,com.sun.identity.sm.RequiredValueValidator,com.sun.identity.sm.ServerIDValidator,com.sun.identity.sm.SiteIDValidator,org.forgerock.openam.sm.validation.Base64EncodedBinaryValidator,org.forgerock.openam.sm.validation.BlankValueValidator,org.forgerock.openam.sm.validation.DurationValidator,org.forgerock.openam.sm.validation.EndpointValidator,org.forgerock.openam.sm.validation.HostnameValidator,org.forgerock.openam.sm.validation.PortValidator,org.forgerock.openam.sm.validation.SecretIdValidator,org.forgerock.openam.sm.validation.StatelessSessionSigningAlgorithmValidator,org.forgerock.openam.sm.validation.StringMapValidator,org.forgerock.openam.sm.validation.URLValidator,org.forgerock.openam.selfservice.config.KeyAliasValidator,org.forgerock.openam.sm.validation.UniqueIndexedValuesValidator,org.forgerock.openam.webhook.HttpHeaderValidator,org.forgerock.oauth2.core.ClientRedirectUriValidator",
+      "openam.session.case.sensitive.uuid": false,
+      "org.forgerock.allow.http.client.debug": false,
+      "org.forgerock.am.auth.chains.authindexuser.strict": true,
+      "org.forgerock.am.auth.node.otp.inSharedState": false,
+      "org.forgerock.am.auth.trees.authenticate.identified.identity": true,
+      "org.forgerock.openam.audit.additionalSuccessStatusCodesEnabled": true,
+      "org.forgerock.openam.audit.identity.activity.events.blacklist": "AM-ACCESS-ATTEMPT,AM-IDENTITY-CHANGE,AM-GROUP-CHANGE",
+      "org.forgerock.openam.auth.transactionauth.returnErrorOnAuthFailure": false,
+      "org.forgerock.openam.authLevel.excludeRequiredOrRequisite": false,
+      "org.forgerock.openam.authentication.forceAuth.enabled": false,
+      "org.forgerock.openam.console.autocomplete.enabled": true,
+      "org.forgerock.openam.core.resource.lookup.cache.enabled": true,
+      "org.forgerock.openam.core.sms.placeholder_api_enabled": "OFF",
+      "org.forgerock.openam.devices.recovery.use_insecure_storage": false,
+      "org.forgerock.openam.encryption.key.digest": "SHA1",
+      "org.forgerock.openam.encryption.key.iterations": "10000",
+      "org.forgerock.openam.encryption.key.size": "128",
+      "org.forgerock.openam.httpclienthandler.system.clients.connection.timeout": "10 seconds",
+      "org.forgerock.openam.httpclienthandler.system.clients.max.connections": "64",
+      "org.forgerock.openam.httpclienthandler.system.clients.pool.ttl": "-1",
+      "org.forgerock.openam.httpclienthandler.system.clients.response.timeout": "10 seconds",
+      "org.forgerock.openam.httpclienthandler.system.clients.retry.failed.requests.enabled": true,
+      "org.forgerock.openam.httpclienthandler.system.clients.reuse.connections.enabled": true,
+      "org.forgerock.openam.httpclienthandler.system.nonProxyHosts": "localhost,127.*,[::1],0.0.0.0,[::0]",
+      "org.forgerock.openam.httpclienthandler.system.proxy.enabled": false,
+      "org.forgerock.openam.httpclienthandler.system.proxy.password": null,
+      "org.forgerock.openam.httpclienthandler.system.proxy.uri": "",
+      "org.forgerock.openam.httpclienthandler.system.proxy.username": "",
+      "org.forgerock.openam.idm.attribute.names.lower.case": false,
+      "org.forgerock.openam.idrepo.ldapv3.passwordpolicy.allowDiagnosticMessage": false,
+      "org.forgerock.openam.idrepo.ldapv3.proxyauth.passwordreset.adminRequest": "isAdminPasswordChangeRequest",
+      "org.forgerock.openam.introspect.token.query.param.allowed": false,
+      "org.forgerock.openam.ldap.dncache.expire.time": "0",
+      "org.forgerock.openam.ldap.heartbeat.timeout": "10",
+      "org.forgerock.openam.ldap.keepalive.search.base": "",
+      "org.forgerock.openam.ldap.keepalive.search.filter": "(objectClass=*)",
+      "org.forgerock.openam.ldap.secure.protocol.version": "TLSv1.3,TLSv1.2",
+      "org.forgerock.openam.notifications.agents.enabled": true,
+      "org.forgerock.openam.oauth2.checkIssuerForIdTokenInfo": true,
+      "org.forgerock.openam.radius.server.context.cache.size": "5000",
+      "org.forgerock.openam.redirecturlvalidator.maxUrlLength": "2000",
+      "org.forgerock.openam.request.max.bytes.entity.size": "1048576",
+      "org.forgerock.openam.saml2.authenticatorlookup.skewAllowance": "60",
+      "org.forgerock.openam.scripting.maxinterpreterstackdepth": "10000",
+      "org.forgerock.openam.secrets.special.user.passwords.format": "ENCRYPTED_PLAIN",
+      "org.forgerock.openam.secrets.special.user.secret.refresh.seconds": "900",
+      "org.forgerock.openam.session.service.persistence.deleteAsynchronously": true,
+      "org.forgerock.openam.session.stateless.encryption.method": "A128CBC-HS256",
+      "org.forgerock.openam.session.stateless.rsa.padding": "RSA-OAEP-256",
+      "org.forgerock.openam.session.stateless.signing.allownone": false,
+      "org.forgerock.openam.showServletTraceInBrowser": false,
+      "org.forgerock.openam.slf4j.enableTraceInMessage": false,
+      "org.forgerock.openam.smtp.system.connect.timeout": "10000",
+      "org.forgerock.openam.smtp.system.socket.read.timeout": "10000",
+      "org.forgerock.openam.smtp.system.socket.write.timeout": "10000",
+      "org.forgerock.openam.sso.providers.list": "org.forgerock.openidconnect.ssoprovider.OpenIdConnectSSOProvider",
+      "org.forgerock.openam.timerpool.shutdown.retry.interval": "15000",
+      "org.forgerock.openam.timerpool.shutdown.retry.limit": "3",
+      "org.forgerock.openam.timerpool.shutdown.retry.multiplier": "1.5",
+      "org.forgerock.openam.trees.consumedstatedata.cache.size": "15",
+      "org.forgerock.openam.trees.ids.cache.size": "50",
+      "org.forgerock.openam.url.connectTimeout": "1000",
+      "org.forgerock.openam.xui.user.session.validation.enabled": true,
+      "org.forgerock.openidconnect.ssoprovider.maxcachesize": "5000",
+      "org.forgerock.security.entitlement.enforce.realm": true,
+      "org.forgerock.security.oauth2.enforce.sub.claim.uniqueness": true,
+      "org.forgerock.services.cts.store.reaper.enabled": true,
+      "org.forgerock.services.cts.store.ttlsupport.enabled": false,
+      "org.forgerock.services.cts.store.ttlsupport.exclusionlist": "",
+      "org.forgerock.services.default.store.max.connections": "",
+      "org.forgerock.services.default.store.min.connections": "",
+      "org.forgerock.services.openid.request.object.lifespan": "120000",
+      "securidHelper.ports": "58943",
+    },
+    "cts": {
+      "_id": "null/properties/cts",
+      "_rev": "78019458",
+      "amconfig.org.forgerock.services.cts.store.common.section": {
+        "org.forgerock.services.cts.store.location": "default",
+        "org.forgerock.services.cts.store.max.connections": "100",
+        "org.forgerock.services.cts.store.page.size": "0",
+        "org.forgerock.services.cts.store.root.suffix": "",
+        "org.forgerock.services.cts.store.vlv.page.size": "1000",
+      },
+      "amconfig.org.forgerock.services.cts.store.external.section": {
+        "org.forgerock.services.cts.store.directory.name": "",
+        "org.forgerock.services.cts.store.heartbeat": "10",
+        "org.forgerock.services.cts.store.loginid": "",
+        "org.forgerock.services.cts.store.mtls.enabled": "",
+        "org.forgerock.services.cts.store.password": null,
+        "org.forgerock.services.cts.store.ssl.enabled": "",
+        "org.forgerock.services.cts.store.starttls.enabled": "",
+      },
+    },
+    "general": {
+      "_id": "null/properties/general",
+      "_rev": "6642759",
+      "amconfig.header.debug": {
+        "com.iplanet.services.debug.directory": "%BASE_DIR%/var/debug",
+        "com.iplanet.services.debug.level": "error",
+        "com.sun.services.debug.mergeall": "off",
+      },
+      "amconfig.header.installdir": {
+        "com.iplanet.am.locale": "en_US",
+        "com.iplanet.am.util.xml.validating": "off",
+        "com.iplanet.services.configpath": "%BASE_DIR%",
+        "com.sun.identity.client.notification.url": "%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice",
+      },
+      "amconfig.header.mailserver": {
+        "com.iplanet.am.smtphost": "localhost",
+        "com.iplanet.am.smtpport": "25",
+      },
+    },
+    "sdk": {
+      "_id": "null/properties/sdk",
+      "_rev": "1846611054",
+      "amconfig.header.cachingreplica": {
+        "com.iplanet.am.sdk.cache.maxSize": "10000",
+      },
+      "amconfig.header.datastore": {
+        "com.sun.identity.sm.enableDataStoreNotification": false,
+        "com.sun.identity.sm.notification.threadpool.size": "1",
+      },
+      "amconfig.header.eventservice": {
+        "com.iplanet.am.event.connection.delay.between.retries": "3000",
+        "com.iplanet.am.event.connection.ldap.error.codes.retries": "80,81,91",
+        "com.iplanet.am.event.connection.num.retries": "3",
+        "com.sun.am.event.connection.disable.list": "aci,um,sm",
+      },
+      "amconfig.header.ldapconnection": {
+        "com.iplanet.am.ldap.connection.delay.between.retries": "1000",
+        "com.iplanet.am.ldap.connection.ldap.error.codes.retries": "80,81,91",
+        "com.iplanet.am.ldap.connection.num.retries": "3",
+      },
+      "amconfig.header.sdktimetoliveconfig": {
+        "com.iplanet.am.sdk.cache.entry.default.expire.time": "30",
+        "com.iplanet.am.sdk.cache.entry.expire.enabled": false,
+        "com.iplanet.am.sdk.cache.entry.user.expire.time": "15",
+      },
+    },
+    "security": {
+      "_id": "null/properties/security",
+      "_rev": "1962770591",
+      "amconfig.header.cookie": {
+        "com.iplanet.am.cookie.encode": false,
+        "com.iplanet.am.cookie.name": "iPlanetDirectoryPro",
+        "com.iplanet.am.cookie.secure": false,
+      },
+      "amconfig.header.crlcache": {
+        "com.sun.identity.crl.cache.directory.host": "",
+        "com.sun.identity.crl.cache.directory.mtlsenabled": false,
+        "com.sun.identity.crl.cache.directory.password": null,
+        "com.sun.identity.crl.cache.directory.port": "",
+        "com.sun.identity.crl.cache.directory.searchattr": "",
+        "com.sun.identity.crl.cache.directory.searchlocs": "",
+        "com.sun.identity.crl.cache.directory.ssl": false,
+        "com.sun.identity.crl.cache.directory.user": "",
+      },
+      "amconfig.header.deserialisationwhitelist": {
+        "openam.deserialisation.classes.whitelist": "com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction",
+      },
+      "amconfig.header.encryption": {
+        "am.encryption.pwd": "@AM_ENC_PWD@",
+        "am.encryption.secret.enabled": false,
+        "am.encryption.secret.keystoreType": "JCEKS",
+        "com.iplanet.security.SecureRandomFactoryImpl": "com.iplanet.am.util.SecureRandomFactoryImpl",
+        "com.iplanet.security.encryptor": "com.iplanet.services.util.JCEEncryption",
+      },
+      "amconfig.header.ocsp.check": {
+        "com.sun.identity.authentication.ocsp.responder.nickname": "",
+        "com.sun.identity.authentication.ocsp.responder.url": "",
+        "com.sun.identity.authentication.ocspCheck": false,
+      },
+      "amconfig.header.securitykey": {
+        "com.sun.identity.saml.xmlsig.certalias": "test",
+        "com.sun.identity.saml.xmlsig.keypass": "%BASE_DIR%/security/secrets/default/.keypass",
+        "com.sun.identity.saml.xmlsig.keystore": "%BASE_DIR%/security/keystores/keystore.jceks",
+        "com.sun.identity.saml.xmlsig.storepass": "%BASE_DIR%/security/secrets/default/.storepass",
+        "com.sun.identity.saml.xmlsig.storetype": "JCEKS",
+      },
+      "amconfig.header.validation": {
+        "com.iplanet.am.clientIPCheckEnabled": false,
+        "com.iplanet.services.comm.server.pllrequest.maxContentLength": "16384",
+      },
+    },
+    "session": {
+      "_id": "null/properties/session",
+      "_rev": "875396629",
+      "amconfig.header.sessionlogging": {
+        "com.iplanet.am.stats.interval": "60",
+        "com.iplanet.services.stats.directory": "%BASE_DIR%/var/stats",
+        "com.iplanet.services.stats.state": "file",
+        "com.sun.am.session.enableHostLookUp": false,
+      },
+      "amconfig.header.sessionnotification": {
+        "com.iplanet.am.notification.threadpool.size": "10",
+        "com.iplanet.am.notification.threadpool.threshold": "5000",
+      },
+      "amconfig.header.sessionthresholds": {
+        "com.iplanet.am.session.invalidsessionmaxtime": "3",
+        "org.forgerock.openam.session.service.access.persistence.caching.maxsize": "5000",
+      },
+      "amconfig.header.sessionvalidation": {
+        "com.sun.am.session.caseInsensitiveDN": true,
+      },
+    },
+    "uma": {
+      "_id": "null/properties/uma",
+      "_rev": "342218910",
+      "amconfig.org.forgerock.services.resourcesets.store.common.section": {
+        "org.forgerock.services.resourcesets.store.location": "default",
+        "org.forgerock.services.resourcesets.store.max.connections": "10",
+        "org.forgerock.services.resourcesets.store.root.suffix": "",
+      },
+      "amconfig.org.forgerock.services.resourcesets.store.external.section": {
+        "org.forgerock.services.resourcesets.store.directory.name": "",
+        "org.forgerock.services.resourcesets.store.heartbeat": "10",
+        "org.forgerock.services.resourcesets.store.loginid": "",
+        "org.forgerock.services.resourcesets.store.mtls.enabled": "",
+        "org.forgerock.services.resourcesets.store.password": null,
+        "org.forgerock.services.resourcesets.store.ssl.enabled": "",
+        "org.forgerock.services.resourcesets.store.starttls.enabled": "",
+      },
+      "amconfig.org.forgerock.services.uma.labels.store.common.section": {
+        "org.forgerock.services.uma.labels.store.location": "default",
+        "org.forgerock.services.uma.labels.store.max.connections": "2",
+        "org.forgerock.services.uma.labels.store.root.suffix": "",
+      },
+      "amconfig.org.forgerock.services.uma.labels.store.external.section": {
+        "org.forgerock.services.uma.labels.store.directory.name": "",
+        "org.forgerock.services.uma.labels.store.heartbeat": "10",
+        "org.forgerock.services.uma.labels.store.loginid": "",
+        "org.forgerock.services.uma.labels.store.mtls.enabled": "",
+        "org.forgerock.services.uma.labels.store.password": null,
+        "org.forgerock.services.uma.labels.store.ssl.enabled": "",
+        "org.forgerock.services.uma.labels.store.starttls.enabled": "",
+      },
+      "amconfig.org.forgerock.services.uma.pendingrequests.store.common.section": {
+        "org.forgerock.services.uma.pendingrequests.store.location": "default",
+        "org.forgerock.services.uma.pendingrequests.store.max.connections": "10",
+        "org.forgerock.services.uma.pendingrequests.store.root.suffix": "",
+      },
+      "amconfig.org.forgerock.services.uma.pendingrequests.store.external.section": {
+        "org.forgerock.services.uma.pendingrequests.store.directory.name": "",
+        "org.forgerock.services.uma.pendingrequests.store.heartbeat": "10",
+        "org.forgerock.services.uma.pendingrequests.store.loginid": "",
+        "org.forgerock.services.uma.pendingrequests.store.mtls.enabled": "",
+        "org.forgerock.services.uma.pendingrequests.store.password": null,
+        "org.forgerock.services.uma.pendingrequests.store.ssl.enabled": "",
+        "org.forgerock.services.uma.pendingrequests.store.starttls.enabled": "",
+      },
+      "amconfig.org.forgerock.services.umaaudit.store.common.section": {
+        "org.forgerock.services.umaaudit.store.location": "default",
+        "org.forgerock.services.umaaudit.store.max.connections": "10",
+        "org.forgerock.services.umaaudit.store.root.suffix": "",
+      },
+      "amconfig.org.forgerock.services.umaaudit.store.external.section": {
+        "org.forgerock.services.umaaudit.store.directory.name": "",
+        "org.forgerock.services.umaaudit.store.heartbeat": "10",
+        "org.forgerock.services.umaaudit.store.loginid": "",
+        "org.forgerock.services.umaaudit.store.mtls.enabled": "",
+        "org.forgerock.services.umaaudit.store.password": null,
+        "org.forgerock.services.umaaudit.store.ssl.enabled": "",
+        "org.forgerock.services.umaaudit.store.starttls.enabled": "",
+      },
+    },
+  },
+  "meta": Any<Object>,
+  "server": {
+    "01": {
+      "_id": "01",
+      "_rev": "-931963190",
+      "properties": {
+        "advanced": {
+          "_id": "01/properties/advanced",
+          "_rev": "640350433",
+          "bootstrap.file": "/home/prestonhales/.openamcfg/AMConfig_usr_local_tomcat_webapps_am_",
+          "com.iplanet.am.lbcookie.value": "01",
+          "com.iplanet.am.serverMode": true,
+          "com.iplanet.security.SSLSocketFactoryImpl": "com.sun.identity.shared.ldap.factory.JSSESocketFactory",
+          "com.sun.embedded.replicationport": "",
+          "com.sun.embedded.sync.servers": "on",
+          "com.sun.identity.common.systemtimerpool.size": "3",
+          "com.sun.identity.sm.sms_object_class_name": "com.sun.identity.sm.SmsWrapperObject",
+          "com.sun.identity.urlconnection.useCache": false,
+          "opensso.protocol.handler.pkgs": "",
+          "org.forgerock.embedded.dsadminport": "4444",
+        },
+        "cts": {
+          "_id": "01/properties/cts",
+          "_rev": "1870095637",
+          "amconfig.org.forgerock.services.cts.store.common.section": {
+            "org.forgerock.services.cts.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.cts.store.max.connections": {
+              "inherited": true,
+              "value": "100",
+            },
+            "org.forgerock.services.cts.store.page.size": {
+              "inherited": true,
+              "value": "0",
+            },
+            "org.forgerock.services.cts.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.vlv.page.size": {
+              "inherited": true,
+              "value": "1000",
+            },
+          },
+          "amconfig.org.forgerock.services.cts.store.external.section": {
+            "org.forgerock.services.cts.store.affinity.enabled": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.cts.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+        "directoryConfiguration": {
+          "_id": "01/properties/directoryConfiguration",
+          "_rev": "977014447",
+          "directoryConfiguration": {
+            "bindDn": "cn=Directory Manager",
+            "bindPassword": null,
+            "maxConnectionPool": 10,
+            "minConnectionPool": 1,
+            "mtlsAlias": "",
+            "mtlsEnabled": false,
+            "mtlsKeyPasswordFile": "",
+            "mtlsKeyStoreFile": "",
+            "mtlsKeyStorePasswordFile": "",
+            "mtlsKeyStoreType": null,
+          },
+          "directoryServers": [
+            {
+              "connectionType": "SSL",
+              "hostName": "localhost",
+              "portNumber": "50636",
+              "serverName": "Server1",
+            },
+          ],
+        },
+        "general": {
+          "_id": "01/properties/general",
+          "_rev": "572685106",
+          "amconfig.header.debug": {
+            "com.iplanet.services.debug.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/debug",
+            },
+            "com.iplanet.services.debug.level": {
+              "inherited": false,
+              "value": "warning",
+            },
+            "com.sun.services.debug.mergeall": {
+              "inherited": false,
+              "value": "off",
+            },
+          },
+          "amconfig.header.installdir": {
+            "com.iplanet.am.locale": {
+              "inherited": false,
+              "value": "en_US",
+            },
+            "com.iplanet.am.util.xml.validating": {
+              "inherited": true,
+              "value": "off",
+            },
+            "com.iplanet.services.configpath": {
+              "inherited": false,
+              "value": "/home/prestonhales/am",
+            },
+            "com.sun.identity.client.notification.url": {
+              "inherited": true,
+              "value": "%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice",
+            },
+          },
+          "amconfig.header.mailserver": {
+            "com.iplanet.am.smtphost": {
+              "inherited": true,
+              "value": "localhost",
+            },
+            "com.iplanet.am.smtpport": {
+              "inherited": true,
+              "value": "25",
+            },
+          },
+          "amconfig.header.site": {
+            "singleChoiceSite": "[Empty]",
+          },
+        },
+        "sdk": {
+          "_id": "01/properties/sdk",
+          "_rev": "2084420578",
+          "amconfig.header.cachingreplica": {
+            "com.iplanet.am.sdk.cache.maxSize": {
+              "inherited": true,
+              "value": "10000",
+            },
+          },
+          "amconfig.header.datastore": {
+            "com.sun.identity.sm.enableDataStoreNotification": {
+              "inherited": false,
+              "value": true,
+            },
+            "com.sun.identity.sm.notification.threadpool.size": {
+              "inherited": true,
+              "value": "1",
+            },
+          },
+          "amconfig.header.eventservice": {
+            "com.iplanet.am.event.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "3000",
+            },
+            "com.iplanet.am.event.connection.ldap.error.codes.retries": {
+              "inherited": true,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.event.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+            "com.sun.am.event.connection.disable.list": {
+              "inherited": false,
+              "value": "aci,um",
+            },
+          },
+          "amconfig.header.ldapconnection": {
+            "com.iplanet.am.ldap.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "1000",
+            },
+            "com.iplanet.am.ldap.connection.ldap.error.codes.retries": {
+              "inherited": false,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.ldap.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+          },
+          "amconfig.header.sdktimetoliveconfig": {
+            "com.iplanet.am.sdk.cache.entry.default.expire.time": {
+              "inherited": true,
+              "value": "30",
+            },
+            "com.iplanet.am.sdk.cache.entry.expire.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.sdk.cache.entry.user.expire.time": {
+              "inherited": true,
+              "value": "15",
+            },
+          },
+        },
+        "security": {
+          "_id": "01/properties/security",
+          "_rev": "1471168313",
+          "amconfig.header.cookie": {
+            "com.iplanet.am.cookie.encode": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.cookie.name": {
+              "inherited": true,
+              "value": "iPlanetDirectoryPro",
+            },
+            "com.iplanet.am.cookie.secure": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.crlcache": {
+            "com.sun.identity.crl.cache.directory.host": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.mtlsenabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "com.sun.identity.crl.cache.directory.port": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchattr": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchlocs": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.ssl": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.user": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.header.deserialisationwhitelist": {
+            "openam.deserialisation.classes.whitelist": {
+              "inherited": true,
+              "value": "com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction",
+            },
+          },
+          "amconfig.header.encryption": {
+            "am.encryption.pwd": {
+              "inherited": false,
+              "value": "efSYcwIhr7uKH30rgciGTVTFzb63LhYu",
+            },
+            "am.encryption.secret.alias": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "am.encryption.secret.keyPass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreFile": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystorePass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreType": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+            "com.iplanet.security.SecureRandomFactoryImpl": {
+              "inherited": true,
+              "value": "com.iplanet.am.util.SecureRandomFactoryImpl",
+            },
+            "com.iplanet.security.encryptor": {
+              "inherited": true,
+              "value": "com.iplanet.services.util.JCEEncryption",
+            },
+          },
+          "amconfig.header.ocsp.check": {
+            "com.sun.identity.authentication.ocsp.responder.nickname": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocsp.responder.url": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocspCheck": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.securitykey": {
+            "com.sun.identity.saml.xmlsig.certalias": {
+              "inherited": true,
+              "value": "test",
+            },
+            "com.sun.identity.saml.xmlsig.keypass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.keypass",
+            },
+            "com.sun.identity.saml.xmlsig.keystore": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/keystores/keystore.jceks",
+            },
+            "com.sun.identity.saml.xmlsig.storepass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.storepass",
+            },
+            "com.sun.identity.saml.xmlsig.storetype": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+          },
+          "amconfig.header.validation": {
+            "com.iplanet.am.clientIPCheckEnabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.services.comm.server.pllrequest.maxContentLength": {
+              "inherited": true,
+              "value": "16384",
+            },
+          },
+        },
+        "session": {
+          "_id": "01/properties/session",
+          "_rev": "448395666",
+          "amconfig.header.sessionlogging": {
+            "com.iplanet.am.stats.interval": {
+              "inherited": true,
+              "value": "60",
+            },
+            "com.iplanet.services.stats.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/stats",
+            },
+            "com.iplanet.services.stats.state": {
+              "inherited": true,
+              "value": "file",
+            },
+            "com.sun.am.session.enableHostLookUp": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.sessionnotification": {
+            "com.iplanet.am.notification.threadpool.size": {
+              "inherited": true,
+              "value": "10",
+            },
+            "com.iplanet.am.notification.threadpool.threshold": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionthresholds": {
+            "com.iplanet.am.session.invalidsessionmaxtime": {
+              "inherited": true,
+              "value": "3",
+            },
+            "org.forgerock.openam.session.service.access.persistence.caching.maxsize": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionvalidation": {
+            "com.sun.am.session.caseInsensitiveDN": {
+              "inherited": true,
+              "value": true,
+            },
+          },
+        },
+        "uma": {
+          "_id": "01/properties/uma",
+          "_rev": "252658597",
+          "amconfig.org.forgerock.services.resourcesets.store.common.section": {
+            "org.forgerock.services.resourcesets.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.resourcesets.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.resourcesets.store.external.section": {
+            "org.forgerock.services.resourcesets.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.resourcesets.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.common.section": {
+            "org.forgerock.services.uma.labels.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.labels.store.max.connections": {
+              "inherited": true,
+              "value": "2",
+            },
+            "org.forgerock.services.uma.labels.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.external.section": {
+            "org.forgerock.services.uma.labels.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.labels.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.labels.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.common.section": {
+            "org.forgerock.services.uma.pendingrequests.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.external.section": {
+            "org.forgerock.services.uma.pendingrequests.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.pendingrequests.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.common.section": {
+            "org.forgerock.services.umaaudit.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.umaaudit.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.external.section": {
+            "org.forgerock.services.umaaudit.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.umaaudit.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+      },
+      "siteName": null,
+      "url": "http://localhost:8080/am",
+    },
+    "03": {
+      "_id": "03",
+      "_rev": "-931738263",
+      "properties": {
+        "advanced": {
+          "_id": "03/properties/advanced",
+          "_rev": "1124473215",
+          "com.iplanet.am.lbcookie.value": "03",
+        },
+        "cts": {
+          "_id": "03/properties/cts",
+          "_rev": "195487139",
+          "amconfig.org.forgerock.services.cts.store.common.section": {
+            "org.forgerock.services.cts.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.cts.store.max.connections": {
+              "inherited": true,
+              "value": "100",
+            },
+            "org.forgerock.services.cts.store.page.size": {
+              "inherited": true,
+              "value": "0",
+            },
+            "org.forgerock.services.cts.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.vlv.page.size": {
+              "inherited": true,
+              "value": "1000",
+            },
+          },
+          "amconfig.org.forgerock.services.cts.store.external.section": {
+            "org.forgerock.services.cts.store.affinity.enabled": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.cts.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+        "directoryConfiguration": {
+          "_id": "03/properties/directoryConfiguration",
+          "_rev": "815965393",
+          "directoryConfiguration": {
+            "bindDn": "cn=Directory Manager",
+            "bindPassword": null,
+            "maxConnectionPool": 10,
+            "minConnectionPool": 1,
+            "mtlsAlias": "",
+            "mtlsEnabled": false,
+            "mtlsKeyPasswordFile": "",
+            "mtlsKeyStoreFile": "",
+            "mtlsKeyStorePasswordFile": "",
+            "mtlsKeyStoreType": null,
+          },
+          "directoryServers": [
+            {
+              "connectionType": "SSL",
+              "hostName": "localhost",
+              "portNumber": "50636",
+              "serverName": "Server1",
+            },
+          ],
+        },
+        "general": {
+          "_id": "03/properties/general",
+          "_rev": "604966163",
+          "amconfig.header.debug": {
+            "com.iplanet.services.debug.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/debug",
+            },
+            "com.iplanet.services.debug.level": {
+              "inherited": true,
+              "value": "error",
+            },
+            "com.sun.services.debug.mergeall": {
+              "inherited": true,
+              "value": "off",
+            },
+          },
+          "amconfig.header.installdir": {
+            "com.iplanet.am.locale": {
+              "inherited": true,
+              "value": "en_US",
+            },
+            "com.iplanet.am.util.xml.validating": {
+              "inherited": true,
+              "value": "off",
+            },
+            "com.iplanet.services.configpath": {
+              "inherited": true,
+              "value": "%BASE_DIR%",
+            },
+            "com.sun.identity.client.notification.url": {
+              "inherited": true,
+              "value": "%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice",
+            },
+          },
+          "amconfig.header.mailserver": {
+            "com.iplanet.am.smtphost": {
+              "inherited": true,
+              "value": "localhost",
+            },
+            "com.iplanet.am.smtpport": {
+              "inherited": true,
+              "value": "25",
+            },
+          },
+          "amconfig.header.site": {
+            "singleChoiceSite": "[Empty]",
+          },
+        },
+        "sdk": {
+          "_id": "03/properties/sdk",
+          "_rev": "1466168525",
+          "amconfig.header.cachingreplica": {
+            "com.iplanet.am.sdk.cache.maxSize": {
+              "inherited": true,
+              "value": "10000",
+            },
+          },
+          "amconfig.header.datastore": {
+            "com.sun.identity.sm.enableDataStoreNotification": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.sm.notification.threadpool.size": {
+              "inherited": true,
+              "value": "1",
+            },
+          },
+          "amconfig.header.eventservice": {
+            "com.iplanet.am.event.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "3000",
+            },
+            "com.iplanet.am.event.connection.ldap.error.codes.retries": {
+              "inherited": true,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.event.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+            "com.sun.am.event.connection.disable.list": {
+              "inherited": true,
+              "value": "aci,um,sm",
+            },
+          },
+          "amconfig.header.ldapconnection": {
+            "com.iplanet.am.ldap.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "1000",
+            },
+            "com.iplanet.am.ldap.connection.ldap.error.codes.retries": {
+              "inherited": true,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.ldap.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+          },
+          "amconfig.header.sdktimetoliveconfig": {
+            "com.iplanet.am.sdk.cache.entry.default.expire.time": {
+              "inherited": true,
+              "value": "30",
+            },
+            "com.iplanet.am.sdk.cache.entry.expire.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.sdk.cache.entry.user.expire.time": {
+              "inherited": true,
+              "value": "15",
+            },
+          },
+        },
+        "security": {
+          "_id": "03/properties/security",
+          "_rev": "1200017169",
+          "amconfig.header.cookie": {
+            "com.iplanet.am.cookie.encode": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.cookie.name": {
+              "inherited": true,
+              "value": "iPlanetDirectoryPro",
+            },
+            "com.iplanet.am.cookie.secure": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.crlcache": {
+            "com.sun.identity.crl.cache.directory.host": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.mtlsenabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "com.sun.identity.crl.cache.directory.port": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchattr": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchlocs": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.ssl": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.user": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.header.deserialisationwhitelist": {
+            "openam.deserialisation.classes.whitelist": {
+              "inherited": true,
+              "value": "com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction",
+            },
+          },
+          "amconfig.header.encryption": {
+            "am.encryption.pwd": {
+              "inherited": true,
+              "value": "@AM_ENC_PWD@",
+            },
+            "am.encryption.secret.alias": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "am.encryption.secret.keyPass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreFile": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystorePass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreType": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+            "com.iplanet.security.SecureRandomFactoryImpl": {
+              "inherited": true,
+              "value": "com.iplanet.am.util.SecureRandomFactoryImpl",
+            },
+            "com.iplanet.security.encryptor": {
+              "inherited": true,
+              "value": "com.iplanet.services.util.JCEEncryption",
+            },
+          },
+          "amconfig.header.ocsp.check": {
+            "com.sun.identity.authentication.ocsp.responder.nickname": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocsp.responder.url": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocspCheck": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.securitykey": {
+            "com.sun.identity.saml.xmlsig.certalias": {
+              "inherited": true,
+              "value": "test",
+            },
+            "com.sun.identity.saml.xmlsig.keypass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.keypass",
+            },
+            "com.sun.identity.saml.xmlsig.keystore": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/keystores/keystore.jceks",
+            },
+            "com.sun.identity.saml.xmlsig.storepass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.storepass",
+            },
+            "com.sun.identity.saml.xmlsig.storetype": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+          },
+          "amconfig.header.validation": {
+            "com.iplanet.am.clientIPCheckEnabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.services.comm.server.pllrequest.maxContentLength": {
+              "inherited": true,
+              "value": "16384",
+            },
+          },
+        },
+        "session": {
+          "_id": "03/properties/session",
+          "_rev": "1755281159",
+          "amconfig.header.sessionlogging": {
+            "com.iplanet.am.stats.interval": {
+              "inherited": true,
+              "value": "60",
+            },
+            "com.iplanet.services.stats.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/stats",
+            },
+            "com.iplanet.services.stats.state": {
+              "inherited": true,
+              "value": "file",
+            },
+            "com.sun.am.session.enableHostLookUp": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.sessionnotification": {
+            "com.iplanet.am.notification.threadpool.size": {
+              "inherited": true,
+              "value": "10",
+            },
+            "com.iplanet.am.notification.threadpool.threshold": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionthresholds": {
+            "com.iplanet.am.session.invalidsessionmaxtime": {
+              "inherited": true,
+              "value": "3",
+            },
+            "org.forgerock.openam.session.service.access.persistence.caching.maxsize": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionvalidation": {
+            "com.sun.am.session.caseInsensitiveDN": {
+              "inherited": true,
+              "value": true,
+            },
+          },
+        },
+        "uma": {
+          "_id": "03/properties/uma",
+          "_rev": "1003517163",
+          "amconfig.org.forgerock.services.resourcesets.store.common.section": {
+            "org.forgerock.services.resourcesets.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.resourcesets.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.resourcesets.store.external.section": {
+            "org.forgerock.services.resourcesets.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.resourcesets.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.common.section": {
+            "org.forgerock.services.uma.labels.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.labels.store.max.connections": {
+              "inherited": true,
+              "value": "2",
+            },
+            "org.forgerock.services.uma.labels.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.external.section": {
+            "org.forgerock.services.uma.labels.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.labels.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.labels.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.common.section": {
+            "org.forgerock.services.uma.pendingrequests.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.external.section": {
+            "org.forgerock.services.uma.pendingrequests.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.pendingrequests.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.common.section": {
+            "org.forgerock.services.umaaudit.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.umaaudit.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.external.section": {
+            "org.forgerock.services.umaaudit.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.umaaudit.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+      },
+      "siteName": null,
+      "url": "http://localhost:8081/am",
+    },
+    "04": {
+      "_id": "04",
+      "_rev": "-931739121",
+      "properties": {
+        "advanced": {
+          "_id": "04/properties/advanced",
+          "_rev": "2014426080",
+          "com.iplanet.am.lbcookie.value": "04",
+        },
+        "cts": {
+          "_id": "04/properties/cts",
+          "_rev": "845265500",
+          "amconfig.org.forgerock.services.cts.store.common.section": {
+            "org.forgerock.services.cts.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.cts.store.max.connections": {
+              "inherited": true,
+              "value": "100",
+            },
+            "org.forgerock.services.cts.store.page.size": {
+              "inherited": true,
+              "value": "0",
+            },
+            "org.forgerock.services.cts.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.vlv.page.size": {
+              "inherited": true,
+              "value": "1000",
+            },
+          },
+          "amconfig.org.forgerock.services.cts.store.external.section": {
+            "org.forgerock.services.cts.store.affinity.enabled": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.cts.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.cts.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.cts.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+        "directoryConfiguration": {
+          "_id": "04/properties/directoryConfiguration",
+          "_rev": "141426662",
+          "directoryConfiguration": {
+            "bindDn": "cn=Directory Manager",
+            "bindPassword": null,
+            "maxConnectionPool": 10,
+            "minConnectionPool": 1,
+            "mtlsAlias": "",
+            "mtlsEnabled": false,
+            "mtlsKeyPasswordFile": "",
+            "mtlsKeyStoreFile": "",
+            "mtlsKeyStorePasswordFile": "",
+            "mtlsKeyStoreType": null,
+          },
+          "directoryServers": [
+            {
+              "connectionType": "SSL",
+              "hostName": "localhost",
+              "portNumber": "50636",
+              "serverName": "Server1",
+            },
+          ],
+        },
+        "general": {
+          "_id": "04/properties/general",
+          "_rev": "565723329",
+          "amconfig.header.debug": {
+            "com.iplanet.services.debug.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/debug",
+            },
+            "com.iplanet.services.debug.level": {
+              "inherited": true,
+              "value": "error",
+            },
+            "com.sun.services.debug.mergeall": {
+              "inherited": true,
+              "value": "off",
+            },
+          },
+          "amconfig.header.installdir": {
+            "com.iplanet.am.locale": {
+              "inherited": true,
+              "value": "en_US",
+            },
+            "com.iplanet.am.util.xml.validating": {
+              "inherited": true,
+              "value": "off",
+            },
+            "com.iplanet.services.configpath": {
+              "inherited": true,
+              "value": "%BASE_DIR%",
+            },
+            "com.sun.identity.client.notification.url": {
+              "inherited": true,
+              "value": "%SERVER_PROTO%://%SERVER_HOST%:%SERVER_PORT%/%SERVER_URI%/notificationservice",
+            },
+          },
+          "amconfig.header.mailserver": {
+            "com.iplanet.am.smtphost": {
+              "inherited": true,
+              "value": "localhost",
+            },
+            "com.iplanet.am.smtpport": {
+              "inherited": true,
+              "value": "25",
+            },
+          },
+          "amconfig.header.site": {
+            "singleChoiceSite": "[Empty]",
+          },
+        },
+        "sdk": {
+          "_id": "04/properties/sdk",
+          "_rev": "1506563030",
+          "amconfig.header.cachingreplica": {
+            "com.iplanet.am.sdk.cache.maxSize": {
+              "inherited": true,
+              "value": "10000",
+            },
+          },
+          "amconfig.header.datastore": {
+            "com.sun.identity.sm.enableDataStoreNotification": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.sm.notification.threadpool.size": {
+              "inherited": true,
+              "value": "1",
+            },
+          },
+          "amconfig.header.eventservice": {
+            "com.iplanet.am.event.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "3000",
+            },
+            "com.iplanet.am.event.connection.ldap.error.codes.retries": {
+              "inherited": true,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.event.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+            "com.sun.am.event.connection.disable.list": {
+              "inherited": true,
+              "value": "aci,um,sm",
+            },
+          },
+          "amconfig.header.ldapconnection": {
+            "com.iplanet.am.ldap.connection.delay.between.retries": {
+              "inherited": true,
+              "value": "1000",
+            },
+            "com.iplanet.am.ldap.connection.ldap.error.codes.retries": {
+              "inherited": true,
+              "value": "80,81,91",
+            },
+            "com.iplanet.am.ldap.connection.num.retries": {
+              "inherited": true,
+              "value": "3",
+            },
+          },
+          "amconfig.header.sdktimetoliveconfig": {
+            "com.iplanet.am.sdk.cache.entry.default.expire.time": {
+              "inherited": true,
+              "value": "30",
+            },
+            "com.iplanet.am.sdk.cache.entry.expire.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.sdk.cache.entry.user.expire.time": {
+              "inherited": true,
+              "value": "15",
+            },
+          },
+        },
+        "security": {
+          "_id": "04/properties/security",
+          "_rev": "1381545338",
+          "amconfig.header.cookie": {
+            "com.iplanet.am.cookie.encode": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.am.cookie.name": {
+              "inherited": true,
+              "value": "iPlanetDirectoryPro",
+            },
+            "com.iplanet.am.cookie.secure": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.crlcache": {
+            "com.sun.identity.crl.cache.directory.host": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.mtlsenabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "com.sun.identity.crl.cache.directory.port": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchattr": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.searchlocs": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.crl.cache.directory.ssl": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.sun.identity.crl.cache.directory.user": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.header.deserialisationwhitelist": {
+            "openam.deserialisation.classes.whitelist": {
+              "inherited": true,
+              "value": "com.iplanet.dpro.session.DNOrIPAddressListTokenRestriction,com.sun.identity.common.CaseInsensitiveHashMap,com.sun.identity.common.CaseInsensitiveHashSet,com.sun.identity.common.CaseInsensitiveKey,com.sun.identity.console.base.model.SMSubConfig,com.sun.identity.console.session.model.SMSessionData,com.sun.identity.console.user.model.UMUserPasswordResetOptionsData,com.sun.identity.shared.datastruct.OrderedSet,com.sun.xml.bind.util.ListImpl,com.sun.xml.bind.util.ProxyListImpl,java.lang.Boolean,java.lang.Integer,java.lang.Number,java.lang.StringBuffer,java.net.InetAddress,java.security.cert.Certificate,java.security.cert.Certificate$CertificateRep,java.util.ArrayList,java.util.Collections$EmptyMap,java.util.Collections$EmptySet,java.util.Collections$SingletonList,java.util.HashMap,java.util.HashSet,java.util.LinkedHashSet,java.util.Locale,org.forgerock.openam.authentication.service.protocol.RemoteCookie,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteHttpServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteServletRequest,org.forgerock.openam.authentication.service.protocol.RemoteServletResponse,org.forgerock.openam.authentication.service.protocol.RemoteSession,org.forgerock.openam.dpro.session.NoOpTokenRestriction,org.forgerock.openam.dpro.session.ProofOfPossessionTokenRestriction",
+            },
+          },
+          "amconfig.header.encryption": {
+            "am.encryption.pwd": {
+              "inherited": true,
+              "value": "@AM_ENC_PWD@",
+            },
+            "am.encryption.secret.alias": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.enabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "am.encryption.secret.keyPass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreFile": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystorePass": {
+              "inherited": true,
+              "value": null,
+            },
+            "am.encryption.secret.keystoreType": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+            "com.iplanet.security.SecureRandomFactoryImpl": {
+              "inherited": true,
+              "value": "com.iplanet.am.util.SecureRandomFactoryImpl",
+            },
+            "com.iplanet.security.encryptor": {
+              "inherited": true,
+              "value": "com.iplanet.services.util.JCEEncryption",
+            },
+          },
+          "amconfig.header.ocsp.check": {
+            "com.sun.identity.authentication.ocsp.responder.nickname": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocsp.responder.url": {
+              "inherited": true,
+              "value": "",
+            },
+            "com.sun.identity.authentication.ocspCheck": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.securitykey": {
+            "com.sun.identity.saml.xmlsig.certalias": {
+              "inherited": true,
+              "value": "test",
+            },
+            "com.sun.identity.saml.xmlsig.keypass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.keypass",
+            },
+            "com.sun.identity.saml.xmlsig.keystore": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/keystores/keystore.jceks",
+            },
+            "com.sun.identity.saml.xmlsig.storepass": {
+              "inherited": true,
+              "value": "%BASE_DIR%/security/secrets/default/.storepass",
+            },
+            "com.sun.identity.saml.xmlsig.storetype": {
+              "inherited": true,
+              "value": "JCEKS",
+            },
+          },
+          "amconfig.header.validation": {
+            "com.iplanet.am.clientIPCheckEnabled": {
+              "inherited": true,
+              "value": false,
+            },
+            "com.iplanet.services.comm.server.pllrequest.maxContentLength": {
+              "inherited": true,
+              "value": "16384",
+            },
+          },
+        },
+        "session": {
+          "_id": "04/properties/session",
+          "_rev": "857545830",
+          "amconfig.header.sessionlogging": {
+            "com.iplanet.am.stats.interval": {
+              "inherited": true,
+              "value": "60",
+            },
+            "com.iplanet.services.stats.directory": {
+              "inherited": true,
+              "value": "%BASE_DIR%/var/stats",
+            },
+            "com.iplanet.services.stats.state": {
+              "inherited": true,
+              "value": "file",
+            },
+            "com.sun.am.session.enableHostLookUp": {
+              "inherited": true,
+              "value": false,
+            },
+          },
+          "amconfig.header.sessionnotification": {
+            "com.iplanet.am.notification.threadpool.size": {
+              "inherited": true,
+              "value": "10",
+            },
+            "com.iplanet.am.notification.threadpool.threshold": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionthresholds": {
+            "com.iplanet.am.session.invalidsessionmaxtime": {
+              "inherited": true,
+              "value": "3",
+            },
+            "org.forgerock.openam.session.service.access.persistence.caching.maxsize": {
+              "inherited": true,
+              "value": "5000",
+            },
+          },
+          "amconfig.header.sessionvalidation": {
+            "com.sun.am.session.caseInsensitiveDN": {
+              "inherited": true,
+              "value": true,
+            },
+          },
+        },
+        "uma": {
+          "_id": "04/properties/uma",
+          "_rev": "801752679",
+          "amconfig.org.forgerock.services.resourcesets.store.common.section": {
+            "org.forgerock.services.resourcesets.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.resourcesets.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.resourcesets.store.external.section": {
+            "org.forgerock.services.resourcesets.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.resourcesets.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.resourcesets.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.resourcesets.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.common.section": {
+            "org.forgerock.services.uma.labels.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.labels.store.max.connections": {
+              "inherited": true,
+              "value": "2",
+            },
+            "org.forgerock.services.uma.labels.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.labels.store.external.section": {
+            "org.forgerock.services.uma.labels.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.labels.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.labels.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.labels.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.common.section": {
+            "org.forgerock.services.uma.pendingrequests.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.uma.pendingrequests.store.external.section": {
+            "org.forgerock.services.uma.pendingrequests.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.uma.pendingrequests.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.uma.pendingrequests.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.common.section": {
+            "org.forgerock.services.umaaudit.store.location": {
+              "inherited": true,
+              "value": "default",
+            },
+            "org.forgerock.services.umaaudit.store.max.connections": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.root.suffix": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+          "amconfig.org.forgerock.services.umaaudit.store.external.section": {
+            "org.forgerock.services.umaaudit.store.directory.name": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.heartbeat": {
+              "inherited": true,
+              "value": "10",
+            },
+            "org.forgerock.services.umaaudit.store.loginid": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.mtls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.password": {
+              "inherited": true,
+              "value": null,
+            },
+            "org.forgerock.services.umaaudit.store.ssl.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+            "org.forgerock.services.umaaudit.store.starttls.enabled": {
+              "inherited": true,
+              "value": "",
+            },
+          },
+        },
+      },
+      "siteName": null,
+      "url": "http://localhost:8082/am",
+    },
+  },
+}
+`;
+
+exports[`ServerOps readServers() 1: Read Servers 1`] = `
+[
+  {
+    "_id": "01",
+    "_rev": "-931963190",
+    "siteName": null,
+    "url": "http://localhost:8080/am",
+  },
+  {
+    "_id": "03",
+    "_rev": "-931738263",
+    "siteName": null,
+    "url": "http://localhost:8081/am",
+  },
+  {
+    "_id": "04",
+    "_rev": "-931739121",
+    "siteName": null,
+    "url": "http://localhost:8082/am",
+  },
+]
+`;


### PR DESCRIPTION
Adds ability to export and import servers for classic deployments, including their properties and default properties.

This PR should be merged in prior to the PR named "Update Full Config Export with new Imports and Exports" that updates the full config export/import since that PR will rely on the changes from this PR.
