### PR TITLE
Add Additional AM Config Imports and Exports

### DIFF
--- a/src/api/AmConfigApi.ts
+++ b/src/api/AmConfigApi.ts
@@ -1,0 +1,504 @@
+import Constants from '../shared/Constants';
+import { State } from '../shared/State';
+import { printError, printMessage } from '../utils/Console';
+import {
+  getRealmPathGlobal,
+  getRealmsForExport,
+  getRealmUsingExportFormat,
+} from '../utils/ForgeRockUtils';
+import { AmConfigEntityInterface, PagedResult } from './ApiTypes';
+import { generateAmApi } from './BaseApi';
+
+export interface AmConfigEntitiesInterface {
+  applicationTypes: AmConfigEntityInterface;
+  authenticationChains: AmConfigEntityInterface;
+  authenticationModules: AmConfigEntityInterface;
+  authenticationTreesConfiguration: AmConfigEntityInterface;
+  conditionTypes: AmConfigEntityInterface;
+  decisionCombiners: AmConfigEntityInterface;
+  secrets: AmConfigEntityInterface;
+  serverInformation: AmConfigEntityInterface;
+  serverVersion: AmConfigEntityInterface;
+  subjectAttributes: AmConfigEntityInterface;
+  subjectTypes: AmConfigEntityInterface;
+  webhookService: AmConfigEntityInterface;
+  wsEntity: AmConfigEntityInterface;
+}
+
+const ALL_DEPLOYMENTS = [
+  Constants.CLASSIC_DEPLOYMENT_TYPE_KEY,
+  Constants.CLOUD_DEPLOYMENT_TYPE_KEY,
+  Constants.FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
+const CLASSIC_DEPLOYMENT = [Constants.CLASSIC_DEPLOYMENT_TYPE_KEY];
+
+const NEXT_DESCENDENTS_ACTION = 'nextdescendents';
+const TRUE_QUERY_FILTER = 'true';
+
+const DEFAULT_PROTOCOL = '2.1';
+
+/**
+ * Consists of all AM entities that are not currently being exported elsewhere in Frodo.
+ * Endpoints and resource versions were scraped directly from the Amster entity reference documentation: https://backstage.forgerock.com/docs/amster/7.5/entity-reference/preface.html
+ */
+const AM_ENTITIES: Record<string, EntityInfo> = {
+  applicationTypes: {
+    realm: { path: '/applicationtypes', version: '1.0' },
+    deployments: ALL_DEPLOYMENTS,
+    queryFilter: TRUE_QUERY_FILTER,
+    readonly: true,
+  },
+  authenticationChains: {
+    realm: {
+      path: '/realm-config/authentication/chains',
+      version: '2.0',
+      importWithId: true,
+      queryFilter: TRUE_QUERY_FILTER,
+    },
+    global: {
+      path: '/global-config/authentication/chains',
+      version: '1.0',
+      deployments: CLASSIC_DEPLOYMENT,
+    },
+    deployments: ALL_DEPLOYMENTS,
+  },
+  authenticationModules: {
+    realm: { path: '/realm-config/authentication/modules', version: '2.0' },
+    global: {
+      path: '/global-config/authentication/modules',
+      version: '1.0',
+      deployments: CLASSIC_DEPLOYMENT,
+    },
+    deployments: ALL_DEPLOYMENTS,
+    action: NEXT_DESCENDENTS_ACTION,
+    readonly: true,
+  },
+  authenticationTreesConfiguration: {
+    global: {
+      path: '/global-config/authentication/authenticationtrees',
+      version: '1.0',
+    },
+    deployments: CLASSIC_DEPLOYMENT,
+  },
+  conditionTypes: {
+    realm: { path: '/conditiontypes', version: '1.0' },
+    deployments: ALL_DEPLOYMENTS,
+    queryFilter: TRUE_QUERY_FILTER,
+    readonly: true,
+  },
+  decisionCombiners: {
+    realm: { path: '/decisioncombiners', version: '1.0' },
+    deployments: ALL_DEPLOYMENTS,
+    queryFilter: TRUE_QUERY_FILTER,
+    readonly: true,
+  },
+  secrets: {
+    realm: { path: '/realm-config/secrets', version: '2.0' },
+    global: {
+      path: '/global-config/secrets',
+      version: '1.0',
+      deployments: CLASSIC_DEPLOYMENT,
+    },
+    deployments: ALL_DEPLOYMENTS,
+    action: NEXT_DESCENDENTS_ACTION,
+    readonly: true,
+  },
+  serverInformation: {
+    // Note: Amster documentation says to do this by realm, but it really should be global (the API explorer does it this way and it makes more sense)
+    global: { path: '/serverinfo/*', version: '2.0' },
+    deployments: ALL_DEPLOYMENTS,
+    readonly: true,
+  },
+  serverVersion: {
+    // Note: Amster documentation says to do this by realm, but it really should be global (the API explorer does it this way and it makes more sense)
+    global: { path: '/serverinfo/version', version: '1.0' },
+    deployments: ALL_DEPLOYMENTS,
+    readonly: true,
+  },
+  subjectAttributes: {
+    // Due to a bug with this endpoint, protocol 1.0 is the only way for it to work as of version 7.5.0.
+    realm: { path: '/subjectattributes', version: '1.0', protocol: '1.0' },
+    deployments: ALL_DEPLOYMENTS,
+    queryFilter: TRUE_QUERY_FILTER,
+    readonly: true,
+  },
+  subjectTypes: {
+    realm: { path: '/subjecttypes', version: '1.0' },
+    deployments: ALL_DEPLOYMENTS,
+    queryFilter: TRUE_QUERY_FILTER,
+    readonly: true,
+  },
+  webhookService: {
+    realm: {
+      path: '/realm-config/webhooks',
+      version: '2.0',
+      importWithId: true,
+      queryFilter: TRUE_QUERY_FILTER,
+    },
+    global: {
+      path: '/global-config/webhooks',
+      version: '1.0',
+      ifMatch: '*',
+      deployments: CLASSIC_DEPLOYMENT,
+    },
+    deployments: ALL_DEPLOYMENTS,
+  },
+  wsEntity: {
+    realm: {
+      path: '/realm-config/federation/entityproviders/ws',
+      version: '2.0',
+      importWithId: true,
+    },
+    deployments: ALL_DEPLOYMENTS,
+    queryFilter: TRUE_QUERY_FILTER,
+  },
+};
+
+function getApiConfig(protocol: string, version: string) {
+  return {
+    apiVersion: `protocol=${protocol},resource=${version}`,
+  };
+}
+
+export type ConfigSkeleton = {
+  global: AmConfigEntitiesInterface;
+  realm: Record<string, AmConfigEntitiesInterface>;
+};
+
+/**
+ * Contains information about how to get a config entity.
+ */
+export type EntityInfo = {
+  realm?: EntitySubInfo;
+  global?: EntitySubInfo;
+  deployments?: string[];
+  queryFilter?: string;
+  action?: string;
+  readonly?: boolean;
+};
+
+/**
+ * Contains realm or global specific information about how to get a config entity. Settings like deployments, queryFilter, and action will override the values contained in the parent EntityInfo object if they are provided.
+ */
+export type EntitySubInfo = {
+  path: string;
+  version: string;
+  protocol?: string;
+  ifMatch?: string;
+  importWithId?: boolean;
+  deployments?: string[];
+  queryFilter?: string;
+  action?: string;
+};
+
+export type ConfigEntitySkeleton =
+  | PagedResult<AmConfigEntityInterface>
+  | AmConfigEntityInterface
+  | undefined;
+
+/**
+ * Gets a single am config entity at the given realm and path
+ * @param {string} path path to the entity
+ * @param {string} version the api resource version
+ * @param {string} protocol the api protocol version
+ * @param {string} realm realm that the entity is in (or leave undefined to get global entity)
+ * @param {string} queryFilter the query filter
+ * @param {string} action the action
+ * @returns {Promise<ConfigEntitySkeleton>} the config entity data
+ */
+export async function getConfigEntity({
+  state,
+  path,
+  version,
+  protocol,
+  realm,
+  queryFilter,
+  action,
+}: {
+  state: State;
+  path: string;
+  version: string;
+  protocol?: string;
+  realm?: string;
+  queryFilter?: string;
+  action?: string;
+}): Promise<ConfigEntitySkeleton> {
+  const currentRealm = state.getRealm();
+  if (realm) {
+    state.setRealm(realm);
+  }
+  const urlString = `${state.getHost()}/json${getRealmPathGlobal(
+    !realm,
+    state
+  )}${path}${queryFilter ? `?_queryFilter=${queryFilter}` : ''}${
+    action ? `${queryFilter ? '&' : '?'}_action=${action}` : ''
+  }`;
+  try {
+    const axios = generateAmApi({
+      resource: getApiConfig(protocol ? protocol : DEFAULT_PROTOCOL, version),
+      state,
+    });
+    let data;
+    if (action) {
+      data = (
+        await axios.post(
+          urlString,
+          {},
+          {
+            withCredentials: true,
+          }
+        )
+      ).data;
+    } else {
+      data = (
+        await axios.get(urlString, {
+          withCredentials: true,
+        })
+      ).data;
+    }
+    state.setRealm(currentRealm);
+    return data;
+  } catch (error) {
+    printError({
+      error,
+      message: `Error getting config entity from resource path '${urlString}'`,
+      state,
+    });
+  }
+}
+
+/**
+ * Get all other AM config entities
+ * @returns {Promise<ConfigSkeleton>} a promise that resolves to a config object containing global and realm config entities
+ */
+export async function getConfigEntities({
+  state,
+}: {
+  state: State;
+}): Promise<ConfigSkeleton> {
+  const realms = await getRealmsForExport({ state });
+  const stateRealms = realms.map(getRealmUsingExportFormat);
+  const entities = {
+    global: {},
+    realm: Object.fromEntries(realms.map((r) => [r, {}])),
+  } as ConfigSkeleton;
+  for (const [key, entityInfo] of Object.entries(AM_ENTITIES)) {
+    const deploymentAllowed =
+      entityInfo.deployments &&
+      entityInfo.deployments.includes(state.getDeploymentType());
+    if (
+      entityInfo.global &&
+      ((entityInfo.global.deployments &&
+        entityInfo.global.deployments.includes(state.getDeploymentType())) ||
+        (entityInfo.global.deployments == undefined && deploymentAllowed))
+    ) {
+      try {
+        entities.global[key] = await getConfigEntity({
+          state,
+          path: entityInfo.global.path,
+          version: entityInfo.global.version,
+          protocol: entityInfo.global.protocol,
+          queryFilter: entityInfo.global.queryFilter
+            ? entityInfo.global.queryFilter
+            : entityInfo.queryFilter,
+          action: entityInfo.global.action
+            ? entityInfo.global.action
+            : entityInfo.action,
+        });
+      } catch (e) {
+        printMessage({
+          message: `Error getting '${key}' from resource path '${entityInfo.global.path}': ${e.message}`,
+          type: 'error',
+          state,
+        });
+      }
+    }
+    if (
+      entityInfo.realm &&
+      ((entityInfo.realm.deployments &&
+        entityInfo.realm.deployments.includes(state.getDeploymentType())) ||
+        (entityInfo.realm.deployments == undefined && deploymentAllowed))
+    ) {
+      for (let i = 0; i < realms.length; i++) {
+        try {
+          entities.realm[realms[i]][key] = await getConfigEntity({
+            state,
+            path: entityInfo.realm.path,
+            version: entityInfo.realm.version,
+            protocol: entityInfo.realm.protocol,
+            realm: stateRealms[i],
+            queryFilter: entityInfo.realm.queryFilter
+              ? entityInfo.realm.queryFilter
+              : entityInfo.queryFilter,
+            action: entityInfo.realm.action
+              ? entityInfo.realm.action
+              : entityInfo.action,
+          });
+        } catch (e) {
+          printMessage({
+            message: `Error getting '${key}' from resource path '${entityInfo.realm.path}': ${e.message}`,
+            type: 'error',
+            state,
+          });
+        }
+      }
+    }
+  }
+  return entities;
+}
+
+/**
+ * Puts a single am config entity at the given realm and path
+ * @param {ConfigEntitySkeleton} entityData config entity object. If it's not provided, no import is performed.
+ * @param {string} path path to the entity
+ * @param {string} version the api resource version
+ * @param {string} protocol the api protocol version
+ * @param {string} ifMatch the if match condition
+ * @param {string} realm realm that the entity is in (or leave undefined to get global entity)
+ * @returns {Promise<ConfigEntitySkeleton>} the config entity object
+ */
+export async function putConfigEntity({
+  state,
+  entityData,
+  path,
+  version,
+  protocol,
+  ifMatch,
+  realm,
+}: {
+  state: State;
+  entityData?: ConfigEntitySkeleton;
+  path: string;
+  version: string;
+  protocol?: string;
+  ifMatch?: string;
+  realm?: string;
+}): Promise<ConfigEntitySkeleton> {
+  if (!entityData) {
+    return entityData;
+  }
+  const currentRealm = state.getRealm();
+  if (realm) {
+    state.setRealm(realm);
+  }
+  const urlString = `${state.getHost()}/json${getRealmPathGlobal(
+    !realm,
+    state
+  )}${path}`;
+  try {
+    const { data } = await generateAmApi({
+      resource: getApiConfig(protocol ? protocol : DEFAULT_PROTOCOL, version),
+      state,
+    }).put(urlString, entityData, {
+      withCredentials: true,
+      headers: ifMatch ? { 'If-Match': ifMatch } : {},
+    });
+    state.setRealm(currentRealm);
+    return data;
+  } catch (error) {
+    printError({
+      error,
+      message: `Error putting config entity at resource path '${urlString}'`,
+      state,
+    });
+  }
+}
+
+/**
+ * Put all other AM config entities
+ * @param {ConfigSkeleton} config the config object containing global and realm config entities
+ * @returns {Promise<ConfigSkeleton>} a promise that resolves to a config object containing global and realm config entities
+ */
+export async function putConfigEntities({
+  config,
+  state,
+}: {
+  config: ConfigSkeleton;
+  state: State;
+}): Promise<ConfigSkeleton> {
+  const realms = config.realm ? Object.keys(config.realm) : [];
+  const stateRealms = realms.map(getRealmUsingExportFormat);
+  const entities = {
+    global: {},
+    realm: Object.fromEntries(realms.map((r) => [r, {}])),
+  } as ConfigSkeleton;
+  for (const [key, entityInfo] of Object.entries(AM_ENTITIES)) {
+    if (entityInfo.readonly) {
+      continue;
+    }
+    const deploymentAllowed =
+      entityInfo.deployments &&
+      entityInfo.deployments.includes(state.getDeploymentType());
+    if (
+      entityInfo.global &&
+      ((entityInfo.global.deployments &&
+        entityInfo.global.deployments.includes(state.getDeploymentType())) ||
+        (entityInfo.global.deployments == undefined && deploymentAllowed)) &&
+      config.global &&
+      config.global[key]
+    ) {
+      try {
+        for (const [id, entityData] of Object.entries(config.global[key])) {
+          if (!entities.global[key]) {
+            entities.global[key] = {};
+          }
+          entities.global[key][id] = await putConfigEntity({
+            state,
+            entityData: entityData as ConfigEntitySkeleton,
+            path:
+              entityInfo.global.path +
+              (entityInfo.global.importWithId ? `/${id}` : ''),
+            version: entityInfo.global.version,
+            protocol: entityInfo.global.protocol,
+            ifMatch: entityInfo.global.ifMatch,
+          });
+        }
+      } catch (e) {
+        printMessage({
+          message: `Error putting '${key}' from resource path '${entityInfo.global.path}': ${e.message}`,
+          type: 'error',
+          state,
+        });
+      }
+    }
+    if (
+      entityInfo.realm &&
+      ((entityInfo.realm.deployments &&
+        entityInfo.realm.deployments.includes(state.getDeploymentType())) ||
+        (entityInfo.realm.deployments == undefined && deploymentAllowed))
+    ) {
+      for (let i = 0; i < realms.length; i++) {
+        if (!config.realm[realms[i]][key]) {
+          continue;
+        }
+        try {
+          for (const [id, entityData] of Object.entries(
+            config.realm[realms[i]][key]
+          )) {
+            if (!entities.realm[realms[i]][key]) {
+              entities.realm[realms[i]][key] = {};
+            }
+            entities.realm[realms[i]][key][id] = await putConfigEntity({
+              state,
+              entityData: entityData as ConfigEntitySkeleton,
+              path:
+                entityInfo.realm.path +
+                (entityInfo.realm.importWithId ? `/${id}` : ''),
+              version: entityInfo.realm.version,
+              protocol: entityInfo.realm.protocol,
+              ifMatch: entityInfo.realm.ifMatch,
+              realm: stateRealms[i],
+            });
+          }
+        } catch (e) {
+          printMessage({
+            message: `Error putting '${key}' from resource path '${entityInfo.realm.path}': ${e.message}`,
+            type: 'error',
+            state,
+          });
+        }
+      }
+    }
+  }
+  return entities;
+}

--- a/src/lib/FrodoLib.ts
+++ b/src/lib/FrodoLib.ts
@@ -1,6 +1,7 @@
 // instantiable modules
 import AdminOps, { Admin } from '../ops/AdminOps';
 import AgentOps, { Agent } from '../ops/AgentOps';
+import AmConfigOps, { AmConfig } from '../ops/AmConfigOps';
 import ApiOps, { ApiFactory } from '../ops/ApiFactoryOps';
 import ApplicationOps, { Application } from '../ops/ApplicationOps';
 import AuthenticateOps, { Authenticate } from '../ops/AuthenticateOps';
@@ -95,6 +96,11 @@ export type Frodo = {
   state: State;
   admin: Admin;
   agent: Agent;
+
+  am: {
+    config: AmConfig;
+  };
+
   app: Application;
 
   authn: {
@@ -254,6 +260,11 @@ const FrodoLib = (config: StateInterface = {}): Frodo => {
     state: state,
     admin: AdminOps(state),
     agent: AgentOps(state),
+
+    am: {
+      config: AmConfigOps(state),
+    },
+
     app: ApplicationOps(state),
 
     authn: {

--- a/src/ops/AmConfigOps.test.ts
+++ b/src/ops/AmConfigOps.test.ts
@@ -1,0 +1,147 @@
+/**
+ * To record and update snapshots, you must perform 3 steps in order:
+ *
+ * 1. Record API responses
+ *
+ *    This step breaks down into 2 phases:
+ *
+ *    Phase 1: Record tests that require cloud deployment
+ *    Phase 2: Record tests that require classic deployment
+ *
+ *    Because certain tests can only be successfully ran in classic deployments and/or
+ *    cloud deployments, they have to be run in groups so that it is possible to record
+ *    each group of tests using their appropriate deployments. Make sure to set the
+ *    FRODO_HOST and FRODO_REALM environment variables when recording to ensure you
+ *    are using the right deployment (by default these are set to the frodo-dev cloud tenant
+ *    and alpha realm respectively). Alternatively, you can use FRODO_DEPLOY=classic to
+ *    use the default settings of host/realm for classic deployments.
+ *
+ *    To record API responses, you must call the test:record script and
+ *    override all the connection state required to connect to the
+ *    env to record from:
+ *
+ *    ATTENTION: For the recording to succeed, you MUST make sure to use a
+ *               user account, not a service account.
+ *
+ *        FRODO_DEBUG=1 FRODO_HOST=frodo-dev npm run test:record AmConfigOps
+ *
+ *    The above command assumes that you have a connection profile for
+ *    'frodo-dev' on your development machine.
+ *
+ * 2. Update snapshots
+ *
+ *    After recording API responses, you must manually update/create snapshots
+ *    by running:
+ *
+ *        FRODO_DEBUG=1 npm run test:update AmConfigOps
+ *
+ * 3. Test your changes
+ *
+ *    If 1 and 2 didn't produce any errors, you are ready to run the tests in
+ *    replay mode and make sure they all succeed as well:
+ *
+ *        FRODO_DEBUG=1 npm run test:only AmConfigOps
+ *
+ * Note: FRODO_DEBUG=1 is optional and enables debug logging for some output
+ * in case things don't function as expected
+ */
+import { autoSetupPolly, setDefaultState } from "../utils/AutoSetupPolly";
+import { filterRecording } from "../utils/PollyUtils";
+import * as AmConfigOps from "./AmConfigOps";
+import { state } from "../lib/FrodoLib";
+import Constants from "../shared/Constants";
+
+const ctx = autoSetupPolly();
+
+describe('AmConfigOps', () => {
+  beforeEach(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      ctx.polly.server.any().on('beforePersist', (_req, recording) => {
+        filterRecording(recording);
+      });
+    }
+  });
+
+  // Phase 1
+  if (
+    !process.env.FRODO_POLLY_MODE ||
+    (process.env.FRODO_POLLY_MODE === 'record' &&
+      process.env.FRODO_RECORD_PHASE === '1')
+  ) {
+    describe('Cloud Tests', () => {
+      beforeEach(() => {
+        setDefaultState();
+      });
+      describe('createConfigEntityExportTemplate()', () => {
+        test('0: Method is implemented', async () => {
+          expect(AmConfigOps.createConfigEntityExportTemplate).toBeDefined();
+        });
+
+        test('1: Create AM Config Export Template', async () => {
+          const response = await AmConfigOps.createConfigEntityExportTemplate({realms: ['alpha', 'bravo'], state});
+          expect(response).toMatchSnapshot({
+            meta: expect.any(Object),
+          });
+        });
+
+        test('2: Create AM Config Export Template without provided realms', async () => {
+          const response = await AmConfigOps.createConfigEntityExportTemplate({state});
+          expect(response).toMatchSnapshot({
+            meta: expect.any(Object),
+          });
+        });
+      });
+
+      describe('exportAmConfigEntities()', () => {
+        test('0: Method is implemented', async () => {
+          expect(AmConfigOps.exportAmConfigEntities).toBeDefined();
+        });
+
+        test('1: Export AM Config Entities', async () => {
+          // Set deployment type to cloud since it is necessary for exporting everything correctly. It does this automatically when recording the mock, but not when running the test after recording
+          state.setDeploymentType(Constants.CLOUD_DEPLOYMENT_TYPE_KEY);
+          const response = await AmConfigOps.exportAmConfigEntities({state});
+          expect(response).toMatchSnapshot({
+            meta: expect.any(Object),
+          });
+        });
+      });
+
+      describe('importAmConfigEntities()', () => {
+        test('0: Method is implemented', async () => {
+          expect(AmConfigOps.importAmConfigEntities).toBeDefined();
+        });
+
+        //TODO: Make tests
+      });
+    });
+  }
+
+  // Phase 2
+  if (
+    !process.env.FRODO_POLLY_MODE ||
+    (process.env.FRODO_POLLY_MODE === 'record' &&
+      process.env.FRODO_RECORD_PHASE === '2')
+  ) {
+    describe('Classic Tests', () => {
+      beforeEach(() => {
+        setDefaultState(Constants.CLASSIC_DEPLOYMENT_TYPE_KEY);
+      });
+
+      describe('exportAmConfigEntities()', () => {
+        test('2: Export AM Config Entities', async () => {
+          // Set deployment type to cloud since it is necessary for exporting everything correctly. It does this automatically when recording the mock, but not when running the test after recording
+          state.setDeploymentType(Constants.CLOUD_DEPLOYMENT_TYPE_KEY);
+          const response = await AmConfigOps.exportAmConfigEntities({state});
+          expect(response).toMatchSnapshot({
+            meta: expect.any(Object),
+          });
+        });
+      });
+
+      describe('importAmConfigEntities()', () => {
+        //TODO: Make tests
+      });
+    });
+  }
+});

--- a/src/ops/AmConfigOps.ts
+++ b/src/ops/AmConfigOps.ts
@@ -1,0 +1,236 @@
+import {
+  AmConfigEntitiesInterface,
+  ConfigSkeleton,
+  getConfigEntities,
+  putConfigEntities,
+} from '../api/AmConfigApi';
+import { AmConfigEntityInterface, PagedResult } from '../api/ApiTypes';
+import { State } from '../shared/State';
+import {
+  createProgressIndicator,
+  debugMessage,
+  stopProgressIndicator,
+  updateProgressIndicator,
+} from '../utils/Console';
+import { getMetadata } from '../utils/ExportImportUtils';
+import { getRealmsForExport } from '../utils/ForgeRockUtils';
+import { FrodoError } from './FrodoError';
+import { ExportMetaData } from './OpsTypes';
+
+export type AmConfig = {
+  /**
+   * Create an empty config entity export template
+   * @returns {Promise<ConfigEntityExportInterface>} an empty config entity export template
+   */
+  createConfigEntityExportTemplate(
+    realms?: string[]
+  ): Promise<ConfigEntityExportInterface>;
+  /**
+   * Export all other AM config entities
+   * @returns {Promise<ConfigEntityExportInterface>} promise resolving to a ConfigEntityExportInterface object
+   */
+  exportAmConfigEntities(): Promise<ConfigEntityExportInterface>;
+  /**
+   * Import all other AM config entities
+   * @param {ConfigEntityExportInterface} importData The config import data
+   * @returns {Promise<ConfigSkeleton | null>} a promise that resolves to a config object containing global and realm config entities, or null if no import was performed
+   */
+  importAmConfigEntities(
+    importData: ConfigEntityExportInterface
+  ): Promise<ConfigSkeleton | null>;
+};
+
+export default (state: State): AmConfig => {
+  return {
+    async createConfigEntityExportTemplate(
+      realms?: string[]
+    ): Promise<ConfigEntityExportInterface> {
+      return createConfigEntityExportTemplate({ realms, state });
+    },
+    async exportAmConfigEntities(): Promise<ConfigEntityExportInterface> {
+      return exportAmConfigEntities({ state });
+    },
+    async importAmConfigEntities(
+      importData: ConfigEntityExportInterface
+    ): Promise<ConfigSkeleton | null> {
+      return importAmConfigEntities({ importData, state });
+    },
+  };
+};
+
+export interface ConfigEntityExportInterface {
+  meta?: ExportMetaData;
+  global: Record<string, Record<string, AmConfigEntityInterface>>;
+  realm: Record<
+    string,
+    Record<string, Record<string, AmConfigEntityInterface>>
+  >;
+}
+
+/**
+ * Create an empty config export template
+ * @param {string[]} realms the list of realm names
+ * @returns {Promise<ConfigEntityExportInterface>} an empty config entity export template
+ */
+export async function createConfigEntityExportTemplate({
+  state,
+  realms,
+}: {
+  state: State;
+  realms?: string[];
+}): Promise<ConfigEntityExportInterface> {
+  if (!realms) {
+    realms = await getRealmsForExport({ state });
+  }
+  return {
+    meta: getMetadata({ state }),
+    global: {},
+    realm: Object.fromEntries(realms.map((r) => [r, {}])),
+  } as ConfigEntityExportInterface;
+}
+
+/**
+ * Export all other AM config entities
+ * @returns {Promise<ConfigEntityExportInterface>} promise resolving to a ConfigEntityExportInterface object
+ */
+export async function exportAmConfigEntities({
+  state,
+}: {
+  state: State;
+}): Promise<ConfigEntityExportInterface> {
+  let indicatorId: string;
+  try {
+    debugMessage({
+      message: `AmConfigOps.exportAmConfigEntities: start`,
+      state,
+    });
+    const entities = await getConfigEntities({ state });
+    const exportData = await createConfigEntityExportTemplate({
+      state,
+      realms: Object.keys(entities.realm),
+    });
+    const totalEntities =
+      Object.keys(entities.global).length +
+      Object.values(entities.realm).reduce(
+        (total, realmEntities) => total + Object.keys(realmEntities).length,
+        0
+      );
+    indicatorId = createProgressIndicator({
+      total: totalEntities,
+      message: 'Exporting am config entities...',
+      state,
+    });
+    exportData.global = processConfigEntitiesForExport({
+      state,
+      indicatorId,
+      entities: entities.global,
+    });
+    Object.entries(entities.realm).forEach(
+      ([key, value]) =>
+        (exportData.realm[key] = processConfigEntitiesForExport({
+          state,
+          indicatorId,
+          entities: value,
+        }))
+    );
+    stopProgressIndicator({
+      id: indicatorId,
+      message: `Exported ${totalEntities} am config entities.`,
+      state,
+    });
+    debugMessage({ message: `AmConfigOps.exportAmConfigEntities: end`, state });
+    return exportData;
+  } catch (error) {
+    stopProgressIndicator({
+      id: indicatorId,
+      message: `Error exporting am config entities.`,
+      status: 'fail',
+      state,
+    });
+    throw new FrodoError(`Error exporting am config entities`, error);
+  }
+}
+
+/**
+ * Import all other AM config entities
+ * @param {ConfigEntityExportInterface} importData The config import data
+ * @returns {Promise<ConfigSkeleton | null>} a promise that resolves to a config object containing global and realm config entities, or null if no import was performed
+ */
+export async function importAmConfigEntities({
+  importData,
+  state,
+}: {
+  importData: ConfigEntityExportInterface;
+  state: State;
+}): Promise<ConfigSkeleton | null> {
+  debugMessage({
+    message: `ServiceOps.importAmConfigEntities: start`,
+    state,
+  });
+  try {
+    const result = await putConfigEntities({
+      config: importData as unknown as ConfigSkeleton,
+      state,
+    });
+    debugMessage({ message: `AmConfigOps.importAmConfigEntities: end`, state });
+    // If no import was accomplished, return null
+    if (
+      Object.keys(result.global).length === 0 &&
+      !Object.values(result.realm).find((r) => Object.keys(r).length > 0)
+    ) {
+      return null;
+    }
+    return result;
+  } catch (error) {
+    throw new FrodoError(`Error importing am config entities`, error);
+  }
+}
+
+/**
+ * Helper to process the API results into export format
+ * @param {AmConfigEntities} entities the entities being processed
+ * @param {string} indicatorId the progress indicator id
+ * @returns {Record<string, AmConfigEntityInterface>} the processed entities
+ */
+function processConfigEntitiesForExport({
+  state,
+  entities,
+  indicatorId,
+}: {
+  state: State;
+  entities: AmConfigEntitiesInterface;
+  indicatorId: string;
+}): Record<string, Record<string, AmConfigEntityInterface>> {
+  const exportedEntities = {};
+  const entries = Object.entries(entities);
+  for (const [key, value] of entries) {
+    updateProgressIndicator({
+      id: indicatorId,
+      message: `Exporting ${key}`,
+      state,
+    });
+    const exportedValue = {};
+    if (!value) {
+      continue;
+    }
+    if (!value.result) {
+      if ((value as AmConfigEntityInterface)._id) {
+        exportedValue[(value as AmConfigEntityInterface)._id] = value;
+        exportedEntities[key] = exportedValue;
+      } else if (
+        (value as AmConfigEntityInterface)._type &&
+        (value as AmConfigEntityInterface)._type._id
+      ) {
+        exportedValue[(value as AmConfigEntityInterface)._type._id] = value;
+        exportedEntities[key] = exportedValue;
+      } else {
+        exportedEntities[key] = value;
+      }
+      continue;
+    }
+    const { result } = value as PagedResult<AmConfigEntityInterface>;
+    result.forEach((o) => (exportedValue[o._id] = o));
+    exportedEntities[key] = exportedValue;
+  }
+  return exportedEntities;
+}

--- a/src/test/mock-recordings/AmConfigOps_3426239351/Classic-Tests_743483830/exportAmConfigEntities_4186179787/2-Export-AM-Config-Entities_403082020/recording.har
+++ b/src/test/mock-recordings/AmConfigOps_3426239351/Classic-Tests_743483830/exportAmConfigEntities_4186179787/2-Export-AM-Config-Entities_403082020/recording.har
@@ -1,0 +1,4554 @@
+{
+  "log": {
+    "_recordingName": "AmConfigOps/Classic Tests/exportAmConfigEntities()/2: Export AM Config Entities",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "eb697468085abfef6b608e5d514d9750",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 568,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/realms/?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 540,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 540,
+            "text": "{\"result\":[{\"_id\":\"Lw\",\"_rev\":\"492331277\",\"parentPath\":null,\"active\":true,\"name\":\"/\",\"aliases\":[\"localhost\",\"openam-frodo-dev.classic.com\",\"openam\",\"testurl.com\"]},{\"_id\":\"L2ZpcnN0\",\"_rev\":\"1051737267\",\"parentPath\":\"/\",\"active\":true,\"name\":\"first\",\"aliases\":[\"one\",\"dnsfirst\"]},{\"_id\":\"L2ZpcnN0L3NlY29uZA\",\"_rev\":\"-1167290418\",\"parentPath\":\"/first\",\"active\":false,\"name\":\"second\",\"aliases\":[\"secondDNS\",\"second\"]}],\"resultCount\":3,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "540"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.604Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "c426bec4c6e4c9edc112fa80b40a8fe1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 575,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/applicationtypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1341,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1341,
+            "text": "{\"result\":[{\"_id\":\"umaApplicationType\",\"name\":\"umaApplicationType\",\"actions\":{},\"resourceComparator\":\"org.forgerock.openam.uma.UmaPolicyResourceMatcher\",\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"org.forgerock.openam.uma.UmaPolicySaveIndex\",\"searchIndex\":\"org.forgerock.openam.uma.UmaPolicySearchIndex\"},{\"_id\":\"sunAMDelegationService\",\"name\":\"sunAMDelegationService\",\"actions\":{\"READ\":true,\"MODIFY\":true,\"DELEGATE\":true},\"resourceComparator\":\"com.sun.identity.entitlement.RegExResourceName\",\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"com.sun.identity.entitlement.opensso.DelegationResourceNameIndexGenerator\",\"searchIndex\":\"com.sun.identity.entitlement.opensso.DelegationResourceNameSplitter\"},{\"_id\":\"iPlanetAMWebAgentService\",\"name\":\"iPlanetAMWebAgentService\",\"actions\":{\"HEAD\":true,\"DELETE\":true,\"POST\":true,\"GET\":true,\"OPTIONS\":true,\"PUT\":true,\"PATCH\":true},\"resourceComparator\":\"com.sun.identity.entitlement.URLResourceName\",\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"org.forgerock.openam.entitlement.indextree.TreeSaveIndex\",\"searchIndex\":\"org.forgerock.openam.entitlement.indextree.TreeSearchIndex\"}],\"resultCount\":3,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1341"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.621Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "b2e1e76f847112ebbebb9f4a3b6daff6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 588,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/applicationtypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1341,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1341,
+            "text": "{\"result\":[{\"_id\":\"umaApplicationType\",\"name\":\"umaApplicationType\",\"actions\":{},\"resourceComparator\":\"org.forgerock.openam.uma.UmaPolicyResourceMatcher\",\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"org.forgerock.openam.uma.UmaPolicySaveIndex\",\"searchIndex\":\"org.forgerock.openam.uma.UmaPolicySearchIndex\"},{\"_id\":\"sunAMDelegationService\",\"name\":\"sunAMDelegationService\",\"actions\":{\"READ\":true,\"MODIFY\":true,\"DELEGATE\":true},\"resourceComparator\":\"com.sun.identity.entitlement.RegExResourceName\",\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"com.sun.identity.entitlement.opensso.DelegationResourceNameIndexGenerator\",\"searchIndex\":\"com.sun.identity.entitlement.opensso.DelegationResourceNameSplitter\"},{\"_id\":\"iPlanetAMWebAgentService\",\"name\":\"iPlanetAMWebAgentService\",\"actions\":{\"HEAD\":true,\"DELETE\":true,\"POST\":true,\"GET\":true,\"OPTIONS\":true,\"PUT\":true,\"PATCH\":true},\"resourceComparator\":\"com.sun.identity.entitlement.URLResourceName\",\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"org.forgerock.openam.entitlement.indextree.TreeSaveIndex\",\"searchIndex\":\"org.forgerock.openam.entitlement.indextree.TreeSearchIndex\"}],\"resultCount\":3,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1341"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.637Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "2d20e9e2c4bf0838a319b8db3c9917d4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 602,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realms/second/applicationtypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1341,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1341,
+            "text": "{\"result\":[{\"_id\":\"umaApplicationType\",\"name\":\"umaApplicationType\",\"actions\":{},\"resourceComparator\":\"org.forgerock.openam.uma.UmaPolicyResourceMatcher\",\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"org.forgerock.openam.uma.UmaPolicySaveIndex\",\"searchIndex\":\"org.forgerock.openam.uma.UmaPolicySearchIndex\"},{\"_id\":\"sunAMDelegationService\",\"name\":\"sunAMDelegationService\",\"actions\":{\"READ\":true,\"MODIFY\":true,\"DELEGATE\":true},\"resourceComparator\":\"com.sun.identity.entitlement.RegExResourceName\",\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"com.sun.identity.entitlement.opensso.DelegationResourceNameIndexGenerator\",\"searchIndex\":\"com.sun.identity.entitlement.opensso.DelegationResourceNameSplitter\"},{\"_id\":\"iPlanetAMWebAgentService\",\"name\":\"iPlanetAMWebAgentService\",\"actions\":{\"HEAD\":true,\"DELETE\":true,\"POST\":true,\"GET\":true,\"OPTIONS\":true,\"PUT\":true,\"PATCH\":true},\"resourceComparator\":\"com.sun.identity.entitlement.URLResourceName\",\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"org.forgerock.openam.entitlement.indextree.TreeSaveIndex\",\"searchIndex\":\"org.forgerock.openam.entitlement.indextree.TreeSearchIndex\"}],\"resultCount\":3,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1341"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.645Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      },
+      {
+        "_id": "1f8e327660d8b21ea224a12080b31c72",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 593,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realm-config/authentication/chains?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 686,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 686,
+            "text": "{\"result\":[{\"_id\":\"amsterService\",\"_rev\":\"644917310\",\"loginPostProcessClass\":[],\"authChainConfiguration\":[{\"module\":\"Amster\",\"criteria\":\"REQUIRED\",\"options\":{}}],\"loginSuccessUrl\":[],\"loginFailureUrl\":[],\"_type\":{\"_id\":\"EMPTY\",\"name\":\"Authentication Configuration\",\"collection\":true}},{\"_id\":\"ldapService\",\"_rev\":\"357765346\",\"loginPostProcessClass\":[],\"authChainConfiguration\":[{\"module\":\"DataStore\",\"criteria\":\"REQUIRED\",\"options\":{}}],\"loginSuccessUrl\":[],\"loginFailureUrl\":[],\"_type\":{\"_id\":\"EMPTY\",\"name\":\"Authentication Configuration\",\"collection\":true}}],\"resultCount\":2,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "686"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.653Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "944c4947782014980962c47952c62871",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 606,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realm-config/authentication/chains?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 686,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 686,
+            "text": "{\"result\":[{\"_id\":\"amsterService\",\"_rev\":\"644917310\",\"loginPostProcessClass\":[],\"authChainConfiguration\":[{\"module\":\"Amster\",\"criteria\":\"REQUIRED\",\"options\":{}}],\"loginSuccessUrl\":[],\"loginFailureUrl\":[],\"_type\":{\"_id\":\"EMPTY\",\"name\":\"Authentication Configuration\",\"collection\":true}},{\"_id\":\"ldapService\",\"_rev\":\"357765346\",\"loginPostProcessClass\":[],\"authChainConfiguration\":[{\"module\":\"DataStore\",\"criteria\":\"REQUIRED\",\"options\":{}}],\"loginSuccessUrl\":[],\"loginFailureUrl\":[],\"_type\":{\"_id\":\"EMPTY\",\"name\":\"Authentication Configuration\",\"collection\":true}}],\"resultCount\":2,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "686"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.669Z",
+        "time": 4,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4
+        }
+      },
+      {
+        "_id": "25942edffa1a4f106d805387e16c8840",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 620,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realms/second/realm-config/authentication/chains?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 686,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 686,
+            "text": "{\"result\":[{\"_id\":\"amsterService\",\"_rev\":\"644917310\",\"loginPostProcessClass\":[],\"authChainConfiguration\":[{\"module\":\"Amster\",\"criteria\":\"REQUIRED\",\"options\":{}}],\"loginSuccessUrl\":[],\"loginFailureUrl\":[],\"_type\":{\"_id\":\"EMPTY\",\"name\":\"Authentication Configuration\",\"collection\":true}},{\"_id\":\"ldapService\",\"_rev\":\"357765346\",\"loginPostProcessClass\":[],\"authChainConfiguration\":[{\"module\":\"DataStore\",\"criteria\":\"REQUIRED\",\"options\":{}}],\"loginSuccessUrl\":[],\"loginFailureUrl\":[],\"_type\":{\"_id\":\"EMPTY\",\"name\":\"Authentication Configuration\",\"collection\":true}}],\"resultCount\":2,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "686"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.679Z",
+        "time": 14,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 14
+        }
+      },
+      {
+        "_id": "788f84832b115ddecf70fb6197162e1a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 620,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realm-config/authentication/modules?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 2245,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 2245,
+            "text": "{\"result\":[{\"authenticationLevel\":0,\"_id\":\"datastore\",\"_type\":{\"_id\":\"datastore\",\"name\":\"Data Store\",\"collection\":true}},{\"minimumPasswordLength\":\"8\",\"trustAllServerCertificates\":false,\"connectionHeartbeatInterval\":10,\"userSearchAttributes\":[\"uid\"],\"operationTimeout\":0,\"beheraPasswordPolicySupportEnabled\":true,\"userBindDN\":\"cn=Directory Manager\",\"primaryLdapServer\":[\"localhost:50636\"],\"userSearchStartDN\":[\"dc=openam,dc=forgerock,dc=org\"],\"profileAttributeMappings\":[],\"stopLdapbindAfterInmemoryLockedEnabled\":false,\"returnUserDN\":true,\"secondaryLdapServer\":[],\"userBindPassword\":null,\"connectionHeartbeatTimeUnit\":\"SECONDS\",\"openam-auth-ldap-connection-mode\":\"LDAPS\",\"authenticationLevel\":0,\"searchScope\":\"SUBTREE\",\"userProfileRetrievalAttribute\":\"uid\",\"_id\":\"ldap\",\"_type\":{\"_id\":\"ldap\",\"name\":\"LDAP\",\"collection\":true}},{\"userProfileEmailAttribute\":\"mail\",\"otpDeliveryMethod\":\"SMS and E-mail\",\"smtpSslEnabled\":\"SSL\",\"userProfileTelephoneAttribute\":\"telephoneNumber\",\"authenticationLevel\":0,\"smtpHostname\":\"smtp.gmail.com\",\"smtpHostPort\":465,\"smtpUserPassword\":null,\"smtpUsername\":\"opensso.sun\",\"smtpFromAddress\":\"no-reply@openam.org\",\"otpValidityDuration\":5,\"autoSendOTP\":false,\"otpMaxRetry\":3,\"otpLength\":\"8\",\"smsGatewayClass\":\"com.sun.identity.authentication.modules.hotp.DefaultSMSGatewayImpl\",\"_id\":\"hotp\",\"_type\":{\"_id\":\"hotp\",\"name\":\"HOTP\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"federation\",\"_type\":{\"_id\":\"federation\",\"name\":\"Federation\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"sae\",\"_type\":{\"_id\":\"sae\",\"name\":\"SAE\",\"collection\":true}},{\"addChecksum\":\"False\",\"forgerock-oath-sharedsecret-implementation-class\":\"org.forgerock.openam.authentication.modules.oath.plugins.DefaultSharedSecretProvider\",\"oathAlgorithm\":\"HOTP\",\"timeStepSize\":30,\"truncationOffset\":-1,\"stepsInWindow\":2,\"forgerock-oath-maximum-clock-drift\":0,\"authenticationLevel\":0,\"oathOtpMaxRetry\":3,\"hotpWindowSize\":100,\"passwordLength\":\"6\",\"minimumSecretKeyLength\":\"32\",\"_id\":\"oath\",\"_type\":{\"_id\":\"oath\",\"name\":\"OATH\",\"collection\":true}},{\"authorizedKeys\":\"/home/prestonhales/am/security/keys/amster/authorized_keys\",\"authenticationLevel\":0,\"enabled\":true,\"_id\":\"amster\",\"_type\":{\"_id\":\"amster\",\"name\":\"ForgeRock Amster\",\"collection\":true}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2245"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 466,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.699Z",
+        "time": 44,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 44
+        }
+      },
+      {
+        "_id": "852736e3bf7d46b8ab672a45c768eb8f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 633,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realm-config/authentication/modules?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 2245,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 2245,
+            "text": "{\"result\":[{\"authenticationLevel\":0,\"_id\":\"datastore\",\"_type\":{\"_id\":\"datastore\",\"name\":\"Data Store\",\"collection\":true}},{\"minimumPasswordLength\":\"8\",\"trustAllServerCertificates\":false,\"connectionHeartbeatInterval\":10,\"userSearchAttributes\":[\"uid\"],\"operationTimeout\":0,\"beheraPasswordPolicySupportEnabled\":true,\"userBindDN\":\"cn=Directory Manager\",\"primaryLdapServer\":[\"localhost:50636\"],\"userSearchStartDN\":[\"dc=openam,dc=forgerock,dc=org\"],\"profileAttributeMappings\":[],\"stopLdapbindAfterInmemoryLockedEnabled\":false,\"returnUserDN\":true,\"secondaryLdapServer\":[],\"userBindPassword\":null,\"connectionHeartbeatTimeUnit\":\"SECONDS\",\"openam-auth-ldap-connection-mode\":\"LDAPS\",\"authenticationLevel\":0,\"searchScope\":\"SUBTREE\",\"userProfileRetrievalAttribute\":\"uid\",\"_id\":\"ldap\",\"_type\":{\"_id\":\"ldap\",\"name\":\"LDAP\",\"collection\":true}},{\"userProfileEmailAttribute\":\"mail\",\"otpDeliveryMethod\":\"SMS and E-mail\",\"smtpSslEnabled\":\"SSL\",\"userProfileTelephoneAttribute\":\"telephoneNumber\",\"authenticationLevel\":0,\"smtpHostname\":\"smtp.gmail.com\",\"smtpHostPort\":465,\"smtpUserPassword\":null,\"smtpUsername\":\"opensso.sun\",\"smtpFromAddress\":\"no-reply@openam.org\",\"otpValidityDuration\":5,\"autoSendOTP\":false,\"otpMaxRetry\":3,\"otpLength\":\"8\",\"smsGatewayClass\":\"com.sun.identity.authentication.modules.hotp.DefaultSMSGatewayImpl\",\"_id\":\"hotp\",\"_type\":{\"_id\":\"hotp\",\"name\":\"HOTP\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"federation\",\"_type\":{\"_id\":\"federation\",\"name\":\"Federation\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"sae\",\"_type\":{\"_id\":\"sae\",\"name\":\"SAE\",\"collection\":true}},{\"addChecksum\":\"False\",\"forgerock-oath-sharedsecret-implementation-class\":\"org.forgerock.openam.authentication.modules.oath.plugins.DefaultSharedSecretProvider\",\"oathAlgorithm\":\"HOTP\",\"timeStepSize\":30,\"truncationOffset\":-1,\"stepsInWindow\":2,\"forgerock-oath-maximum-clock-drift\":0,\"authenticationLevel\":0,\"oathOtpMaxRetry\":3,\"hotpWindowSize\":100,\"passwordLength\":\"6\",\"minimumSecretKeyLength\":\"32\",\"_id\":\"oath\",\"_type\":{\"_id\":\"oath\",\"name\":\"OATH\",\"collection\":true}},{\"authorizedKeys\":\"/home/prestonhales/am/security/keys/amster/authorized_keys\",\"authenticationLevel\":0,\"enabled\":true,\"_id\":\"amster\",\"_type\":{\"_id\":\"amster\",\"name\":\"ForgeRock Amster\",\"collection\":true}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2245"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 466,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.749Z",
+        "time": 51,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 51
+        }
+      },
+      {
+        "_id": "c1582cd0908b92ec27b4aed42f13b347",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 647,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realms/second/realm-config/authentication/modules?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 2245,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 2245,
+            "text": "{\"result\":[{\"authenticationLevel\":0,\"_id\":\"datastore\",\"_type\":{\"_id\":\"datastore\",\"name\":\"Data Store\",\"collection\":true}},{\"minimumPasswordLength\":\"8\",\"trustAllServerCertificates\":false,\"connectionHeartbeatInterval\":10,\"userSearchAttributes\":[\"uid\"],\"operationTimeout\":0,\"beheraPasswordPolicySupportEnabled\":true,\"userBindDN\":\"cn=Directory Manager\",\"primaryLdapServer\":[\"localhost:50636\"],\"userSearchStartDN\":[\"dc=openam,dc=forgerock,dc=org\"],\"profileAttributeMappings\":[],\"stopLdapbindAfterInmemoryLockedEnabled\":false,\"returnUserDN\":true,\"secondaryLdapServer\":[],\"userBindPassword\":null,\"connectionHeartbeatTimeUnit\":\"SECONDS\",\"openam-auth-ldap-connection-mode\":\"LDAPS\",\"authenticationLevel\":0,\"searchScope\":\"SUBTREE\",\"userProfileRetrievalAttribute\":\"uid\",\"_id\":\"ldap\",\"_type\":{\"_id\":\"ldap\",\"name\":\"LDAP\",\"collection\":true}},{\"userProfileEmailAttribute\":\"mail\",\"otpDeliveryMethod\":\"SMS and E-mail\",\"smtpSslEnabled\":\"SSL\",\"userProfileTelephoneAttribute\":\"telephoneNumber\",\"authenticationLevel\":0,\"smtpHostname\":\"smtp.gmail.com\",\"smtpHostPort\":465,\"smtpUserPassword\":null,\"smtpUsername\":\"opensso.sun\",\"smtpFromAddress\":\"no-reply@openam.org\",\"otpValidityDuration\":5,\"autoSendOTP\":false,\"otpMaxRetry\":3,\"otpLength\":\"8\",\"smsGatewayClass\":\"com.sun.identity.authentication.modules.hotp.DefaultSMSGatewayImpl\",\"_id\":\"hotp\",\"_type\":{\"_id\":\"hotp\",\"name\":\"HOTP\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"federation\",\"_type\":{\"_id\":\"federation\",\"name\":\"Federation\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"sae\",\"_type\":{\"_id\":\"sae\",\"name\":\"SAE\",\"collection\":true}},{\"addChecksum\":\"False\",\"forgerock-oath-sharedsecret-implementation-class\":\"org.forgerock.openam.authentication.modules.oath.plugins.DefaultSharedSecretProvider\",\"oathAlgorithm\":\"HOTP\",\"timeStepSize\":30,\"truncationOffset\":-1,\"stepsInWindow\":2,\"forgerock-oath-maximum-clock-drift\":0,\"authenticationLevel\":0,\"oathOtpMaxRetry\":3,\"hotpWindowSize\":100,\"passwordLength\":\"6\",\"minimumSecretKeyLength\":\"32\",\"_id\":\"oath\",\"_type\":{\"_id\":\"oath\",\"name\":\"OATH\",\"collection\":true}},{\"authorizedKeys\":\"/home/prestonhales/am/security/keys/amster/authorized_keys\",\"authenticationLevel\":0,\"enabled\":true,\"_id\":\"amster\",\"_type\":{\"_id\":\"amster\",\"name\":\"ForgeRock Amster\",\"collection\":true}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2245"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 466,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.805Z",
+        "time": 52,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 52
+        }
+      },
+      {
+        "_id": "0d273976f7cb8615d0f7eefecca5ee98",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 573,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/conditiontypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 3505,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 3505,
+            "text": "{\"result\":[{\"_id\":\"AMIdentityMembership\",\"title\":\"AMIdentityMembership\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"amIdentityName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"AND\",\"title\":\"AND\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"conditions\":{\"type\":\"array\"}}}},{\"_id\":\"AuthLevel\",\"title\":\"AuthLevel\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authLevel\":{\"type\":\"integer\"}}}},{\"_id\":\"AuthScheme\",\"title\":\"AuthScheme\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authScheme\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"applicationIdleTimeout\":{\"type\":\"integer\"},\"applicationName\":{\"type\":\"string\"}}}},{\"_id\":\"AuthenticateToRealm\",\"title\":\"AuthenticateToRealm\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticateToRealm\":{\"type\":\"string\"}}}},{\"_id\":\"AuthenticateToService\",\"title\":\"AuthenticateToService\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticateToService\":{\"type\":\"string\"}}}},{\"_id\":\"IPv4\",\"title\":\"IPv4\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startIp\":{\"type\":\"string\"},\"endIp\":{\"type\":\"string\"},\"dnsName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"IPv6\",\"title\":\"IPv6\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startIp\":{\"type\":\"string\"},\"endIp\":{\"type\":\"string\"},\"dnsName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"LDAPFilter\",\"title\":\"LDAPFilter\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"ldapFilter\":{\"type\":\"string\"}}}},{\"_id\":\"LEAuthLevel\",\"title\":\"LEAuthLevel\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authLevel\":{\"type\":\"integer\"}}}},{\"_id\":\"NOT\",\"title\":\"NOT\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"condition\":{\"type\":\"object\",\"properties\":{}}}}},{\"_id\":\"OAuth2Scope\",\"title\":\"OAuth2Scope\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"requiredScopes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"OR\",\"title\":\"OR\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"conditions\":{\"type\":\"array\"}}}},{\"_id\":\"Policy\",\"title\":\"Policy\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"className\":{\"type\":\"string\"},\"properties\":{\"type\":\"object\"}}}},{\"_id\":\"ResourceEnvIP\",\"title\":\"ResourceEnvIP\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"resourceEnvIPConditionValue\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"Script\",\"title\":\"Script\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"scriptId\":{\"type\":\"string\"}}}},{\"_id\":\"Session\",\"title\":\"Session\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"maxSessionTime\":{\"type\":\"integer\"},\"terminateSession\":{\"type\":\"boolean\",\"required\":true}}}},{\"_id\":\"SessionProperty\",\"title\":\"SessionProperty\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"ignoreValueCase\":{\"type\":\"boolean\",\"required\":true},\"properties\":{\"type\":\"object\"}}}},{\"_id\":\"SimpleTime\",\"title\":\"SimpleTime\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startTime\":{\"type\":\"string\"},\"endTime\":{\"type\":\"string\"},\"startDay\":{\"type\":\"string\"},\"endDay\":{\"type\":\"string\"},\"startDate\":{\"type\":\"string\"},\"endDate\":{\"type\":\"string\"},\"enforcementTimeZone\":{\"type\":\"string\"}}}},{\"_id\":\"Transaction\",\"title\":\"Transaction\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticationStrategy\":{\"type\":\"string\"},\"strategySpecifier\":{\"type\":\"string\"}}}}],\"resultCount\":20,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "3505"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.863Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "e769b011d89094c5d6c5962bbbc0727c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 586,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/conditiontypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 3505,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 3505,
+            "text": "{\"result\":[{\"_id\":\"AMIdentityMembership\",\"title\":\"AMIdentityMembership\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"amIdentityName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"AND\",\"title\":\"AND\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"conditions\":{\"type\":\"array\"}}}},{\"_id\":\"AuthLevel\",\"title\":\"AuthLevel\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authLevel\":{\"type\":\"integer\"}}}},{\"_id\":\"AuthScheme\",\"title\":\"AuthScheme\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authScheme\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"applicationIdleTimeout\":{\"type\":\"integer\"},\"applicationName\":{\"type\":\"string\"}}}},{\"_id\":\"AuthenticateToRealm\",\"title\":\"AuthenticateToRealm\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticateToRealm\":{\"type\":\"string\"}}}},{\"_id\":\"AuthenticateToService\",\"title\":\"AuthenticateToService\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticateToService\":{\"type\":\"string\"}}}},{\"_id\":\"IPv4\",\"title\":\"IPv4\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startIp\":{\"type\":\"string\"},\"endIp\":{\"type\":\"string\"},\"dnsName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"IPv6\",\"title\":\"IPv6\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startIp\":{\"type\":\"string\"},\"endIp\":{\"type\":\"string\"},\"dnsName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"LDAPFilter\",\"title\":\"LDAPFilter\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"ldapFilter\":{\"type\":\"string\"}}}},{\"_id\":\"LEAuthLevel\",\"title\":\"LEAuthLevel\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authLevel\":{\"type\":\"integer\"}}}},{\"_id\":\"NOT\",\"title\":\"NOT\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"condition\":{\"type\":\"object\",\"properties\":{}}}}},{\"_id\":\"OAuth2Scope\",\"title\":\"OAuth2Scope\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"requiredScopes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"OR\",\"title\":\"OR\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"conditions\":{\"type\":\"array\"}}}},{\"_id\":\"Policy\",\"title\":\"Policy\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"className\":{\"type\":\"string\"},\"properties\":{\"type\":\"object\"}}}},{\"_id\":\"ResourceEnvIP\",\"title\":\"ResourceEnvIP\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"resourceEnvIPConditionValue\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"Script\",\"title\":\"Script\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"scriptId\":{\"type\":\"string\"}}}},{\"_id\":\"Session\",\"title\":\"Session\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"maxSessionTime\":{\"type\":\"integer\"},\"terminateSession\":{\"type\":\"boolean\",\"required\":true}}}},{\"_id\":\"SessionProperty\",\"title\":\"SessionProperty\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"ignoreValueCase\":{\"type\":\"boolean\",\"required\":true},\"properties\":{\"type\":\"object\"}}}},{\"_id\":\"SimpleTime\",\"title\":\"SimpleTime\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startTime\":{\"type\":\"string\"},\"endTime\":{\"type\":\"string\"},\"startDay\":{\"type\":\"string\"},\"endDay\":{\"type\":\"string\"},\"startDate\":{\"type\":\"string\"},\"endDate\":{\"type\":\"string\"},\"enforcementTimeZone\":{\"type\":\"string\"}}}},{\"_id\":\"Transaction\",\"title\":\"Transaction\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticationStrategy\":{\"type\":\"string\"},\"strategySpecifier\":{\"type\":\"string\"}}}}],\"resultCount\":20,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "3505"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.869Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "2461b700422e3a6cbd891caadff4e9c9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 600,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realms/second/conditiontypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 3505,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 3505,
+            "text": "{\"result\":[{\"_id\":\"AMIdentityMembership\",\"title\":\"AMIdentityMembership\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"amIdentityName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"AND\",\"title\":\"AND\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"conditions\":{\"type\":\"array\"}}}},{\"_id\":\"AuthLevel\",\"title\":\"AuthLevel\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authLevel\":{\"type\":\"integer\"}}}},{\"_id\":\"AuthScheme\",\"title\":\"AuthScheme\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authScheme\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"applicationIdleTimeout\":{\"type\":\"integer\"},\"applicationName\":{\"type\":\"string\"}}}},{\"_id\":\"AuthenticateToRealm\",\"title\":\"AuthenticateToRealm\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticateToRealm\":{\"type\":\"string\"}}}},{\"_id\":\"AuthenticateToService\",\"title\":\"AuthenticateToService\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticateToService\":{\"type\":\"string\"}}}},{\"_id\":\"IPv4\",\"title\":\"IPv4\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startIp\":{\"type\":\"string\"},\"endIp\":{\"type\":\"string\"},\"dnsName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"IPv6\",\"title\":\"IPv6\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startIp\":{\"type\":\"string\"},\"endIp\":{\"type\":\"string\"},\"dnsName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"LDAPFilter\",\"title\":\"LDAPFilter\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"ldapFilter\":{\"type\":\"string\"}}}},{\"_id\":\"LEAuthLevel\",\"title\":\"LEAuthLevel\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authLevel\":{\"type\":\"integer\"}}}},{\"_id\":\"NOT\",\"title\":\"NOT\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"condition\":{\"type\":\"object\",\"properties\":{}}}}},{\"_id\":\"OAuth2Scope\",\"title\":\"OAuth2Scope\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"requiredScopes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"OR\",\"title\":\"OR\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"conditions\":{\"type\":\"array\"}}}},{\"_id\":\"Policy\",\"title\":\"Policy\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"className\":{\"type\":\"string\"},\"properties\":{\"type\":\"object\"}}}},{\"_id\":\"ResourceEnvIP\",\"title\":\"ResourceEnvIP\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"resourceEnvIPConditionValue\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"Script\",\"title\":\"Script\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"scriptId\":{\"type\":\"string\"}}}},{\"_id\":\"Session\",\"title\":\"Session\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"maxSessionTime\":{\"type\":\"integer\"},\"terminateSession\":{\"type\":\"boolean\",\"required\":true}}}},{\"_id\":\"SessionProperty\",\"title\":\"SessionProperty\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"ignoreValueCase\":{\"type\":\"boolean\",\"required\":true},\"properties\":{\"type\":\"object\"}}}},{\"_id\":\"SimpleTime\",\"title\":\"SimpleTime\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startTime\":{\"type\":\"string\"},\"endTime\":{\"type\":\"string\"},\"startDay\":{\"type\":\"string\"},\"endDay\":{\"type\":\"string\"},\"startDate\":{\"type\":\"string\"},\"endDate\":{\"type\":\"string\"},\"enforcementTimeZone\":{\"type\":\"string\"}}}},{\"_id\":\"Transaction\",\"title\":\"Transaction\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticationStrategy\":{\"type\":\"string\"},\"strategySpecifier\":{\"type\":\"string\"}}}}],\"resultCount\":20,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "3505"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.876Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "f2b816d038942f9491cab71932335c93",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 576,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/decisioncombiners?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 182,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 182,
+            "text": "{\"result\":[{\"_id\":\"DenyOverride\",\"title\":\"DenyOverride\"}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.883Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "7e98d74748df68ba7a6263e58c7fec56",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/decisioncombiners?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 182,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 182,
+            "text": "{\"result\":[{\"_id\":\"DenyOverride\",\"title\":\"DenyOverride\"}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.889Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "98b9288352212752f60b81bf260b8500",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 603,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realms/second/decisioncombiners?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 182,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 182,
+            "text": "{\"result\":[{\"_id\":\"DenyOverride\",\"title\":\"DenyOverride\"}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.893Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "3390a06531c831ed59c684dd225c63b9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 605,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realm-config/secrets?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 13,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 13,
+            "text": "{\"result\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "13"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 464,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.898Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "13733c47f2daf768f909866ffa9fe2e7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 618,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realm-config/secrets?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 13,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 13,
+            "text": "{\"result\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "13"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 464,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.904Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "495e428c463c3279681fcb798830e647",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 632,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realms/second/realm-config/secrets?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 13,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 13,
+            "text": "{\"result\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "13"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 464,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.909Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "a92fbf6a95676ead13c4d7e1621eb0a1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 563,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 563,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1352294770\",\"domains\":[null],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"iPlanetDirectoryPro\",\"secureCookie\":false,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":false,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1352294770\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "563"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 486,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.914Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "aa49f3ff76d93ac5b0dbc7d6f8a32b44",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 547,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 258,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 258,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-1772220916\",\"version\":\"7.5.0\",\"fullVersion\":\"ForgeRock Access Management 7.5.0 Build 89116d59a1ebe73ed1931dd3649adb7f217cd06b (2024-March-28 16:00)\",\"revision\":\"89116d59a1ebe73ed1931dd3649adb7f217cd06b\",\"date\":\"2024-March-28 16:00\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-1772220916\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "258"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 487,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.920Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "c1f9b21132b93e7115da94f5a83f72b4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 576,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/subjectattributes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1622,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1622,
+            "text": "{\"result\":[\"iplanet-am-user-admin-start-dn\",\"push2faEnabled\",\"createTimestamp\",\"uid\",\"iplanet-am-user-auth-config\",\"boundDevices\",\"thingKeys\",\"retryLimitNodeCount\",\"thingType\",\"iplanet-am-session-max-idle-time\",\"lastEmailSent\",\"oathDeviceProfiles\",\"userCertificate\",\"kbaInfo\",\"iplanet-am-auth-configuration\",\"iplanet-am-user-account-life\",\"kbaActiveIndex\",\"iplanet-am-session-service-status\",\"sun-fm-saml2-nameid-infokey\",\"iplanet-am-session-max-session-time\",\"sun-fm-saml2-nameid-info\",\"kbaInfoAttempts\",\"preferredtimezone\",\"memberOf\",\"userPassword\",\"pushDeviceProfiles\",\"thingConfig\",\"assignedDashboard\",\"inetUserHttpURL\",\"preferredlanguage\",\"oath2faEnabled\",\"iplanet-am-user-password-reset-options\",\"iplanet-am-session-max-caching-time\",\"dn\",\"webauthnDeviceProfiles\",\"mail\",\"objectClass\",\"modifyTimestamp\",\"iplanet-am-session-destroy-sessions\",\"deviceProfiles\",\"inetUserStatus\",\"authorityRevocationList\",\"thingProperties\",\"iplanet-am-session-quota-limit\",\"caCertificate\",\"iplanet-am-user-auth-modules\",\"sn\",\"telephoneNumber\",\"manager\",\"iplanet-am-user-password-reset-force-reset\",\"cn\",\"adminRole\",\"sunAMAuthInvalidAttemptsData\",\"givenName\",\"iplanet-am-user-success-url\",\"thingOAuth2ClientName\",\"iplanet-am-session-get-valid-sessions\",\"postalAddress\",\"devicePrintProfiles\",\"preferredLocale\",\"employeeNumber\",\"sunIdentityMSISDNNumber\",\"iplanet-am-user-failure-url\",\"distinguishedName\",\"iplanet-am-user-alias-list\",\"iplanet-am-user-password-reset-question-answer\",\"iplanet-am-user-login-status\"],\"resultCount\":67,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":0,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=1.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1622"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.925Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "284e8e2c6bf3a8fa43271f86c475f77b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/subjectattributes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1542,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1542,
+            "text": "{\"result\":[\"iplanet-am-user-admin-start-dn\",\"push2faEnabled\",\"createTimestamp\",\"uid\",\"iplanet-am-user-auth-config\",\"boundDevices\",\"retryLimitNodeCount\",\"iplanet-am-session-max-idle-time\",\"lastEmailSent\",\"oathDeviceProfiles\",\"userCertificate\",\"kbaInfo\",\"iplanet-am-auth-configuration\",\"iplanet-am-user-account-life\",\"kbaActiveIndex\",\"iplanet-am-session-service-status\",\"sun-fm-saml2-nameid-infokey\",\"iplanet-am-session-max-session-time\",\"sun-fm-saml2-nameid-info\",\"kbaInfoAttempts\",\"preferredtimezone\",\"memberOf\",\"userPassword\",\"pushDeviceProfiles\",\"assignedDashboard\",\"inetUserHttpURL\",\"preferredlanguage\",\"oath2faEnabled\",\"iplanet-am-user-password-reset-options\",\"iplanet-am-session-max-caching-time\",\"dn\",\"webauthnDeviceProfiles\",\"mail\",\"objectClass\",\"modifyTimestamp\",\"iplanet-am-session-destroy-sessions\",\"deviceProfiles\",\"inetUserStatus\",\"authorityRevocationList\",\"iplanet-am-session-quota-limit\",\"caCertificate\",\"iplanet-am-user-auth-modules\",\"sn\",\"telephoneNumber\",\"manager\",\"iplanet-am-user-password-reset-force-reset\",\"cn\",\"adminRole\",\"sunAMAuthInvalidAttemptsData\",\"givenName\",\"iplanet-am-user-success-url\",\"iplanet-am-session-get-valid-sessions\",\"postalAddress\",\"devicePrintProfiles\",\"preferredLocale\",\"employeeNumber\",\"sunIdentityMSISDNNumber\",\"iplanet-am-user-failure-url\",\"distinguishedName\",\"iplanet-am-user-alias-list\",\"iplanet-am-user-password-reset-question-answer\",\"iplanet-am-user-login-status\"],\"resultCount\":62,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":0,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=1.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1542"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.932Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "0c4c212316c4b5fecb1dc306b9213247",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 603,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realms/second/subjectattributes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1542,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1542,
+            "text": "{\"result\":[\"iplanet-am-user-admin-start-dn\",\"push2faEnabled\",\"createTimestamp\",\"uid\",\"iplanet-am-user-auth-config\",\"boundDevices\",\"retryLimitNodeCount\",\"iplanet-am-session-max-idle-time\",\"lastEmailSent\",\"oathDeviceProfiles\",\"userCertificate\",\"kbaInfo\",\"iplanet-am-auth-configuration\",\"iplanet-am-user-account-life\",\"kbaActiveIndex\",\"iplanet-am-session-service-status\",\"sun-fm-saml2-nameid-infokey\",\"iplanet-am-session-max-session-time\",\"sun-fm-saml2-nameid-info\",\"kbaInfoAttempts\",\"preferredtimezone\",\"memberOf\",\"userPassword\",\"pushDeviceProfiles\",\"assignedDashboard\",\"inetUserHttpURL\",\"preferredlanguage\",\"oath2faEnabled\",\"iplanet-am-user-password-reset-options\",\"iplanet-am-session-max-caching-time\",\"dn\",\"webauthnDeviceProfiles\",\"mail\",\"objectClass\",\"modifyTimestamp\",\"iplanet-am-session-destroy-sessions\",\"deviceProfiles\",\"inetUserStatus\",\"authorityRevocationList\",\"iplanet-am-session-quota-limit\",\"caCertificate\",\"iplanet-am-user-auth-modules\",\"sn\",\"telephoneNumber\",\"manager\",\"iplanet-am-user-password-reset-force-reset\",\"cn\",\"adminRole\",\"sunAMAuthInvalidAttemptsData\",\"givenName\",\"iplanet-am-user-success-url\",\"iplanet-am-session-get-valid-sessions\",\"postalAddress\",\"devicePrintProfiles\",\"preferredLocale\",\"employeeNumber\",\"sunIdentityMSISDNNumber\",\"iplanet-am-user-failure-url\",\"distinguishedName\",\"iplanet-am-user-alias-list\",\"iplanet-am-user-password-reset-question-answer\",\"iplanet-am-user-login-status\"],\"resultCount\":62,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":0,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=1.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1542"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.937Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "06e8d6eb7f64590e79c9176346ea74d3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 571,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/subjecttypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1206,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1206,
+            "text": "{\"result\":[{\"_id\":\"AND\",\"title\":\"AND\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subjects\":{\"type\":\"array\"}}}},{\"_id\":\"AuthenticatedUsers\",\"title\":\"AuthenticatedUsers\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{}}},{\"_id\":\"Identity\",\"title\":\"Identity\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"subjectValues\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"JwtClaim\",\"title\":\"JwtClaim\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"claimName\":{\"type\":\"string\"},\"claimValue\":{\"type\":\"string\"}}}},{\"_id\":\"NONE\",\"title\":\"NONE\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{}}},{\"_id\":\"NOT\",\"title\":\"NOT\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subject\":{\"type\":\"object\",\"properties\":{}}}}},{\"_id\":\"OR\",\"title\":\"OR\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subjects\":{\"type\":\"array\"}}}},{\"_id\":\"Policy\",\"title\":\"Policy\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"className\":{\"type\":\"string\"},\"values\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}}],\"resultCount\":8,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1206"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.942Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "9ecf5e4820ad306d6dce52ef4ff90437",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 584,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/subjecttypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1206,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1206,
+            "text": "{\"result\":[{\"_id\":\"AND\",\"title\":\"AND\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subjects\":{\"type\":\"array\"}}}},{\"_id\":\"AuthenticatedUsers\",\"title\":\"AuthenticatedUsers\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{}}},{\"_id\":\"Identity\",\"title\":\"Identity\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"subjectValues\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"JwtClaim\",\"title\":\"JwtClaim\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"claimName\":{\"type\":\"string\"},\"claimValue\":{\"type\":\"string\"}}}},{\"_id\":\"NONE\",\"title\":\"NONE\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{}}},{\"_id\":\"NOT\",\"title\":\"NOT\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subject\":{\"type\":\"object\",\"properties\":{}}}}},{\"_id\":\"OR\",\"title\":\"OR\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subjects\":{\"type\":\"array\"}}}},{\"_id\":\"Policy\",\"title\":\"Policy\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"className\":{\"type\":\"string\"},\"values\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}}],\"resultCount\":8,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1206"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.947Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "9ce9f8208bcf496d74904cf3c5ad7f91",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 598,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realms/second/subjecttypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1206,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1206,
+            "text": "{\"result\":[{\"_id\":\"AND\",\"title\":\"AND\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subjects\":{\"type\":\"array\"}}}},{\"_id\":\"AuthenticatedUsers\",\"title\":\"AuthenticatedUsers\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{}}},{\"_id\":\"Identity\",\"title\":\"Identity\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"subjectValues\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"JwtClaim\",\"title\":\"JwtClaim\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"claimName\":{\"type\":\"string\"},\"claimValue\":{\"type\":\"string\"}}}},{\"_id\":\"NONE\",\"title\":\"NONE\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{}}},{\"_id\":\"NOT\",\"title\":\"NOT\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subject\":{\"type\":\"object\",\"properties\":{}}}}},{\"_id\":\"OR\",\"title\":\"OR\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subjects\":{\"type\":\"array\"}}}},{\"_id\":\"Policy\",\"title\":\"Policy\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"className\":{\"type\":\"string\"},\"values\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}}],\"resultCount\":8,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1206"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.952Z",
+        "time": 1,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1
+        }
+      },
+      {
+        "_id": "0d21aba3571beb564eb6a439845dae0e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 580,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realm-config/webhooks?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 473,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 473,
+            "text": "{\"result\":[{\"_id\":\"Cool Webhook\",\"_rev\":\"1386996185\",\"url\":\"test\",\"headers\":{\"accept\":\"*/*\",\"cool\":\"test\"},\"body\":\"body\",\"_type\":{\"_id\":\"webhooks\",\"name\":\"Webhook Service\",\"collection\":true}},{\"_id\":\"Test Webhook\",\"_rev\":\"2105362594\",\"headers\":{\"accept\":\"*/*\"},\"body\":\"hello\",\"_type\":{\"_id\":\"webhooks\",\"name\":\"Webhook Service\",\"collection\":true}}],\"resultCount\":2,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "473"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.957Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "b7f9bd808e7b497cfdc6743976a03ad3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 593,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realm-config/webhooks?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 273,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 273,
+            "text": "{\"result\":[{\"_id\":\"webhooks\",\"_rev\":\"1954901829\",\"headers\":{\"accept\":\"*/*\"},\"_type\":{\"_id\":\"webhooks\",\"name\":\"Webhook Service\",\"collection\":true}}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "273"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.974Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "0d325343bb64528cf8526c4d5680c8a6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 607,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realms/second/realm-config/webhooks?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 273,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 273,
+            "text": "{\"result\":[{\"_id\":\"webhooks\",\"_rev\":\"1954901829\",\"headers\":{\"accept\":\"*/*\"},\"_type\":{\"_id\":\"webhooks\",\"name\":\"Webhook Service\",\"collection\":true}}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "273"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.981Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "793a27f1bb756a04b52cdb6863ebc513",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 601,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realm-config/federation/entityproviders/ws?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 236,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 236,
+            "text": "{\"result\":[{\"_id\":\"ws\",\"_rev\":\"720692750\",\"_type\":{\"_id\":\"ws\",\"name\":\"Entity Descriptor \",\"collection\":true}}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "236"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:15.992Z",
+        "time": 4,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4
+        }
+      },
+      {
+        "_id": "b05de0403c6385f635b26a29de2e0b16",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 614,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realm-config/federation/entityproviders/ws?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 236,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 236,
+            "text": "{\"result\":[{\"_id\":\"ws\",\"_rev\":\"720692750\",\"_type\":{\"_id\":\"ws\",\"name\":\"Entity Descriptor \",\"collection\":true}}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "236"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:16.000Z",
+        "time": 2,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2
+        }
+      },
+      {
+        "_id": "cdd6ee5d9afcdeea7efeca5b757ce79a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7b0f4a1a-1e6a-43ca-b63e-96fbde2f79dc"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.classic.com:8080"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/realms/root/realms/first/realms/second/realm-config/federation/entityproviders/ws?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 236,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 236,
+            "text": "{\"result\":[{\"_id\":\"ws\",\"_rev\":\"720692750\",\"_type\":{\"_id\":\"ws\",\"name\":\"Entity Descriptor \",\"collection\":true}}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "236"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:16:15 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:16:16.006Z",
+        "time": 3,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/AmConfigOps_3426239351/Cloud-Tests_2178067211/createConfigEntityExportTemplate_2250574419/2-Create-AM-Config-Export-Template-without-provided-realms_1977906186/recording.har
+++ b/src/test/mock-recordings/AmConfigOps_3426239351/Cloud-Tests_2178067211/createConfigEntityExportTemplate_2250574419/2-Create-AM-Config-Export-Template-without-provided-realms_1977906186/recording.har
@@ -1,0 +1,166 @@
+{
+  "log": {
+    "_recordingName": "AmConfigOps/Cloud Tests/createConfigEntityExportTemplate()/2: Create AM Config Export Template without provided realms",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "fc71be44855f4e764537c68893e9a626",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1970,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/global-config/realms/?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 331,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 331,
+            "text": "{\"result\":[{\"_id\":\"L2FscGhh\",\"_rev\":\"362268810\",\"parentPath\":\"/\",\"active\":true,\"name\":\"alpha\",\"aliases\":[]},{\"_id\":\"L2JyYXZv\",\"_rev\":\"480875699\",\"parentPath\":\"/\",\"active\":true,\"name\":\"bravo\",\"aliases\":[]}],\"resultCount\":2,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:49 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 800,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:49.881Z",
+        "time": 333,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 333
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/AmConfigOps_3426239351/Cloud-Tests_2178067211/exportAmConfigEntities_4186179787/1-Export-AM-Config-Entities_1503066215/recording.har
+++ b/src/test/mock-recordings/AmConfigOps_3426239351/Cloud-Tests_2178067211/exportAmConfigEntities_4186179787/1-Export-AM-Config-Entities_1503066215/recording.har
@@ -1,0 +1,3544 @@
+{
+  "log": {
+    "_recordingName": "AmConfigOps/Cloud Tests/exportAmConfigEntities()/1: Export AM Config Entities",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "fc71be44855f4e764537c68893e9a626",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1970,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/global-config/realms/?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 331,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 331,
+            "text": "{\"result\":[{\"_id\":\"L2FscGhh\",\"_rev\":\"362268810\",\"parentPath\":\"/\",\"active\":true,\"name\":\"alpha\",\"aliases\":[]},{\"_id\":\"L2JyYXZv\",\"_rev\":\"480875699\",\"parentPath\":\"/\",\"active\":true,\"name\":\"bravo\",\"aliases\":[]}],\"resultCount\":2,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:49 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 800,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:50.226Z",
+        "time": 307,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 307
+        }
+      },
+      {
+        "_id": "1ee245d6a72b8aeb85a5c7986e8ba2f8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1990,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/applicationtypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1341,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1341,
+            "text": "{\"result\":[{\"_id\":\"umaApplicationType\",\"name\":\"umaApplicationType\",\"actions\":{},\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"org.forgerock.openam.uma.UmaPolicySaveIndex\",\"searchIndex\":\"org.forgerock.openam.uma.UmaPolicySearchIndex\",\"resourceComparator\":\"org.forgerock.openam.uma.UmaPolicyResourceMatcher\"},{\"_id\":\"sunAMDelegationService\",\"name\":\"sunAMDelegationService\",\"actions\":{\"READ\":true,\"MODIFY\":true,\"DELEGATE\":true},\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"com.sun.identity.entitlement.opensso.DelegationResourceNameIndexGenerator\",\"searchIndex\":\"com.sun.identity.entitlement.opensso.DelegationResourceNameSplitter\",\"resourceComparator\":\"com.sun.identity.entitlement.RegExResourceName\"},{\"_id\":\"iPlanetAMWebAgentService\",\"name\":\"iPlanetAMWebAgentService\",\"actions\":{\"HEAD\":true,\"DELETE\":true,\"POST\":true,\"GET\":true,\"OPTIONS\":true,\"PUT\":true,\"PATCH\":true},\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"org.forgerock.openam.entitlement.indextree.TreeSaveIndex\",\"searchIndex\":\"org.forgerock.openam.entitlement.indextree.TreeSearchIndex\",\"resourceComparator\":\"com.sun.identity.entitlement.URLResourceName\"}],\"resultCount\":3,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1341"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:50 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:50.539Z",
+        "time": 181,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 181
+        }
+      },
+      {
+        "_id": "d876647120f52b0656df716a2ca8f904",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1990,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/applicationtypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1341,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1341,
+            "text": "{\"result\":[{\"_id\":\"umaApplicationType\",\"name\":\"umaApplicationType\",\"actions\":{},\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"org.forgerock.openam.uma.UmaPolicySaveIndex\",\"searchIndex\":\"org.forgerock.openam.uma.UmaPolicySearchIndex\",\"resourceComparator\":\"org.forgerock.openam.uma.UmaPolicyResourceMatcher\"},{\"_id\":\"sunAMDelegationService\",\"name\":\"sunAMDelegationService\",\"actions\":{\"READ\":true,\"MODIFY\":true,\"DELEGATE\":true},\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"com.sun.identity.entitlement.opensso.DelegationResourceNameIndexGenerator\",\"searchIndex\":\"com.sun.identity.entitlement.opensso.DelegationResourceNameSplitter\",\"resourceComparator\":\"com.sun.identity.entitlement.RegExResourceName\"},{\"_id\":\"iPlanetAMWebAgentService\",\"name\":\"iPlanetAMWebAgentService\",\"actions\":{\"HEAD\":true,\"DELETE\":true,\"POST\":true,\"GET\":true,\"OPTIONS\":true,\"PUT\":true,\"PATCH\":true},\"applicationClassName\":\"com.sun.identity.entitlement.Application\",\"saveIndex\":\"org.forgerock.openam.entitlement.indextree.TreeSaveIndex\",\"searchIndex\":\"org.forgerock.openam.entitlement.indextree.TreeSearchIndex\",\"resourceComparator\":\"com.sun.identity.entitlement.URLResourceName\"}],\"resultCount\":3,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1341"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:50 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:50.726Z",
+        "time": 75,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 75
+        }
+      },
+      {
+        "_id": "c2d4a07670ee940e56f162278f36c82f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2008,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/authentication/chains?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:50 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:50.808Z",
+        "time": 95,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 95
+        }
+      },
+      {
+        "_id": "a7b3dee181192a76be1cb161727428c9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2008,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/realm-config/authentication/chains?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:50 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:50.909Z",
+        "time": 95,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 95
+        }
+      },
+      {
+        "_id": "b47cd65f921c415d1041c0465ea1b1d9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2035,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/authentication/modules?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 2399,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 2399,
+            "text": "{\"result\":[{\"authenticationLevel\":0,\"_id\":\"datastore\",\"_type\":{\"_id\":\"datastore\",\"name\":\"Data Store\",\"collection\":true}},{\"minimumPasswordLength\":\"8\",\"trustAllServerCertificates\":false,\"connectionHeartbeatInterval\":10,\"userSearchAttributes\":[\"uid\"],\"operationTimeout\":0,\"beheraPasswordPolicySupportEnabled\":true,\"userBindDN\":\"uid=admin\",\"primaryLdapServer\":[\"userstore-1.userstore:1389\",\"userstore-0.userstore:1389\",\"userstore-2.userstore:1389\"],\"userSearchStartDN\":[\"ou=identities\"],\"profileAttributeMappings\":[],\"stopLdapbindAfterInmemoryLockedEnabled\":false,\"returnUserDN\":true,\"secondaryLdapServer\":[],\"userBindPassword\":null,\"connectionHeartbeatTimeUnit\":\"SECONDS\",\"openam-auth-ldap-connection-mode\":\"LDAP\",\"authenticationLevel\":0,\"searchScope\":\"SUBTREE\",\"userProfileRetrievalAttribute\":\"uid\",\"_id\":\"ldap\",\"_type\":{\"_id\":\"ldap\",\"name\":\"LDAP\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"sae\",\"_type\":{\"_id\":\"sae\",\"name\":\"SAE\",\"collection\":true}},{\"userProfileEmailAttribute\":\"mail\",\"otpDeliveryMethod\":\"SMS and E-mail\",\"smtpSslEnabled\":\"SSL\",\"userProfileTelephoneAttribute\":\"telephoneNumber\",\"authenticationLevel\":0,\"smtpHostname\":\"smtp.gmail.com\",\"smtpHostPort\":465,\"smtpUserPassword\":null,\"smtpUsername\":\"opensso.sun\",\"smtpFromAddress\":\"no-reply@openam.org\",\"otpValidityDuration\":5,\"autoSendOTP\":false,\"otpMaxRetry\":3,\"otpLength\":\"8\",\"smsGatewayClass\":\"com.sun.identity.authentication.modules.hotp.DefaultSMSGatewayImpl\",\"_id\":\"hotp\",\"_type\":{\"_id\":\"hotp\",\"name\":\"HOTP\",\"collection\":true}},{\"addChecksum\":\"False\",\"forgerock-oath-sharedsecret-implementation-class\":\"org.forgerock.openam.authentication.modules.oath.plugins.DefaultSharedSecretProvider\",\"oathAlgorithm\":\"HOTP\",\"timeStepSize\":30,\"truncationOffset\":-1,\"stepsInWindow\":2,\"forgerock-oath-maximum-clock-drift\":0,\"authenticationLevel\":0,\"oathOtpMaxRetry\":3,\"hotpWindowSize\":100,\"passwordLength\":\"6\",\"minimumSecretKeyLength\":\"32\",\"_id\":\"oath\",\"_type\":{\"_id\":\"oath\",\"name\":\"OATH\",\"collection\":true}},{\"authorizedKeys\":\"/home/forgerock/openam/security/keys/amster/authorized_keys\",\"authenticationLevel\":0,\"enabled\":true,\"_id\":\"amster\",\"_type\":{\"_id\":\"amster\",\"name\":\"ForgeRock Amster\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"Federation\",\"_type\":{\"_id\":\"federation\",\"name\":\"Federation\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"federation\",\"_type\":{\"_id\":\"federation\",\"name\":\"Federation\",\"collection\":true}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2399"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:50 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:51.012Z",
+        "time": 355,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 355
+        }
+      },
+      {
+        "_id": "b8ff1d20d159ad74ea258b92b97de742",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2035,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/realm-config/authentication/modules?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 2399,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 2399,
+            "text": "{\"result\":[{\"authenticationLevel\":0,\"_id\":\"datastore\",\"_type\":{\"_id\":\"datastore\",\"name\":\"Data Store\",\"collection\":true}},{\"minimumPasswordLength\":\"8\",\"trustAllServerCertificates\":false,\"connectionHeartbeatInterval\":10,\"userSearchAttributes\":[\"uid\"],\"operationTimeout\":0,\"beheraPasswordPolicySupportEnabled\":true,\"userBindDN\":\"uid=admin\",\"primaryLdapServer\":[\"userstore-1.userstore:1389\",\"userstore-0.userstore:1389\",\"userstore-2.userstore:1389\"],\"userSearchStartDN\":[\"ou=identities\"],\"profileAttributeMappings\":[],\"stopLdapbindAfterInmemoryLockedEnabled\":false,\"returnUserDN\":true,\"secondaryLdapServer\":[],\"userBindPassword\":null,\"connectionHeartbeatTimeUnit\":\"SECONDS\",\"openam-auth-ldap-connection-mode\":\"LDAP\",\"authenticationLevel\":0,\"searchScope\":\"SUBTREE\",\"userProfileRetrievalAttribute\":\"uid\",\"_id\":\"ldap\",\"_type\":{\"_id\":\"ldap\",\"name\":\"LDAP\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"sae\",\"_type\":{\"_id\":\"sae\",\"name\":\"SAE\",\"collection\":true}},{\"userProfileEmailAttribute\":\"mail\",\"otpDeliveryMethod\":\"SMS and E-mail\",\"smtpSslEnabled\":\"SSL\",\"userProfileTelephoneAttribute\":\"telephoneNumber\",\"authenticationLevel\":0,\"smtpHostname\":\"smtp.gmail.com\",\"smtpHostPort\":465,\"smtpUserPassword\":null,\"smtpUsername\":\"opensso.sun\",\"smtpFromAddress\":\"no-reply@openam.org\",\"otpValidityDuration\":5,\"autoSendOTP\":false,\"otpMaxRetry\":3,\"otpLength\":\"8\",\"smsGatewayClass\":\"com.sun.identity.authentication.modules.hotp.DefaultSMSGatewayImpl\",\"_id\":\"hotp\",\"_type\":{\"_id\":\"hotp\",\"name\":\"HOTP\",\"collection\":true}},{\"addChecksum\":\"False\",\"forgerock-oath-sharedsecret-implementation-class\":\"org.forgerock.openam.authentication.modules.oath.plugins.DefaultSharedSecretProvider\",\"oathAlgorithm\":\"HOTP\",\"timeStepSize\":30,\"truncationOffset\":-1,\"stepsInWindow\":2,\"forgerock-oath-maximum-clock-drift\":0,\"authenticationLevel\":0,\"oathOtpMaxRetry\":3,\"hotpWindowSize\":100,\"passwordLength\":\"6\",\"minimumSecretKeyLength\":\"32\",\"_id\":\"oath\",\"_type\":{\"_id\":\"oath\",\"name\":\"OATH\",\"collection\":true}},{\"authorizedKeys\":\"/home/forgerock/openam/security/keys/amster/authorized_keys\",\"authenticationLevel\":0,\"enabled\":true,\"_id\":\"amster\",\"_type\":{\"_id\":\"amster\",\"name\":\"ForgeRock Amster\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"Federation\",\"_type\":{\"_id\":\"federation\",\"name\":\"Federation\",\"collection\":true}},{\"authenticationLevel\":0,\"_id\":\"federation\",\"_type\":{\"_id\":\"federation\",\"name\":\"Federation\",\"collection\":true}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2399"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:50 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:51.374Z",
+        "time": 242,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 242
+        }
+      },
+      {
+        "_id": "83913e91127b48641d8342a82e8f62f8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/conditiontypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 3505,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 3505,
+            "text": "{\"result\":[{\"_id\":\"AMIdentityMembership\",\"title\":\"AMIdentityMembership\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"amIdentityName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"AND\",\"title\":\"AND\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"conditions\":{\"type\":\"array\"}}}},{\"_id\":\"AuthLevel\",\"title\":\"AuthLevel\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authLevel\":{\"type\":\"integer\"}}}},{\"_id\":\"AuthScheme\",\"title\":\"AuthScheme\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authScheme\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"applicationIdleTimeout\":{\"type\":\"integer\"},\"applicationName\":{\"type\":\"string\"}}}},{\"_id\":\"AuthenticateToRealm\",\"title\":\"AuthenticateToRealm\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticateToRealm\":{\"type\":\"string\"}}}},{\"_id\":\"AuthenticateToService\",\"title\":\"AuthenticateToService\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticateToService\":{\"type\":\"string\"}}}},{\"_id\":\"IPv4\",\"title\":\"IPv4\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startIp\":{\"type\":\"string\"},\"endIp\":{\"type\":\"string\"},\"dnsName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"IPv6\",\"title\":\"IPv6\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startIp\":{\"type\":\"string\"},\"endIp\":{\"type\":\"string\"},\"dnsName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"LDAPFilter\",\"title\":\"LDAPFilter\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"ldapFilter\":{\"type\":\"string\"}}}},{\"_id\":\"LEAuthLevel\",\"title\":\"LEAuthLevel\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authLevel\":{\"type\":\"integer\"}}}},{\"_id\":\"NOT\",\"title\":\"NOT\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"condition\":{\"type\":\"object\",\"properties\":{}}}}},{\"_id\":\"OAuth2Scope\",\"title\":\"OAuth2Scope\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"requiredScopes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"OR\",\"title\":\"OR\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"conditions\":{\"type\":\"array\"}}}},{\"_id\":\"Policy\",\"title\":\"Policy\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"className\":{\"type\":\"string\"},\"properties\":{\"type\":\"object\"}}}},{\"_id\":\"ResourceEnvIP\",\"title\":\"ResourceEnvIP\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"resourceEnvIPConditionValue\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"Script\",\"title\":\"Script\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"scriptId\":{\"type\":\"string\"}}}},{\"_id\":\"Session\",\"title\":\"Session\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"maxSessionTime\":{\"type\":\"integer\"},\"terminateSession\":{\"type\":\"boolean\",\"required\":true}}}},{\"_id\":\"SessionProperty\",\"title\":\"SessionProperty\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"ignoreValueCase\":{\"type\":\"boolean\",\"required\":true},\"properties\":{\"type\":\"object\"}}}},{\"_id\":\"SimpleTime\",\"title\":\"SimpleTime\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startTime\":{\"type\":\"string\"},\"endTime\":{\"type\":\"string\"},\"startDay\":{\"type\":\"string\"},\"endDay\":{\"type\":\"string\"},\"startDate\":{\"type\":\"string\"},\"endDate\":{\"type\":\"string\"},\"enforcementTimeZone\":{\"type\":\"string\"}}}},{\"_id\":\"Transaction\",\"title\":\"Transaction\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticationStrategy\":{\"type\":\"string\"},\"strategySpecifier\":{\"type\":\"string\"}}}}],\"resultCount\":20,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "3505"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:51.621Z",
+        "time": 71,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 71
+        }
+      },
+      {
+        "_id": "e3ebc1998ec72c07d35f838ed992a5ac",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1988,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/conditiontypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 3505,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 3505,
+            "text": "{\"result\":[{\"_id\":\"AMIdentityMembership\",\"title\":\"AMIdentityMembership\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"amIdentityName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"AND\",\"title\":\"AND\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"conditions\":{\"type\":\"array\"}}}},{\"_id\":\"AuthLevel\",\"title\":\"AuthLevel\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authLevel\":{\"type\":\"integer\"}}}},{\"_id\":\"AuthScheme\",\"title\":\"AuthScheme\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authScheme\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"applicationIdleTimeout\":{\"type\":\"integer\"},\"applicationName\":{\"type\":\"string\"}}}},{\"_id\":\"AuthenticateToRealm\",\"title\":\"AuthenticateToRealm\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticateToRealm\":{\"type\":\"string\"}}}},{\"_id\":\"AuthenticateToService\",\"title\":\"AuthenticateToService\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticateToService\":{\"type\":\"string\"}}}},{\"_id\":\"IPv4\",\"title\":\"IPv4\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startIp\":{\"type\":\"string\"},\"endIp\":{\"type\":\"string\"},\"dnsName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"IPv6\",\"title\":\"IPv6\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startIp\":{\"type\":\"string\"},\"endIp\":{\"type\":\"string\"},\"dnsName\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"LDAPFilter\",\"title\":\"LDAPFilter\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"ldapFilter\":{\"type\":\"string\"}}}},{\"_id\":\"LEAuthLevel\",\"title\":\"LEAuthLevel\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authLevel\":{\"type\":\"integer\"}}}},{\"_id\":\"NOT\",\"title\":\"NOT\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"condition\":{\"type\":\"object\",\"properties\":{}}}}},{\"_id\":\"OAuth2Scope\",\"title\":\"OAuth2Scope\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"requiredScopes\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"OR\",\"title\":\"OR\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"conditions\":{\"type\":\"array\"}}}},{\"_id\":\"Policy\",\"title\":\"Policy\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"className\":{\"type\":\"string\"},\"properties\":{\"type\":\"object\"}}}},{\"_id\":\"ResourceEnvIP\",\"title\":\"ResourceEnvIP\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"resourceEnvIPConditionValue\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"Script\",\"title\":\"Script\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"scriptId\":{\"type\":\"string\"}}}},{\"_id\":\"Session\",\"title\":\"Session\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"maxSessionTime\":{\"type\":\"integer\"},\"terminateSession\":{\"type\":\"boolean\",\"required\":true}}}},{\"_id\":\"SessionProperty\",\"title\":\"SessionProperty\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"ignoreValueCase\":{\"type\":\"boolean\",\"required\":true},\"properties\":{\"type\":\"object\"}}}},{\"_id\":\"SimpleTime\",\"title\":\"SimpleTime\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"startTime\":{\"type\":\"string\"},\"endTime\":{\"type\":\"string\"},\"startDay\":{\"type\":\"string\"},\"endDay\":{\"type\":\"string\"},\"startDate\":{\"type\":\"string\"},\"endDate\":{\"type\":\"string\"},\"enforcementTimeZone\":{\"type\":\"string\"}}}},{\"_id\":\"Transaction\",\"title\":\"Transaction\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"authenticationStrategy\":{\"type\":\"string\"},\"strategySpecifier\":{\"type\":\"string\"}}}}],\"resultCount\":20,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "3505"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:51.698Z",
+        "time": 67,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 67
+        }
+      },
+      {
+        "_id": "7c1684919d3c39aaa988c6a4a3ac4363",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1991,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/decisioncombiners?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 182,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 182,
+            "text": "{\"result\":[{\"_id\":\"DenyOverride\",\"title\":\"DenyOverride\"}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 793,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:51.770Z",
+        "time": 67,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 67
+        }
+      },
+      {
+        "_id": "eb3bb38284a35b06c8bb5dad3480c315",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1991,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/decisioncombiners?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 182,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 182,
+            "text": "{\"result\":[{\"_id\":\"DenyOverride\",\"title\":\"DenyOverride\"}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 793,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:51.844Z",
+        "time": 71,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 71
+        }
+      },
+      {
+        "_id": "df263574b44b634fbcd214acb78c9527",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2020,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/secrets?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 13,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 13,
+            "text": "{\"result\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "13"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 765,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:51.922Z",
+        "time": 73,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 73
+        }
+      },
+      {
+        "_id": "15b970472b5c4ac0bc1eca62d9f16e8d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2020,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "nextdescendents"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/realm-config/secrets?_action=nextdescendents"
+        },
+        "response": {
+          "bodySize": 13,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 13,
+            "text": "{\"result\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "13"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 765,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.000Z",
+        "time": 65,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 65
+        }
+      },
+      {
+        "_id": "33c52e4ceb99b07961cc4718e320cd5c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1943,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 588,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 588,
+            "text": "{\"_id\":\"*\",\"_rev\":\"-1019531729\",\"domains\":[\"openam-frodo-dev.forgeblocks.com\"],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-1019531729\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "588"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 788,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.070Z",
+        "time": 72,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 72
+        }
+      },
+      {
+        "_id": "aa10efcdc38c441b757de1bbca70d9de",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1949,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 282,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 282,
+            "text": "{\"_id\":\"version\",\"_rev\":\"355151460\",\"version\":\"7.6.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.6.0-SNAPSHOT Build 493165657bbb9390016bd43ca767a46f23d8d24a (2024-September-23 14:30)\",\"revision\":\"493165657bbb9390016bd43ca767a46f23d8d24a\",\"date\":\"2024-September-23 14:30\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"355151460\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "282"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.147Z",
+        "time": 68,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 68
+        }
+      },
+      {
+        "_id": "c7a304b05d6dbb5961330aefc0fb3ab7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1991,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/subjectattributes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 2960,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 2960,
+            "text": "{\"result\":[\"fr-idm-role\",\"description\",\"l\",\"createTimestamp\",\"uid\",\"fr-idm-nick-name\",\"fr-attr-iint4\",\"fr-attr-str5\",\"iplanet-am-user-auth-config\",\"boundDevices\",\"retryLimitNodeCount\",\"st\",\"oathDeviceProfiles\",\"userCertificate\",\"labeledURI\",\"iplanet-am-auth-configuration\",\"fr-attr-istr1\",\"fr-idm-profile-url\",\"iplanet-am-session-service-status\",\"fr-attr-imulti1\",\"sun-fm-saml2-nameid-infokey\",\"fr-attr-int4\",\"fr-attr-str3\",\"fr-idm-inviteDate\",\"fr-idm-managed-organization-member\",\"sun-fm-saml2-nameid-info\",\"fr-attr-idate5\",\"kbaInfoAttempts\",\"fr-idm-preferences\",\"fr-attr-multi5\",\"memberOf\",\"fr-idm-photos\",\"co\",\"userPassword\",\"pushDeviceProfiles\",\"fr-attr-iint2\",\"fr-idm-birthdate\",\"oath2faEnabled\",\"iplanet-am-user-password-reset-options\",\"fr-idm-uuid\",\"iplanet-am-session-max-caching-time\",\"fr-attr-int2\",\"pwdExpireWarning\",\"webauthnDeviceProfiles\",\"fr-idm-effectiveAssignment\",\"objectClass\",\"fr-attr-date3\",\"isMemberOf\",\"fr-attr-imulti5\",\"fr-attr-imulti2\",\"fr-idm-name\",\"iplanet-am-session-quota-limit\",\"caCertificate\",\"iplanet-am-user-auth-modules\",\"fr-attr-multi4\",\"fr-idm-managed-user-memberoforgid\",\"telephoneNumber\",\"fr-idm-kbaInfo\",\"street\",\"cn\",\"ds-pwp-account-disabled\",\"fr-attr-istr4\",\"fr-idm-phone-numbers\",\"fr-attr-date1\",\"givenName\",\"fr-idm-addresses\",\"postalAddress\",\"fr-idm-gender\",\"fr-attr-multi2\",\"iplanet-am-user-failure-url\",\"distinguishedName\",\"postalCode\",\"iplanet-am-user-admin-start-dn\",\"pwdCheckQuality\",\"push2faEnabled\",\"pwdMinLength\",\"fr-attr-istr2\",\"fr-attr-int3\",\"iplanet-am-session-max-idle-time\",\"fr-idm-website\",\"fr-idm-custom-attrs\",\"fr-idm-password\",\"fr-attr-idate4\",\"kbaInfo\",\"fr-attr-str4\",\"iplanet-am-user-account-life\",\"kbaActiveIndex\",\"fr-attr-multi1\",\"fr-idm-title\",\"iplanet-am-session-max-session-time\",\"fr-attr-int1\",\"fr-attr-iint5\",\"fr-attr-date5\",\"preferredtimezone\",\"fr-attr-date2\",\"fr-attr-idate2\",\"assignedDashboard\",\"inetUserHttpURL\",\"preferredlanguage\",\"dn\",\"fr-idm-timezone\",\"mail\",\"fr-attr-str2\",\"modifyTimestamp\",\"iplanet-am-session-destroy-sessions\",\"fr-attr-iint3\",\"fr-attr-multi3\",\"deviceProfiles\",\"fr-attr-str1\",\"inetUserStatus\",\"authorityRevocationList\",\"fr-attr-istr5\",\"fr-idm-preferred-language\",\"fr-attr-imulti4\",\"fr-idm-emails\",\"sn\",\"fr-idm-effectiveRole\",\"manager\",\"fr-idm-lastChanged\",\"iplanet-am-user-password-reset-force-reset\",\"fr-idm-name-object\",\"fr-attr-idate3\",\"fr-attr-date4\",\"adminRole\",\"sunAMAuthInvalidAttemptsData\",\"displayName\",\"iplanet-am-user-success-url\",\"fr-attr-iint1\",\"fr-idm-locale\",\"iplanet-am-session-get-valid-sessions\",\"devicePrintProfiles\",\"fr-attr-int5\",\"preferredLocale\",\"employeeNumber\",\"sunIdentityMSISDNNumber\",\"fr-idm-onboardDate\",\"fr-attr-imulti3\",\"iplanet-am-user-alias-list\",\"iplanet-am-user-password-reset-question-answer\",\"fr-attr-istr3\",\"fr-attr-idate1\",\"fr-idm-consentedMapping\",\"fr-idm-lastSync\",\"iplanet-am-user-login-status\"],\"resultCount\":144,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":0,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=1.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2960"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.220Z",
+        "time": 86,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 86
+        }
+      },
+      {
+        "_id": "659599ec04379c96aea6462a4c029012",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1991,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/subjectattributes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 2960,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 2960,
+            "text": "{\"result\":[\"fr-idm-role\",\"description\",\"l\",\"createTimestamp\",\"uid\",\"fr-idm-nick-name\",\"fr-attr-iint4\",\"fr-attr-str5\",\"iplanet-am-user-auth-config\",\"boundDevices\",\"retryLimitNodeCount\",\"st\",\"oathDeviceProfiles\",\"userCertificate\",\"labeledURI\",\"iplanet-am-auth-configuration\",\"fr-attr-istr1\",\"fr-idm-profile-url\",\"iplanet-am-session-service-status\",\"fr-attr-imulti1\",\"sun-fm-saml2-nameid-infokey\",\"fr-attr-int4\",\"fr-attr-str3\",\"fr-idm-inviteDate\",\"fr-idm-managed-organization-member\",\"sun-fm-saml2-nameid-info\",\"fr-attr-idate5\",\"kbaInfoAttempts\",\"fr-idm-preferences\",\"fr-attr-multi5\",\"memberOf\",\"fr-idm-photos\",\"co\",\"userPassword\",\"pushDeviceProfiles\",\"fr-attr-iint2\",\"fr-idm-birthdate\",\"oath2faEnabled\",\"iplanet-am-user-password-reset-options\",\"fr-idm-uuid\",\"iplanet-am-session-max-caching-time\",\"fr-attr-int2\",\"pwdExpireWarning\",\"webauthnDeviceProfiles\",\"fr-idm-effectiveAssignment\",\"objectClass\",\"fr-attr-date3\",\"isMemberOf\",\"fr-attr-imulti5\",\"fr-attr-imulti2\",\"fr-idm-name\",\"iplanet-am-session-quota-limit\",\"caCertificate\",\"iplanet-am-user-auth-modules\",\"fr-attr-multi4\",\"fr-idm-managed-user-memberoforgid\",\"telephoneNumber\",\"fr-idm-kbaInfo\",\"street\",\"cn\",\"ds-pwp-account-disabled\",\"fr-attr-istr4\",\"fr-idm-phone-numbers\",\"fr-attr-date1\",\"givenName\",\"fr-idm-addresses\",\"postalAddress\",\"fr-idm-gender\",\"fr-attr-multi2\",\"iplanet-am-user-failure-url\",\"distinguishedName\",\"postalCode\",\"iplanet-am-user-admin-start-dn\",\"pwdCheckQuality\",\"push2faEnabled\",\"pwdMinLength\",\"fr-attr-istr2\",\"fr-attr-int3\",\"iplanet-am-session-max-idle-time\",\"fr-idm-website\",\"fr-idm-custom-attrs\",\"fr-idm-password\",\"fr-attr-idate4\",\"kbaInfo\",\"fr-attr-str4\",\"iplanet-am-user-account-life\",\"kbaActiveIndex\",\"fr-attr-multi1\",\"fr-idm-title\",\"iplanet-am-session-max-session-time\",\"fr-attr-int1\",\"fr-attr-iint5\",\"fr-attr-date5\",\"preferredtimezone\",\"fr-attr-date2\",\"fr-attr-idate2\",\"assignedDashboard\",\"inetUserHttpURL\",\"preferredlanguage\",\"dn\",\"fr-idm-timezone\",\"mail\",\"fr-attr-str2\",\"modifyTimestamp\",\"iplanet-am-session-destroy-sessions\",\"fr-attr-iint3\",\"fr-attr-multi3\",\"deviceProfiles\",\"fr-attr-str1\",\"inetUserStatus\",\"authorityRevocationList\",\"fr-attr-istr5\",\"fr-idm-preferred-language\",\"fr-attr-imulti4\",\"fr-idm-emails\",\"sn\",\"fr-idm-effectiveRole\",\"manager\",\"fr-idm-lastChanged\",\"iplanet-am-user-password-reset-force-reset\",\"fr-idm-name-object\",\"fr-attr-idate3\",\"fr-attr-date4\",\"adminRole\",\"sunAMAuthInvalidAttemptsData\",\"displayName\",\"iplanet-am-user-success-url\",\"fr-attr-iint1\",\"fr-idm-locale\",\"iplanet-am-session-get-valid-sessions\",\"devicePrintProfiles\",\"fr-attr-int5\",\"preferredLocale\",\"employeeNumber\",\"sunIdentityMSISDNNumber\",\"fr-idm-onboardDate\",\"fr-attr-imulti3\",\"iplanet-am-user-alias-list\",\"iplanet-am-user-password-reset-question-answer\",\"fr-attr-istr3\",\"fr-attr-idate1\",\"fr-idm-consentedMapping\",\"fr-idm-lastSync\",\"iplanet-am-user-login-status\"],\"resultCount\":144,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"EXACT\",\"totalPagedResults\":0,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=1.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2960"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.313Z",
+        "time": 72,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 72
+        }
+      },
+      {
+        "_id": "e5bff9c7c5f3f7ced4744b09a51a4924",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1986,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/subjecttypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1206,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1206,
+            "text": "{\"result\":[{\"_id\":\"AND\",\"title\":\"AND\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subjects\":{\"type\":\"array\"}}}},{\"_id\":\"AuthenticatedUsers\",\"title\":\"AuthenticatedUsers\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{}}},{\"_id\":\"Identity\",\"title\":\"Identity\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"subjectValues\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"JwtClaim\",\"title\":\"JwtClaim\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"claimName\":{\"type\":\"string\"},\"claimValue\":{\"type\":\"string\"}}}},{\"_id\":\"NONE\",\"title\":\"NONE\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{}}},{\"_id\":\"NOT\",\"title\":\"NOT\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subject\":{\"type\":\"object\",\"properties\":{}}}}},{\"_id\":\"OR\",\"title\":\"OR\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subjects\":{\"type\":\"array\"}}}},{\"_id\":\"Policy\",\"title\":\"Policy\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"className\":{\"type\":\"string\"},\"values\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}}],\"resultCount\":8,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1206"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.390Z",
+        "time": 71,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 71
+        }
+      },
+      {
+        "_id": "8c2bb94d735cde043751f3943d4bb185",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1986,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/subjecttypes?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1206,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1206,
+            "text": "{\"result\":[{\"_id\":\"AND\",\"title\":\"AND\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subjects\":{\"type\":\"array\"}}}},{\"_id\":\"AuthenticatedUsers\",\"title\":\"AuthenticatedUsers\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{}}},{\"_id\":\"Identity\",\"title\":\"Identity\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"subjectValues\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}},{\"_id\":\"JwtClaim\",\"title\":\"JwtClaim\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"claimName\":{\"type\":\"string\"},\"claimValue\":{\"type\":\"string\"}}}},{\"_id\":\"NONE\",\"title\":\"NONE\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{}}},{\"_id\":\"NOT\",\"title\":\"NOT\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subject\":{\"type\":\"object\",\"properties\":{}}}}},{\"_id\":\"OR\",\"title\":\"OR\",\"logical\":true,\"config\":{\"type\":\"object\",\"properties\":{\"subjects\":{\"type\":\"array\"}}}},{\"_id\":\"Policy\",\"title\":\"Policy\",\"logical\":false,\"config\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"className\":{\"type\":\"string\"},\"values\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}}],\"resultCount\":8,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1206"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.467Z",
+        "time": 64,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 64
+        }
+      },
+      {
+        "_id": "2874ee10c7869cca540bfb0ccc8dce0b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1995,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/webhooks?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.537Z",
+        "time": 83,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 83
+        }
+      },
+      {
+        "_id": "f0f315df038dffc05ceaf4d64fb96788",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1995,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/realm-config/webhooks?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:52 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.625Z",
+        "time": 71,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 71
+        }
+      },
+      {
+        "_id": "26d73af01d88daeb886c9a61cf0912d3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2016,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/federation/entityproviders/ws?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:52 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.701Z",
+        "time": 69,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 69
+        }
+      },
+      {
+        "_id": "a6e4e97642cdbe7eb5a99b648bc3dd4c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.1.2-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2016,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/realm-config/federation/entityproviders/ws?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 138,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 138,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "138"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 07 Oct 2024 20:15:52 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ef43683e-cf7f-48eb-a58f-f2412a8a50fd"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-10-07T20:15:52.775Z",
+        "time": 73,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 73
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/snapshots/ops/AmConfigOps.test.js.snap
+++ b/src/test/snapshots/ops/AmConfigOps.test.js.snap
@@ -1,0 +1,3436 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AmConfigOps Classic Tests exportAmConfigEntities() 2: Export AM Config Entities 1`] = `
+{
+  "global": {
+    "serverInformation": {
+      "*": {
+        "_id": "*",
+        "_rev": "1352294770",
+        "cookieName": "iPlanetDirectoryPro",
+        "domains": [
+          null,
+        ],
+        "fileBasedConfiguration": false,
+        "forgotPassword": "false",
+        "forgotUsername": "false",
+        "kbaEnabled": "false",
+        "lang": "en-US",
+        "protectedUserAttributes": [
+          "telephoneNumber",
+          "mail",
+        ],
+        "realm": "/",
+        "referralsEnabled": "false",
+        "secureCookie": false,
+        "selfRegistration": "false",
+        "socialImplementations": [],
+        "successfulUserRegistrationDestination": "default",
+        "userIdAttributes": [],
+        "xuiUserSessionValidationEnabled": true,
+        "zeroPageLogin": {
+          "allowedWithoutReferer": true,
+          "enabled": false,
+          "refererWhitelist": [],
+        },
+      },
+    },
+    "serverVersion": {
+      "version": {
+        "_id": "version",
+        "_rev": "-1772220916",
+        "date": "2024-March-28 16:00",
+        "fullVersion": "ForgeRock Access Management 7.5.0 Build 89116d59a1ebe73ed1931dd3649adb7f217cd06b (2024-March-28 16:00)",
+        "revision": "89116d59a1ebe73ed1931dd3649adb7f217cd06b",
+        "version": "7.5.0",
+      },
+    },
+  },
+  "meta": Any<Object>,
+  "realm": {
+    "root": {
+      "applicationTypes": {
+        "iPlanetAMWebAgentService": {
+          "_id": "iPlanetAMWebAgentService",
+          "actions": {
+            "DELETE": true,
+            "GET": true,
+            "HEAD": true,
+            "OPTIONS": true,
+            "PATCH": true,
+            "POST": true,
+            "PUT": true,
+          },
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "iPlanetAMWebAgentService",
+          "resourceComparator": "com.sun.identity.entitlement.URLResourceName",
+          "saveIndex": "org.forgerock.openam.entitlement.indextree.TreeSaveIndex",
+          "searchIndex": "org.forgerock.openam.entitlement.indextree.TreeSearchIndex",
+        },
+        "sunAMDelegationService": {
+          "_id": "sunAMDelegationService",
+          "actions": {
+            "DELEGATE": true,
+            "MODIFY": true,
+            "READ": true,
+          },
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "sunAMDelegationService",
+          "resourceComparator": "com.sun.identity.entitlement.RegExResourceName",
+          "saveIndex": "com.sun.identity.entitlement.opensso.DelegationResourceNameIndexGenerator",
+          "searchIndex": "com.sun.identity.entitlement.opensso.DelegationResourceNameSplitter",
+        },
+        "umaApplicationType": {
+          "_id": "umaApplicationType",
+          "actions": {},
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "umaApplicationType",
+          "resourceComparator": "org.forgerock.openam.uma.UmaPolicyResourceMatcher",
+          "saveIndex": "org.forgerock.openam.uma.UmaPolicySaveIndex",
+          "searchIndex": "org.forgerock.openam.uma.UmaPolicySearchIndex",
+        },
+      },
+      "authenticationChains": {
+        "amsterService": {
+          "_id": "amsterService",
+          "_rev": "644917310",
+          "_type": {
+            "_id": "EMPTY",
+            "collection": true,
+            "name": "Authentication Configuration",
+          },
+          "authChainConfiguration": [
+            {
+              "criteria": "REQUIRED",
+              "module": "Amster",
+              "options": {},
+            },
+          ],
+          "loginFailureUrl": [],
+          "loginPostProcessClass": [],
+          "loginSuccessUrl": [],
+        },
+        "ldapService": {
+          "_id": "ldapService",
+          "_rev": "357765346",
+          "_type": {
+            "_id": "EMPTY",
+            "collection": true,
+            "name": "Authentication Configuration",
+          },
+          "authChainConfiguration": [
+            {
+              "criteria": "REQUIRED",
+              "module": "DataStore",
+              "options": {},
+            },
+          ],
+          "loginFailureUrl": [],
+          "loginPostProcessClass": [],
+          "loginSuccessUrl": [],
+        },
+      },
+      "authenticationModules": {
+        "amster": {
+          "_id": "amster",
+          "_type": {
+            "_id": "amster",
+            "collection": true,
+            "name": "ForgeRock Amster",
+          },
+          "authenticationLevel": 0,
+          "authorizedKeys": "/home/prestonhales/am/security/keys/amster/authorized_keys",
+          "enabled": true,
+        },
+        "datastore": {
+          "_id": "datastore",
+          "_type": {
+            "_id": "datastore",
+            "collection": true,
+            "name": "Data Store",
+          },
+          "authenticationLevel": 0,
+        },
+        "federation": {
+          "_id": "federation",
+          "_type": {
+            "_id": "federation",
+            "collection": true,
+            "name": "Federation",
+          },
+          "authenticationLevel": 0,
+        },
+        "hotp": {
+          "_id": "hotp",
+          "_type": {
+            "_id": "hotp",
+            "collection": true,
+            "name": "HOTP",
+          },
+          "authenticationLevel": 0,
+          "autoSendOTP": false,
+          "otpDeliveryMethod": "SMS and E-mail",
+          "otpLength": "8",
+          "otpMaxRetry": 3,
+          "otpValidityDuration": 5,
+          "smsGatewayClass": "com.sun.identity.authentication.modules.hotp.DefaultSMSGatewayImpl",
+          "smtpFromAddress": "no-reply@openam.org",
+          "smtpHostPort": 465,
+          "smtpHostname": "smtp.gmail.com",
+          "smtpSslEnabled": "SSL",
+          "smtpUserPassword": null,
+          "smtpUsername": "opensso.sun",
+          "userProfileEmailAttribute": "mail",
+          "userProfileTelephoneAttribute": "telephoneNumber",
+        },
+        "ldap": {
+          "_id": "ldap",
+          "_type": {
+            "_id": "ldap",
+            "collection": true,
+            "name": "LDAP",
+          },
+          "authenticationLevel": 0,
+          "beheraPasswordPolicySupportEnabled": true,
+          "connectionHeartbeatInterval": 10,
+          "connectionHeartbeatTimeUnit": "SECONDS",
+          "minimumPasswordLength": "8",
+          "openam-auth-ldap-connection-mode": "LDAPS",
+          "operationTimeout": 0,
+          "primaryLdapServer": [
+            "localhost:50636",
+          ],
+          "profileAttributeMappings": [],
+          "returnUserDN": true,
+          "searchScope": "SUBTREE",
+          "secondaryLdapServer": [],
+          "stopLdapbindAfterInmemoryLockedEnabled": false,
+          "trustAllServerCertificates": false,
+          "userBindDN": "cn=Directory Manager",
+          "userBindPassword": null,
+          "userProfileRetrievalAttribute": "uid",
+          "userSearchAttributes": [
+            "uid",
+          ],
+          "userSearchStartDN": [
+            "dc=openam,dc=forgerock,dc=org",
+          ],
+        },
+        "oath": {
+          "_id": "oath",
+          "_type": {
+            "_id": "oath",
+            "collection": true,
+            "name": "OATH",
+          },
+          "addChecksum": "False",
+          "authenticationLevel": 0,
+          "forgerock-oath-maximum-clock-drift": 0,
+          "forgerock-oath-sharedsecret-implementation-class": "org.forgerock.openam.authentication.modules.oath.plugins.DefaultSharedSecretProvider",
+          "hotpWindowSize": 100,
+          "minimumSecretKeyLength": "32",
+          "oathAlgorithm": "HOTP",
+          "oathOtpMaxRetry": 3,
+          "passwordLength": "6",
+          "stepsInWindow": 2,
+          "timeStepSize": 30,
+          "truncationOffset": -1,
+        },
+        "sae": {
+          "_id": "sae",
+          "_type": {
+            "_id": "sae",
+            "collection": true,
+            "name": "SAE",
+          },
+          "authenticationLevel": 0,
+        },
+      },
+      "conditionTypes": {
+        "AMIdentityMembership": {
+          "_id": "AMIdentityMembership",
+          "config": {
+            "properties": {
+              "amIdentityName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AMIdentityMembership",
+        },
+        "AND": {
+          "_id": "AND",
+          "config": {
+            "properties": {
+              "conditions": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "AND",
+        },
+        "AuthLevel": {
+          "_id": "AuthLevel",
+          "config": {
+            "properties": {
+              "authLevel": {
+                "type": "integer",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthLevel",
+        },
+        "AuthScheme": {
+          "_id": "AuthScheme",
+          "config": {
+            "properties": {
+              "applicationIdleTimeout": {
+                "type": "integer",
+              },
+              "applicationName": {
+                "type": "string",
+              },
+              "authScheme": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthScheme",
+        },
+        "AuthenticateToRealm": {
+          "_id": "AuthenticateToRealm",
+          "config": {
+            "properties": {
+              "authenticateToRealm": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticateToRealm",
+        },
+        "AuthenticateToService": {
+          "_id": "AuthenticateToService",
+          "config": {
+            "properties": {
+              "authenticateToService": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticateToService",
+        },
+        "IPv4": {
+          "_id": "IPv4",
+          "config": {
+            "properties": {
+              "dnsName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "endIp": {
+                "type": "string",
+              },
+              "startIp": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "IPv4",
+        },
+        "IPv6": {
+          "_id": "IPv6",
+          "config": {
+            "properties": {
+              "dnsName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "endIp": {
+                "type": "string",
+              },
+              "startIp": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "IPv6",
+        },
+        "LDAPFilter": {
+          "_id": "LDAPFilter",
+          "config": {
+            "properties": {
+              "ldapFilter": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "LDAPFilter",
+        },
+        "LEAuthLevel": {
+          "_id": "LEAuthLevel",
+          "config": {
+            "properties": {
+              "authLevel": {
+                "type": "integer",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "LEAuthLevel",
+        },
+        "NOT": {
+          "_id": "NOT",
+          "config": {
+            "properties": {
+              "condition": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "NOT",
+        },
+        "OAuth2Scope": {
+          "_id": "OAuth2Scope",
+          "config": {
+            "properties": {
+              "requiredScopes": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "OAuth2Scope",
+        },
+        "OR": {
+          "_id": "OR",
+          "config": {
+            "properties": {
+              "conditions": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "OR",
+        },
+        "Policy": {
+          "_id": "Policy",
+          "config": {
+            "properties": {
+              "className": {
+                "type": "string",
+              },
+              "properties": {
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Policy",
+        },
+        "ResourceEnvIP": {
+          "_id": "ResourceEnvIP",
+          "config": {
+            "properties": {
+              "resourceEnvIPConditionValue": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "ResourceEnvIP",
+        },
+        "Script": {
+          "_id": "Script",
+          "config": {
+            "properties": {
+              "scriptId": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Script",
+        },
+        "Session": {
+          "_id": "Session",
+          "config": {
+            "properties": {
+              "maxSessionTime": {
+                "type": "integer",
+              },
+              "terminateSession": {
+                "required": true,
+                "type": "boolean",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Session",
+        },
+        "SessionProperty": {
+          "_id": "SessionProperty",
+          "config": {
+            "properties": {
+              "ignoreValueCase": {
+                "required": true,
+                "type": "boolean",
+              },
+              "properties": {
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "SessionProperty",
+        },
+        "SimpleTime": {
+          "_id": "SimpleTime",
+          "config": {
+            "properties": {
+              "endDate": {
+                "type": "string",
+              },
+              "endDay": {
+                "type": "string",
+              },
+              "endTime": {
+                "type": "string",
+              },
+              "enforcementTimeZone": {
+                "type": "string",
+              },
+              "startDate": {
+                "type": "string",
+              },
+              "startDay": {
+                "type": "string",
+              },
+              "startTime": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "SimpleTime",
+        },
+        "Transaction": {
+          "_id": "Transaction",
+          "config": {
+            "properties": {
+              "authenticationStrategy": {
+                "type": "string",
+              },
+              "strategySpecifier": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Transaction",
+        },
+      },
+      "decisionCombiners": {
+        "DenyOverride": {
+          "_id": "DenyOverride",
+          "title": "DenyOverride",
+        },
+      },
+      "secrets": {},
+      "subjectAttributes": {
+        "undefined": "iplanet-am-user-login-status",
+      },
+      "subjectTypes": {
+        "AND": {
+          "_id": "AND",
+          "config": {
+            "properties": {
+              "subjects": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "AND",
+        },
+        "AuthenticatedUsers": {
+          "_id": "AuthenticatedUsers",
+          "config": {
+            "properties": {},
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticatedUsers",
+        },
+        "Identity": {
+          "_id": "Identity",
+          "config": {
+            "properties": {
+              "subjectValues": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Identity",
+        },
+        "JwtClaim": {
+          "_id": "JwtClaim",
+          "config": {
+            "properties": {
+              "claimName": {
+                "type": "string",
+              },
+              "claimValue": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "JwtClaim",
+        },
+        "NONE": {
+          "_id": "NONE",
+          "config": {
+            "properties": {},
+            "type": "object",
+          },
+          "logical": false,
+          "title": "NONE",
+        },
+        "NOT": {
+          "_id": "NOT",
+          "config": {
+            "properties": {
+              "subject": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "NOT",
+        },
+        "OR": {
+          "_id": "OR",
+          "config": {
+            "properties": {
+              "subjects": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "OR",
+        },
+        "Policy": {
+          "_id": "Policy",
+          "config": {
+            "properties": {
+              "className": {
+                "type": "string",
+              },
+              "name": {
+                "type": "string",
+              },
+              "values": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Policy",
+        },
+      },
+      "webhookService": {
+        "Cool Webhook": {
+          "_id": "Cool Webhook",
+          "_rev": "1386996185",
+          "_type": {
+            "_id": "webhooks",
+            "collection": true,
+            "name": "Webhook Service",
+          },
+          "body": "body",
+          "headers": {
+            "accept": "*/*",
+            "cool": "test",
+          },
+          "url": "test",
+        },
+        "Test Webhook": {
+          "_id": "Test Webhook",
+          "_rev": "2105362594",
+          "_type": {
+            "_id": "webhooks",
+            "collection": true,
+            "name": "Webhook Service",
+          },
+          "body": "hello",
+          "headers": {
+            "accept": "*/*",
+          },
+        },
+      },
+      "wsEntity": {
+        "ws": {
+          "_id": "ws",
+          "_rev": "720692750",
+          "_type": {
+            "_id": "ws",
+            "collection": true,
+            "name": "Entity Descriptor ",
+          },
+        },
+      },
+    },
+    "root-first": {
+      "applicationTypes": {
+        "iPlanetAMWebAgentService": {
+          "_id": "iPlanetAMWebAgentService",
+          "actions": {
+            "DELETE": true,
+            "GET": true,
+            "HEAD": true,
+            "OPTIONS": true,
+            "PATCH": true,
+            "POST": true,
+            "PUT": true,
+          },
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "iPlanetAMWebAgentService",
+          "resourceComparator": "com.sun.identity.entitlement.URLResourceName",
+          "saveIndex": "org.forgerock.openam.entitlement.indextree.TreeSaveIndex",
+          "searchIndex": "org.forgerock.openam.entitlement.indextree.TreeSearchIndex",
+        },
+        "sunAMDelegationService": {
+          "_id": "sunAMDelegationService",
+          "actions": {
+            "DELEGATE": true,
+            "MODIFY": true,
+            "READ": true,
+          },
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "sunAMDelegationService",
+          "resourceComparator": "com.sun.identity.entitlement.RegExResourceName",
+          "saveIndex": "com.sun.identity.entitlement.opensso.DelegationResourceNameIndexGenerator",
+          "searchIndex": "com.sun.identity.entitlement.opensso.DelegationResourceNameSplitter",
+        },
+        "umaApplicationType": {
+          "_id": "umaApplicationType",
+          "actions": {},
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "umaApplicationType",
+          "resourceComparator": "org.forgerock.openam.uma.UmaPolicyResourceMatcher",
+          "saveIndex": "org.forgerock.openam.uma.UmaPolicySaveIndex",
+          "searchIndex": "org.forgerock.openam.uma.UmaPolicySearchIndex",
+        },
+      },
+      "authenticationChains": {
+        "amsterService": {
+          "_id": "amsterService",
+          "_rev": "644917310",
+          "_type": {
+            "_id": "EMPTY",
+            "collection": true,
+            "name": "Authentication Configuration",
+          },
+          "authChainConfiguration": [
+            {
+              "criteria": "REQUIRED",
+              "module": "Amster",
+              "options": {},
+            },
+          ],
+          "loginFailureUrl": [],
+          "loginPostProcessClass": [],
+          "loginSuccessUrl": [],
+        },
+        "ldapService": {
+          "_id": "ldapService",
+          "_rev": "357765346",
+          "_type": {
+            "_id": "EMPTY",
+            "collection": true,
+            "name": "Authentication Configuration",
+          },
+          "authChainConfiguration": [
+            {
+              "criteria": "REQUIRED",
+              "module": "DataStore",
+              "options": {},
+            },
+          ],
+          "loginFailureUrl": [],
+          "loginPostProcessClass": [],
+          "loginSuccessUrl": [],
+        },
+      },
+      "authenticationModules": {
+        "amster": {
+          "_id": "amster",
+          "_type": {
+            "_id": "amster",
+            "collection": true,
+            "name": "ForgeRock Amster",
+          },
+          "authenticationLevel": 0,
+          "authorizedKeys": "/home/prestonhales/am/security/keys/amster/authorized_keys",
+          "enabled": true,
+        },
+        "datastore": {
+          "_id": "datastore",
+          "_type": {
+            "_id": "datastore",
+            "collection": true,
+            "name": "Data Store",
+          },
+          "authenticationLevel": 0,
+        },
+        "federation": {
+          "_id": "federation",
+          "_type": {
+            "_id": "federation",
+            "collection": true,
+            "name": "Federation",
+          },
+          "authenticationLevel": 0,
+        },
+        "hotp": {
+          "_id": "hotp",
+          "_type": {
+            "_id": "hotp",
+            "collection": true,
+            "name": "HOTP",
+          },
+          "authenticationLevel": 0,
+          "autoSendOTP": false,
+          "otpDeliveryMethod": "SMS and E-mail",
+          "otpLength": "8",
+          "otpMaxRetry": 3,
+          "otpValidityDuration": 5,
+          "smsGatewayClass": "com.sun.identity.authentication.modules.hotp.DefaultSMSGatewayImpl",
+          "smtpFromAddress": "no-reply@openam.org",
+          "smtpHostPort": 465,
+          "smtpHostname": "smtp.gmail.com",
+          "smtpSslEnabled": "SSL",
+          "smtpUserPassword": null,
+          "smtpUsername": "opensso.sun",
+          "userProfileEmailAttribute": "mail",
+          "userProfileTelephoneAttribute": "telephoneNumber",
+        },
+        "ldap": {
+          "_id": "ldap",
+          "_type": {
+            "_id": "ldap",
+            "collection": true,
+            "name": "LDAP",
+          },
+          "authenticationLevel": 0,
+          "beheraPasswordPolicySupportEnabled": true,
+          "connectionHeartbeatInterval": 10,
+          "connectionHeartbeatTimeUnit": "SECONDS",
+          "minimumPasswordLength": "8",
+          "openam-auth-ldap-connection-mode": "LDAPS",
+          "operationTimeout": 0,
+          "primaryLdapServer": [
+            "localhost:50636",
+          ],
+          "profileAttributeMappings": [],
+          "returnUserDN": true,
+          "searchScope": "SUBTREE",
+          "secondaryLdapServer": [],
+          "stopLdapbindAfterInmemoryLockedEnabled": false,
+          "trustAllServerCertificates": false,
+          "userBindDN": "cn=Directory Manager",
+          "userBindPassword": null,
+          "userProfileRetrievalAttribute": "uid",
+          "userSearchAttributes": [
+            "uid",
+          ],
+          "userSearchStartDN": [
+            "dc=openam,dc=forgerock,dc=org",
+          ],
+        },
+        "oath": {
+          "_id": "oath",
+          "_type": {
+            "_id": "oath",
+            "collection": true,
+            "name": "OATH",
+          },
+          "addChecksum": "False",
+          "authenticationLevel": 0,
+          "forgerock-oath-maximum-clock-drift": 0,
+          "forgerock-oath-sharedsecret-implementation-class": "org.forgerock.openam.authentication.modules.oath.plugins.DefaultSharedSecretProvider",
+          "hotpWindowSize": 100,
+          "minimumSecretKeyLength": "32",
+          "oathAlgorithm": "HOTP",
+          "oathOtpMaxRetry": 3,
+          "passwordLength": "6",
+          "stepsInWindow": 2,
+          "timeStepSize": 30,
+          "truncationOffset": -1,
+        },
+        "sae": {
+          "_id": "sae",
+          "_type": {
+            "_id": "sae",
+            "collection": true,
+            "name": "SAE",
+          },
+          "authenticationLevel": 0,
+        },
+      },
+      "conditionTypes": {
+        "AMIdentityMembership": {
+          "_id": "AMIdentityMembership",
+          "config": {
+            "properties": {
+              "amIdentityName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AMIdentityMembership",
+        },
+        "AND": {
+          "_id": "AND",
+          "config": {
+            "properties": {
+              "conditions": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "AND",
+        },
+        "AuthLevel": {
+          "_id": "AuthLevel",
+          "config": {
+            "properties": {
+              "authLevel": {
+                "type": "integer",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthLevel",
+        },
+        "AuthScheme": {
+          "_id": "AuthScheme",
+          "config": {
+            "properties": {
+              "applicationIdleTimeout": {
+                "type": "integer",
+              },
+              "applicationName": {
+                "type": "string",
+              },
+              "authScheme": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthScheme",
+        },
+        "AuthenticateToRealm": {
+          "_id": "AuthenticateToRealm",
+          "config": {
+            "properties": {
+              "authenticateToRealm": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticateToRealm",
+        },
+        "AuthenticateToService": {
+          "_id": "AuthenticateToService",
+          "config": {
+            "properties": {
+              "authenticateToService": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticateToService",
+        },
+        "IPv4": {
+          "_id": "IPv4",
+          "config": {
+            "properties": {
+              "dnsName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "endIp": {
+                "type": "string",
+              },
+              "startIp": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "IPv4",
+        },
+        "IPv6": {
+          "_id": "IPv6",
+          "config": {
+            "properties": {
+              "dnsName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "endIp": {
+                "type": "string",
+              },
+              "startIp": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "IPv6",
+        },
+        "LDAPFilter": {
+          "_id": "LDAPFilter",
+          "config": {
+            "properties": {
+              "ldapFilter": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "LDAPFilter",
+        },
+        "LEAuthLevel": {
+          "_id": "LEAuthLevel",
+          "config": {
+            "properties": {
+              "authLevel": {
+                "type": "integer",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "LEAuthLevel",
+        },
+        "NOT": {
+          "_id": "NOT",
+          "config": {
+            "properties": {
+              "condition": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "NOT",
+        },
+        "OAuth2Scope": {
+          "_id": "OAuth2Scope",
+          "config": {
+            "properties": {
+              "requiredScopes": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "OAuth2Scope",
+        },
+        "OR": {
+          "_id": "OR",
+          "config": {
+            "properties": {
+              "conditions": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "OR",
+        },
+        "Policy": {
+          "_id": "Policy",
+          "config": {
+            "properties": {
+              "className": {
+                "type": "string",
+              },
+              "properties": {
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Policy",
+        },
+        "ResourceEnvIP": {
+          "_id": "ResourceEnvIP",
+          "config": {
+            "properties": {
+              "resourceEnvIPConditionValue": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "ResourceEnvIP",
+        },
+        "Script": {
+          "_id": "Script",
+          "config": {
+            "properties": {
+              "scriptId": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Script",
+        },
+        "Session": {
+          "_id": "Session",
+          "config": {
+            "properties": {
+              "maxSessionTime": {
+                "type": "integer",
+              },
+              "terminateSession": {
+                "required": true,
+                "type": "boolean",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Session",
+        },
+        "SessionProperty": {
+          "_id": "SessionProperty",
+          "config": {
+            "properties": {
+              "ignoreValueCase": {
+                "required": true,
+                "type": "boolean",
+              },
+              "properties": {
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "SessionProperty",
+        },
+        "SimpleTime": {
+          "_id": "SimpleTime",
+          "config": {
+            "properties": {
+              "endDate": {
+                "type": "string",
+              },
+              "endDay": {
+                "type": "string",
+              },
+              "endTime": {
+                "type": "string",
+              },
+              "enforcementTimeZone": {
+                "type": "string",
+              },
+              "startDate": {
+                "type": "string",
+              },
+              "startDay": {
+                "type": "string",
+              },
+              "startTime": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "SimpleTime",
+        },
+        "Transaction": {
+          "_id": "Transaction",
+          "config": {
+            "properties": {
+              "authenticationStrategy": {
+                "type": "string",
+              },
+              "strategySpecifier": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Transaction",
+        },
+      },
+      "decisionCombiners": {
+        "DenyOverride": {
+          "_id": "DenyOverride",
+          "title": "DenyOverride",
+        },
+      },
+      "secrets": {},
+      "subjectAttributes": {
+        "undefined": "iplanet-am-user-login-status",
+      },
+      "subjectTypes": {
+        "AND": {
+          "_id": "AND",
+          "config": {
+            "properties": {
+              "subjects": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "AND",
+        },
+        "AuthenticatedUsers": {
+          "_id": "AuthenticatedUsers",
+          "config": {
+            "properties": {},
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticatedUsers",
+        },
+        "Identity": {
+          "_id": "Identity",
+          "config": {
+            "properties": {
+              "subjectValues": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Identity",
+        },
+        "JwtClaim": {
+          "_id": "JwtClaim",
+          "config": {
+            "properties": {
+              "claimName": {
+                "type": "string",
+              },
+              "claimValue": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "JwtClaim",
+        },
+        "NONE": {
+          "_id": "NONE",
+          "config": {
+            "properties": {},
+            "type": "object",
+          },
+          "logical": false,
+          "title": "NONE",
+        },
+        "NOT": {
+          "_id": "NOT",
+          "config": {
+            "properties": {
+              "subject": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "NOT",
+        },
+        "OR": {
+          "_id": "OR",
+          "config": {
+            "properties": {
+              "subjects": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "OR",
+        },
+        "Policy": {
+          "_id": "Policy",
+          "config": {
+            "properties": {
+              "className": {
+                "type": "string",
+              },
+              "name": {
+                "type": "string",
+              },
+              "values": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Policy",
+        },
+      },
+      "webhookService": {
+        "webhooks": {
+          "_id": "webhooks",
+          "_rev": "1954901829",
+          "_type": {
+            "_id": "webhooks",
+            "collection": true,
+            "name": "Webhook Service",
+          },
+          "headers": {
+            "accept": "*/*",
+          },
+        },
+      },
+      "wsEntity": {
+        "ws": {
+          "_id": "ws",
+          "_rev": "720692750",
+          "_type": {
+            "_id": "ws",
+            "collection": true,
+            "name": "Entity Descriptor ",
+          },
+        },
+      },
+    },
+    "root-first-second": {
+      "applicationTypes": {
+        "iPlanetAMWebAgentService": {
+          "_id": "iPlanetAMWebAgentService",
+          "actions": {
+            "DELETE": true,
+            "GET": true,
+            "HEAD": true,
+            "OPTIONS": true,
+            "PATCH": true,
+            "POST": true,
+            "PUT": true,
+          },
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "iPlanetAMWebAgentService",
+          "resourceComparator": "com.sun.identity.entitlement.URLResourceName",
+          "saveIndex": "org.forgerock.openam.entitlement.indextree.TreeSaveIndex",
+          "searchIndex": "org.forgerock.openam.entitlement.indextree.TreeSearchIndex",
+        },
+        "sunAMDelegationService": {
+          "_id": "sunAMDelegationService",
+          "actions": {
+            "DELEGATE": true,
+            "MODIFY": true,
+            "READ": true,
+          },
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "sunAMDelegationService",
+          "resourceComparator": "com.sun.identity.entitlement.RegExResourceName",
+          "saveIndex": "com.sun.identity.entitlement.opensso.DelegationResourceNameIndexGenerator",
+          "searchIndex": "com.sun.identity.entitlement.opensso.DelegationResourceNameSplitter",
+        },
+        "umaApplicationType": {
+          "_id": "umaApplicationType",
+          "actions": {},
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "umaApplicationType",
+          "resourceComparator": "org.forgerock.openam.uma.UmaPolicyResourceMatcher",
+          "saveIndex": "org.forgerock.openam.uma.UmaPolicySaveIndex",
+          "searchIndex": "org.forgerock.openam.uma.UmaPolicySearchIndex",
+        },
+      },
+      "authenticationChains": {
+        "amsterService": {
+          "_id": "amsterService",
+          "_rev": "644917310",
+          "_type": {
+            "_id": "EMPTY",
+            "collection": true,
+            "name": "Authentication Configuration",
+          },
+          "authChainConfiguration": [
+            {
+              "criteria": "REQUIRED",
+              "module": "Amster",
+              "options": {},
+            },
+          ],
+          "loginFailureUrl": [],
+          "loginPostProcessClass": [],
+          "loginSuccessUrl": [],
+        },
+        "ldapService": {
+          "_id": "ldapService",
+          "_rev": "357765346",
+          "_type": {
+            "_id": "EMPTY",
+            "collection": true,
+            "name": "Authentication Configuration",
+          },
+          "authChainConfiguration": [
+            {
+              "criteria": "REQUIRED",
+              "module": "DataStore",
+              "options": {},
+            },
+          ],
+          "loginFailureUrl": [],
+          "loginPostProcessClass": [],
+          "loginSuccessUrl": [],
+        },
+      },
+      "authenticationModules": {
+        "amster": {
+          "_id": "amster",
+          "_type": {
+            "_id": "amster",
+            "collection": true,
+            "name": "ForgeRock Amster",
+          },
+          "authenticationLevel": 0,
+          "authorizedKeys": "/home/prestonhales/am/security/keys/amster/authorized_keys",
+          "enabled": true,
+        },
+        "datastore": {
+          "_id": "datastore",
+          "_type": {
+            "_id": "datastore",
+            "collection": true,
+            "name": "Data Store",
+          },
+          "authenticationLevel": 0,
+        },
+        "federation": {
+          "_id": "federation",
+          "_type": {
+            "_id": "federation",
+            "collection": true,
+            "name": "Federation",
+          },
+          "authenticationLevel": 0,
+        },
+        "hotp": {
+          "_id": "hotp",
+          "_type": {
+            "_id": "hotp",
+            "collection": true,
+            "name": "HOTP",
+          },
+          "authenticationLevel": 0,
+          "autoSendOTP": false,
+          "otpDeliveryMethod": "SMS and E-mail",
+          "otpLength": "8",
+          "otpMaxRetry": 3,
+          "otpValidityDuration": 5,
+          "smsGatewayClass": "com.sun.identity.authentication.modules.hotp.DefaultSMSGatewayImpl",
+          "smtpFromAddress": "no-reply@openam.org",
+          "smtpHostPort": 465,
+          "smtpHostname": "smtp.gmail.com",
+          "smtpSslEnabled": "SSL",
+          "smtpUserPassword": null,
+          "smtpUsername": "opensso.sun",
+          "userProfileEmailAttribute": "mail",
+          "userProfileTelephoneAttribute": "telephoneNumber",
+        },
+        "ldap": {
+          "_id": "ldap",
+          "_type": {
+            "_id": "ldap",
+            "collection": true,
+            "name": "LDAP",
+          },
+          "authenticationLevel": 0,
+          "beheraPasswordPolicySupportEnabled": true,
+          "connectionHeartbeatInterval": 10,
+          "connectionHeartbeatTimeUnit": "SECONDS",
+          "minimumPasswordLength": "8",
+          "openam-auth-ldap-connection-mode": "LDAPS",
+          "operationTimeout": 0,
+          "primaryLdapServer": [
+            "localhost:50636",
+          ],
+          "profileAttributeMappings": [],
+          "returnUserDN": true,
+          "searchScope": "SUBTREE",
+          "secondaryLdapServer": [],
+          "stopLdapbindAfterInmemoryLockedEnabled": false,
+          "trustAllServerCertificates": false,
+          "userBindDN": "cn=Directory Manager",
+          "userBindPassword": null,
+          "userProfileRetrievalAttribute": "uid",
+          "userSearchAttributes": [
+            "uid",
+          ],
+          "userSearchStartDN": [
+            "dc=openam,dc=forgerock,dc=org",
+          ],
+        },
+        "oath": {
+          "_id": "oath",
+          "_type": {
+            "_id": "oath",
+            "collection": true,
+            "name": "OATH",
+          },
+          "addChecksum": "False",
+          "authenticationLevel": 0,
+          "forgerock-oath-maximum-clock-drift": 0,
+          "forgerock-oath-sharedsecret-implementation-class": "org.forgerock.openam.authentication.modules.oath.plugins.DefaultSharedSecretProvider",
+          "hotpWindowSize": 100,
+          "minimumSecretKeyLength": "32",
+          "oathAlgorithm": "HOTP",
+          "oathOtpMaxRetry": 3,
+          "passwordLength": "6",
+          "stepsInWindow": 2,
+          "timeStepSize": 30,
+          "truncationOffset": -1,
+        },
+        "sae": {
+          "_id": "sae",
+          "_type": {
+            "_id": "sae",
+            "collection": true,
+            "name": "SAE",
+          },
+          "authenticationLevel": 0,
+        },
+      },
+      "conditionTypes": {
+        "AMIdentityMembership": {
+          "_id": "AMIdentityMembership",
+          "config": {
+            "properties": {
+              "amIdentityName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AMIdentityMembership",
+        },
+        "AND": {
+          "_id": "AND",
+          "config": {
+            "properties": {
+              "conditions": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "AND",
+        },
+        "AuthLevel": {
+          "_id": "AuthLevel",
+          "config": {
+            "properties": {
+              "authLevel": {
+                "type": "integer",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthLevel",
+        },
+        "AuthScheme": {
+          "_id": "AuthScheme",
+          "config": {
+            "properties": {
+              "applicationIdleTimeout": {
+                "type": "integer",
+              },
+              "applicationName": {
+                "type": "string",
+              },
+              "authScheme": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthScheme",
+        },
+        "AuthenticateToRealm": {
+          "_id": "AuthenticateToRealm",
+          "config": {
+            "properties": {
+              "authenticateToRealm": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticateToRealm",
+        },
+        "AuthenticateToService": {
+          "_id": "AuthenticateToService",
+          "config": {
+            "properties": {
+              "authenticateToService": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticateToService",
+        },
+        "IPv4": {
+          "_id": "IPv4",
+          "config": {
+            "properties": {
+              "dnsName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "endIp": {
+                "type": "string",
+              },
+              "startIp": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "IPv4",
+        },
+        "IPv6": {
+          "_id": "IPv6",
+          "config": {
+            "properties": {
+              "dnsName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "endIp": {
+                "type": "string",
+              },
+              "startIp": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "IPv6",
+        },
+        "LDAPFilter": {
+          "_id": "LDAPFilter",
+          "config": {
+            "properties": {
+              "ldapFilter": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "LDAPFilter",
+        },
+        "LEAuthLevel": {
+          "_id": "LEAuthLevel",
+          "config": {
+            "properties": {
+              "authLevel": {
+                "type": "integer",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "LEAuthLevel",
+        },
+        "NOT": {
+          "_id": "NOT",
+          "config": {
+            "properties": {
+              "condition": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "NOT",
+        },
+        "OAuth2Scope": {
+          "_id": "OAuth2Scope",
+          "config": {
+            "properties": {
+              "requiredScopes": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "OAuth2Scope",
+        },
+        "OR": {
+          "_id": "OR",
+          "config": {
+            "properties": {
+              "conditions": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "OR",
+        },
+        "Policy": {
+          "_id": "Policy",
+          "config": {
+            "properties": {
+              "className": {
+                "type": "string",
+              },
+              "properties": {
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Policy",
+        },
+        "ResourceEnvIP": {
+          "_id": "ResourceEnvIP",
+          "config": {
+            "properties": {
+              "resourceEnvIPConditionValue": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "ResourceEnvIP",
+        },
+        "Script": {
+          "_id": "Script",
+          "config": {
+            "properties": {
+              "scriptId": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Script",
+        },
+        "Session": {
+          "_id": "Session",
+          "config": {
+            "properties": {
+              "maxSessionTime": {
+                "type": "integer",
+              },
+              "terminateSession": {
+                "required": true,
+                "type": "boolean",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Session",
+        },
+        "SessionProperty": {
+          "_id": "SessionProperty",
+          "config": {
+            "properties": {
+              "ignoreValueCase": {
+                "required": true,
+                "type": "boolean",
+              },
+              "properties": {
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "SessionProperty",
+        },
+        "SimpleTime": {
+          "_id": "SimpleTime",
+          "config": {
+            "properties": {
+              "endDate": {
+                "type": "string",
+              },
+              "endDay": {
+                "type": "string",
+              },
+              "endTime": {
+                "type": "string",
+              },
+              "enforcementTimeZone": {
+                "type": "string",
+              },
+              "startDate": {
+                "type": "string",
+              },
+              "startDay": {
+                "type": "string",
+              },
+              "startTime": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "SimpleTime",
+        },
+        "Transaction": {
+          "_id": "Transaction",
+          "config": {
+            "properties": {
+              "authenticationStrategy": {
+                "type": "string",
+              },
+              "strategySpecifier": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Transaction",
+        },
+      },
+      "decisionCombiners": {
+        "DenyOverride": {
+          "_id": "DenyOverride",
+          "title": "DenyOverride",
+        },
+      },
+      "secrets": {},
+      "subjectAttributes": {
+        "undefined": "iplanet-am-user-login-status",
+      },
+      "subjectTypes": {
+        "AND": {
+          "_id": "AND",
+          "config": {
+            "properties": {
+              "subjects": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "AND",
+        },
+        "AuthenticatedUsers": {
+          "_id": "AuthenticatedUsers",
+          "config": {
+            "properties": {},
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticatedUsers",
+        },
+        "Identity": {
+          "_id": "Identity",
+          "config": {
+            "properties": {
+              "subjectValues": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Identity",
+        },
+        "JwtClaim": {
+          "_id": "JwtClaim",
+          "config": {
+            "properties": {
+              "claimName": {
+                "type": "string",
+              },
+              "claimValue": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "JwtClaim",
+        },
+        "NONE": {
+          "_id": "NONE",
+          "config": {
+            "properties": {},
+            "type": "object",
+          },
+          "logical": false,
+          "title": "NONE",
+        },
+        "NOT": {
+          "_id": "NOT",
+          "config": {
+            "properties": {
+              "subject": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "NOT",
+        },
+        "OR": {
+          "_id": "OR",
+          "config": {
+            "properties": {
+              "subjects": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "OR",
+        },
+        "Policy": {
+          "_id": "Policy",
+          "config": {
+            "properties": {
+              "className": {
+                "type": "string",
+              },
+              "name": {
+                "type": "string",
+              },
+              "values": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Policy",
+        },
+      },
+      "webhookService": {
+        "webhooks": {
+          "_id": "webhooks",
+          "_rev": "1954901829",
+          "_type": {
+            "_id": "webhooks",
+            "collection": true,
+            "name": "Webhook Service",
+          },
+          "headers": {
+            "accept": "*/*",
+          },
+        },
+      },
+      "wsEntity": {
+        "ws": {
+          "_id": "ws",
+          "_rev": "720692750",
+          "_type": {
+            "_id": "ws",
+            "collection": true,
+            "name": "Entity Descriptor ",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`AmConfigOps Cloud Tests createConfigEntityExportTemplate() 1: Create AM Config Export Template 1`] = `
+{
+  "global": {},
+  "meta": Any<Object>,
+  "realm": {
+    "alpha": {},
+    "bravo": {},
+  },
+}
+`;
+
+exports[`AmConfigOps Cloud Tests createConfigEntityExportTemplate() 2: Create AM Config Export Template without provided realms 1`] = `
+{
+  "global": {},
+  "meta": Any<Object>,
+  "realm": {
+    "root-alpha": {},
+    "root-bravo": {},
+  },
+}
+`;
+
+exports[`AmConfigOps Cloud Tests exportAmConfigEntities() 1: Export AM Config Entities 1`] = `
+{
+  "global": {
+    "serverInformation": {
+      "*": {
+        "_id": "*",
+        "_rev": "-1019531729",
+        "cookieName": "6ac6499e9da2071",
+        "domains": [
+          "openam-frodo-dev.forgeblocks.com",
+        ],
+        "fileBasedConfiguration": true,
+        "forgotPassword": "false",
+        "forgotUsername": "false",
+        "kbaEnabled": "false",
+        "lang": "en-US",
+        "protectedUserAttributes": [
+          "telephoneNumber",
+          "mail",
+        ],
+        "realm": "/",
+        "referralsEnabled": "false",
+        "secureCookie": true,
+        "selfRegistration": "false",
+        "socialImplementations": [],
+        "successfulUserRegistrationDestination": "default",
+        "userIdAttributes": [],
+        "xuiUserSessionValidationEnabled": true,
+        "zeroPageLogin": {
+          "allowedWithoutReferer": true,
+          "enabled": false,
+          "refererWhitelist": [],
+        },
+      },
+    },
+    "serverVersion": {
+      "version": {
+        "_id": "version",
+        "_rev": "355151460",
+        "date": "2024-September-23 14:30",
+        "fullVersion": "ForgeRock Access Management 7.6.0-SNAPSHOT Build 493165657bbb9390016bd43ca767a46f23d8d24a (2024-September-23 14:30)",
+        "revision": "493165657bbb9390016bd43ca767a46f23d8d24a",
+        "version": "7.6.0-SNAPSHOT",
+      },
+    },
+  },
+  "meta": Any<Object>,
+  "realm": {
+    "root-alpha": {
+      "applicationTypes": {
+        "iPlanetAMWebAgentService": {
+          "_id": "iPlanetAMWebAgentService",
+          "actions": {
+            "DELETE": true,
+            "GET": true,
+            "HEAD": true,
+            "OPTIONS": true,
+            "PATCH": true,
+            "POST": true,
+            "PUT": true,
+          },
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "iPlanetAMWebAgentService",
+          "resourceComparator": "com.sun.identity.entitlement.URLResourceName",
+          "saveIndex": "org.forgerock.openam.entitlement.indextree.TreeSaveIndex",
+          "searchIndex": "org.forgerock.openam.entitlement.indextree.TreeSearchIndex",
+        },
+        "sunAMDelegationService": {
+          "_id": "sunAMDelegationService",
+          "actions": {
+            "DELEGATE": true,
+            "MODIFY": true,
+            "READ": true,
+          },
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "sunAMDelegationService",
+          "resourceComparator": "com.sun.identity.entitlement.RegExResourceName",
+          "saveIndex": "com.sun.identity.entitlement.opensso.DelegationResourceNameIndexGenerator",
+          "searchIndex": "com.sun.identity.entitlement.opensso.DelegationResourceNameSplitter",
+        },
+        "umaApplicationType": {
+          "_id": "umaApplicationType",
+          "actions": {},
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "umaApplicationType",
+          "resourceComparator": "org.forgerock.openam.uma.UmaPolicyResourceMatcher",
+          "saveIndex": "org.forgerock.openam.uma.UmaPolicySaveIndex",
+          "searchIndex": "org.forgerock.openam.uma.UmaPolicySearchIndex",
+        },
+      },
+      "authenticationChains": {},
+      "authenticationModules": {
+        "Federation": {
+          "_id": "Federation",
+          "_type": {
+            "_id": "federation",
+            "collection": true,
+            "name": "Federation",
+          },
+          "authenticationLevel": 0,
+        },
+        "amster": {
+          "_id": "amster",
+          "_type": {
+            "_id": "amster",
+            "collection": true,
+            "name": "ForgeRock Amster",
+          },
+          "authenticationLevel": 0,
+          "authorizedKeys": "/home/forgerock/openam/security/keys/amster/authorized_keys",
+          "enabled": true,
+        },
+        "datastore": {
+          "_id": "datastore",
+          "_type": {
+            "_id": "datastore",
+            "collection": true,
+            "name": "Data Store",
+          },
+          "authenticationLevel": 0,
+        },
+        "federation": {
+          "_id": "federation",
+          "_type": {
+            "_id": "federation",
+            "collection": true,
+            "name": "Federation",
+          },
+          "authenticationLevel": 0,
+        },
+        "hotp": {
+          "_id": "hotp",
+          "_type": {
+            "_id": "hotp",
+            "collection": true,
+            "name": "HOTP",
+          },
+          "authenticationLevel": 0,
+          "autoSendOTP": false,
+          "otpDeliveryMethod": "SMS and E-mail",
+          "otpLength": "8",
+          "otpMaxRetry": 3,
+          "otpValidityDuration": 5,
+          "smsGatewayClass": "com.sun.identity.authentication.modules.hotp.DefaultSMSGatewayImpl",
+          "smtpFromAddress": "no-reply@openam.org",
+          "smtpHostPort": 465,
+          "smtpHostname": "smtp.gmail.com",
+          "smtpSslEnabled": "SSL",
+          "smtpUserPassword": null,
+          "smtpUsername": "opensso.sun",
+          "userProfileEmailAttribute": "mail",
+          "userProfileTelephoneAttribute": "telephoneNumber",
+        },
+        "ldap": {
+          "_id": "ldap",
+          "_type": {
+            "_id": "ldap",
+            "collection": true,
+            "name": "LDAP",
+          },
+          "authenticationLevel": 0,
+          "beheraPasswordPolicySupportEnabled": true,
+          "connectionHeartbeatInterval": 10,
+          "connectionHeartbeatTimeUnit": "SECONDS",
+          "minimumPasswordLength": "8",
+          "openam-auth-ldap-connection-mode": "LDAP",
+          "operationTimeout": 0,
+          "primaryLdapServer": [
+            "userstore-1.userstore:1389",
+            "userstore-0.userstore:1389",
+            "userstore-2.userstore:1389",
+          ],
+          "profileAttributeMappings": [],
+          "returnUserDN": true,
+          "searchScope": "SUBTREE",
+          "secondaryLdapServer": [],
+          "stopLdapbindAfterInmemoryLockedEnabled": false,
+          "trustAllServerCertificates": false,
+          "userBindDN": "uid=admin",
+          "userBindPassword": null,
+          "userProfileRetrievalAttribute": "uid",
+          "userSearchAttributes": [
+            "uid",
+          ],
+          "userSearchStartDN": [
+            "ou=identities",
+          ],
+        },
+        "oath": {
+          "_id": "oath",
+          "_type": {
+            "_id": "oath",
+            "collection": true,
+            "name": "OATH",
+          },
+          "addChecksum": "False",
+          "authenticationLevel": 0,
+          "forgerock-oath-maximum-clock-drift": 0,
+          "forgerock-oath-sharedsecret-implementation-class": "org.forgerock.openam.authentication.modules.oath.plugins.DefaultSharedSecretProvider",
+          "hotpWindowSize": 100,
+          "minimumSecretKeyLength": "32",
+          "oathAlgorithm": "HOTP",
+          "oathOtpMaxRetry": 3,
+          "passwordLength": "6",
+          "stepsInWindow": 2,
+          "timeStepSize": 30,
+          "truncationOffset": -1,
+        },
+        "sae": {
+          "_id": "sae",
+          "_type": {
+            "_id": "sae",
+            "collection": true,
+            "name": "SAE",
+          },
+          "authenticationLevel": 0,
+        },
+      },
+      "conditionTypes": {
+        "AMIdentityMembership": {
+          "_id": "AMIdentityMembership",
+          "config": {
+            "properties": {
+              "amIdentityName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AMIdentityMembership",
+        },
+        "AND": {
+          "_id": "AND",
+          "config": {
+            "properties": {
+              "conditions": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "AND",
+        },
+        "AuthLevel": {
+          "_id": "AuthLevel",
+          "config": {
+            "properties": {
+              "authLevel": {
+                "type": "integer",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthLevel",
+        },
+        "AuthScheme": {
+          "_id": "AuthScheme",
+          "config": {
+            "properties": {
+              "applicationIdleTimeout": {
+                "type": "integer",
+              },
+              "applicationName": {
+                "type": "string",
+              },
+              "authScheme": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthScheme",
+        },
+        "AuthenticateToRealm": {
+          "_id": "AuthenticateToRealm",
+          "config": {
+            "properties": {
+              "authenticateToRealm": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticateToRealm",
+        },
+        "AuthenticateToService": {
+          "_id": "AuthenticateToService",
+          "config": {
+            "properties": {
+              "authenticateToService": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticateToService",
+        },
+        "IPv4": {
+          "_id": "IPv4",
+          "config": {
+            "properties": {
+              "dnsName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "endIp": {
+                "type": "string",
+              },
+              "startIp": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "IPv4",
+        },
+        "IPv6": {
+          "_id": "IPv6",
+          "config": {
+            "properties": {
+              "dnsName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "endIp": {
+                "type": "string",
+              },
+              "startIp": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "IPv6",
+        },
+        "LDAPFilter": {
+          "_id": "LDAPFilter",
+          "config": {
+            "properties": {
+              "ldapFilter": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "LDAPFilter",
+        },
+        "LEAuthLevel": {
+          "_id": "LEAuthLevel",
+          "config": {
+            "properties": {
+              "authLevel": {
+                "type": "integer",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "LEAuthLevel",
+        },
+        "NOT": {
+          "_id": "NOT",
+          "config": {
+            "properties": {
+              "condition": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "NOT",
+        },
+        "OAuth2Scope": {
+          "_id": "OAuth2Scope",
+          "config": {
+            "properties": {
+              "requiredScopes": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "OAuth2Scope",
+        },
+        "OR": {
+          "_id": "OR",
+          "config": {
+            "properties": {
+              "conditions": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "OR",
+        },
+        "Policy": {
+          "_id": "Policy",
+          "config": {
+            "properties": {
+              "className": {
+                "type": "string",
+              },
+              "properties": {
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Policy",
+        },
+        "ResourceEnvIP": {
+          "_id": "ResourceEnvIP",
+          "config": {
+            "properties": {
+              "resourceEnvIPConditionValue": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "ResourceEnvIP",
+        },
+        "Script": {
+          "_id": "Script",
+          "config": {
+            "properties": {
+              "scriptId": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Script",
+        },
+        "Session": {
+          "_id": "Session",
+          "config": {
+            "properties": {
+              "maxSessionTime": {
+                "type": "integer",
+              },
+              "terminateSession": {
+                "required": true,
+                "type": "boolean",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Session",
+        },
+        "SessionProperty": {
+          "_id": "SessionProperty",
+          "config": {
+            "properties": {
+              "ignoreValueCase": {
+                "required": true,
+                "type": "boolean",
+              },
+              "properties": {
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "SessionProperty",
+        },
+        "SimpleTime": {
+          "_id": "SimpleTime",
+          "config": {
+            "properties": {
+              "endDate": {
+                "type": "string",
+              },
+              "endDay": {
+                "type": "string",
+              },
+              "endTime": {
+                "type": "string",
+              },
+              "enforcementTimeZone": {
+                "type": "string",
+              },
+              "startDate": {
+                "type": "string",
+              },
+              "startDay": {
+                "type": "string",
+              },
+              "startTime": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "SimpleTime",
+        },
+        "Transaction": {
+          "_id": "Transaction",
+          "config": {
+            "properties": {
+              "authenticationStrategy": {
+                "type": "string",
+              },
+              "strategySpecifier": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Transaction",
+        },
+      },
+      "decisionCombiners": {
+        "DenyOverride": {
+          "_id": "DenyOverride",
+          "title": "DenyOverride",
+        },
+      },
+      "secrets": {},
+      "subjectAttributes": {
+        "undefined": "iplanet-am-user-login-status",
+      },
+      "subjectTypes": {
+        "AND": {
+          "_id": "AND",
+          "config": {
+            "properties": {
+              "subjects": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "AND",
+        },
+        "AuthenticatedUsers": {
+          "_id": "AuthenticatedUsers",
+          "config": {
+            "properties": {},
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticatedUsers",
+        },
+        "Identity": {
+          "_id": "Identity",
+          "config": {
+            "properties": {
+              "subjectValues": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Identity",
+        },
+        "JwtClaim": {
+          "_id": "JwtClaim",
+          "config": {
+            "properties": {
+              "claimName": {
+                "type": "string",
+              },
+              "claimValue": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "JwtClaim",
+        },
+        "NONE": {
+          "_id": "NONE",
+          "config": {
+            "properties": {},
+            "type": "object",
+          },
+          "logical": false,
+          "title": "NONE",
+        },
+        "NOT": {
+          "_id": "NOT",
+          "config": {
+            "properties": {
+              "subject": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "NOT",
+        },
+        "OR": {
+          "_id": "OR",
+          "config": {
+            "properties": {
+              "subjects": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "OR",
+        },
+        "Policy": {
+          "_id": "Policy",
+          "config": {
+            "properties": {
+              "className": {
+                "type": "string",
+              },
+              "name": {
+                "type": "string",
+              },
+              "values": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Policy",
+        },
+      },
+      "webhookService": {},
+      "wsEntity": {},
+    },
+    "root-bravo": {
+      "applicationTypes": {
+        "iPlanetAMWebAgentService": {
+          "_id": "iPlanetAMWebAgentService",
+          "actions": {
+            "DELETE": true,
+            "GET": true,
+            "HEAD": true,
+            "OPTIONS": true,
+            "PATCH": true,
+            "POST": true,
+            "PUT": true,
+          },
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "iPlanetAMWebAgentService",
+          "resourceComparator": "com.sun.identity.entitlement.URLResourceName",
+          "saveIndex": "org.forgerock.openam.entitlement.indextree.TreeSaveIndex",
+          "searchIndex": "org.forgerock.openam.entitlement.indextree.TreeSearchIndex",
+        },
+        "sunAMDelegationService": {
+          "_id": "sunAMDelegationService",
+          "actions": {
+            "DELEGATE": true,
+            "MODIFY": true,
+            "READ": true,
+          },
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "sunAMDelegationService",
+          "resourceComparator": "com.sun.identity.entitlement.RegExResourceName",
+          "saveIndex": "com.sun.identity.entitlement.opensso.DelegationResourceNameIndexGenerator",
+          "searchIndex": "com.sun.identity.entitlement.opensso.DelegationResourceNameSplitter",
+        },
+        "umaApplicationType": {
+          "_id": "umaApplicationType",
+          "actions": {},
+          "applicationClassName": "com.sun.identity.entitlement.Application",
+          "name": "umaApplicationType",
+          "resourceComparator": "org.forgerock.openam.uma.UmaPolicyResourceMatcher",
+          "saveIndex": "org.forgerock.openam.uma.UmaPolicySaveIndex",
+          "searchIndex": "org.forgerock.openam.uma.UmaPolicySearchIndex",
+        },
+      },
+      "authenticationChains": {},
+      "authenticationModules": {
+        "Federation": {
+          "_id": "Federation",
+          "_type": {
+            "_id": "federation",
+            "collection": true,
+            "name": "Federation",
+          },
+          "authenticationLevel": 0,
+        },
+        "amster": {
+          "_id": "amster",
+          "_type": {
+            "_id": "amster",
+            "collection": true,
+            "name": "ForgeRock Amster",
+          },
+          "authenticationLevel": 0,
+          "authorizedKeys": "/home/forgerock/openam/security/keys/amster/authorized_keys",
+          "enabled": true,
+        },
+        "datastore": {
+          "_id": "datastore",
+          "_type": {
+            "_id": "datastore",
+            "collection": true,
+            "name": "Data Store",
+          },
+          "authenticationLevel": 0,
+        },
+        "federation": {
+          "_id": "federation",
+          "_type": {
+            "_id": "federation",
+            "collection": true,
+            "name": "Federation",
+          },
+          "authenticationLevel": 0,
+        },
+        "hotp": {
+          "_id": "hotp",
+          "_type": {
+            "_id": "hotp",
+            "collection": true,
+            "name": "HOTP",
+          },
+          "authenticationLevel": 0,
+          "autoSendOTP": false,
+          "otpDeliveryMethod": "SMS and E-mail",
+          "otpLength": "8",
+          "otpMaxRetry": 3,
+          "otpValidityDuration": 5,
+          "smsGatewayClass": "com.sun.identity.authentication.modules.hotp.DefaultSMSGatewayImpl",
+          "smtpFromAddress": "no-reply@openam.org",
+          "smtpHostPort": 465,
+          "smtpHostname": "smtp.gmail.com",
+          "smtpSslEnabled": "SSL",
+          "smtpUserPassword": null,
+          "smtpUsername": "opensso.sun",
+          "userProfileEmailAttribute": "mail",
+          "userProfileTelephoneAttribute": "telephoneNumber",
+        },
+        "ldap": {
+          "_id": "ldap",
+          "_type": {
+            "_id": "ldap",
+            "collection": true,
+            "name": "LDAP",
+          },
+          "authenticationLevel": 0,
+          "beheraPasswordPolicySupportEnabled": true,
+          "connectionHeartbeatInterval": 10,
+          "connectionHeartbeatTimeUnit": "SECONDS",
+          "minimumPasswordLength": "8",
+          "openam-auth-ldap-connection-mode": "LDAP",
+          "operationTimeout": 0,
+          "primaryLdapServer": [
+            "userstore-1.userstore:1389",
+            "userstore-0.userstore:1389",
+            "userstore-2.userstore:1389",
+          ],
+          "profileAttributeMappings": [],
+          "returnUserDN": true,
+          "searchScope": "SUBTREE",
+          "secondaryLdapServer": [],
+          "stopLdapbindAfterInmemoryLockedEnabled": false,
+          "trustAllServerCertificates": false,
+          "userBindDN": "uid=admin",
+          "userBindPassword": null,
+          "userProfileRetrievalAttribute": "uid",
+          "userSearchAttributes": [
+            "uid",
+          ],
+          "userSearchStartDN": [
+            "ou=identities",
+          ],
+        },
+        "oath": {
+          "_id": "oath",
+          "_type": {
+            "_id": "oath",
+            "collection": true,
+            "name": "OATH",
+          },
+          "addChecksum": "False",
+          "authenticationLevel": 0,
+          "forgerock-oath-maximum-clock-drift": 0,
+          "forgerock-oath-sharedsecret-implementation-class": "org.forgerock.openam.authentication.modules.oath.plugins.DefaultSharedSecretProvider",
+          "hotpWindowSize": 100,
+          "minimumSecretKeyLength": "32",
+          "oathAlgorithm": "HOTP",
+          "oathOtpMaxRetry": 3,
+          "passwordLength": "6",
+          "stepsInWindow": 2,
+          "timeStepSize": 30,
+          "truncationOffset": -1,
+        },
+        "sae": {
+          "_id": "sae",
+          "_type": {
+            "_id": "sae",
+            "collection": true,
+            "name": "SAE",
+          },
+          "authenticationLevel": 0,
+        },
+      },
+      "conditionTypes": {
+        "AMIdentityMembership": {
+          "_id": "AMIdentityMembership",
+          "config": {
+            "properties": {
+              "amIdentityName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AMIdentityMembership",
+        },
+        "AND": {
+          "_id": "AND",
+          "config": {
+            "properties": {
+              "conditions": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "AND",
+        },
+        "AuthLevel": {
+          "_id": "AuthLevel",
+          "config": {
+            "properties": {
+              "authLevel": {
+                "type": "integer",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthLevel",
+        },
+        "AuthScheme": {
+          "_id": "AuthScheme",
+          "config": {
+            "properties": {
+              "applicationIdleTimeout": {
+                "type": "integer",
+              },
+              "applicationName": {
+                "type": "string",
+              },
+              "authScheme": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthScheme",
+        },
+        "AuthenticateToRealm": {
+          "_id": "AuthenticateToRealm",
+          "config": {
+            "properties": {
+              "authenticateToRealm": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticateToRealm",
+        },
+        "AuthenticateToService": {
+          "_id": "AuthenticateToService",
+          "config": {
+            "properties": {
+              "authenticateToService": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticateToService",
+        },
+        "IPv4": {
+          "_id": "IPv4",
+          "config": {
+            "properties": {
+              "dnsName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "endIp": {
+                "type": "string",
+              },
+              "startIp": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "IPv4",
+        },
+        "IPv6": {
+          "_id": "IPv6",
+          "config": {
+            "properties": {
+              "dnsName": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "endIp": {
+                "type": "string",
+              },
+              "startIp": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "IPv6",
+        },
+        "LDAPFilter": {
+          "_id": "LDAPFilter",
+          "config": {
+            "properties": {
+              "ldapFilter": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "LDAPFilter",
+        },
+        "LEAuthLevel": {
+          "_id": "LEAuthLevel",
+          "config": {
+            "properties": {
+              "authLevel": {
+                "type": "integer",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "LEAuthLevel",
+        },
+        "NOT": {
+          "_id": "NOT",
+          "config": {
+            "properties": {
+              "condition": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "NOT",
+        },
+        "OAuth2Scope": {
+          "_id": "OAuth2Scope",
+          "config": {
+            "properties": {
+              "requiredScopes": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "OAuth2Scope",
+        },
+        "OR": {
+          "_id": "OR",
+          "config": {
+            "properties": {
+              "conditions": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "OR",
+        },
+        "Policy": {
+          "_id": "Policy",
+          "config": {
+            "properties": {
+              "className": {
+                "type": "string",
+              },
+              "properties": {
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Policy",
+        },
+        "ResourceEnvIP": {
+          "_id": "ResourceEnvIP",
+          "config": {
+            "properties": {
+              "resourceEnvIPConditionValue": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "ResourceEnvIP",
+        },
+        "Script": {
+          "_id": "Script",
+          "config": {
+            "properties": {
+              "scriptId": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Script",
+        },
+        "Session": {
+          "_id": "Session",
+          "config": {
+            "properties": {
+              "maxSessionTime": {
+                "type": "integer",
+              },
+              "terminateSession": {
+                "required": true,
+                "type": "boolean",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Session",
+        },
+        "SessionProperty": {
+          "_id": "SessionProperty",
+          "config": {
+            "properties": {
+              "ignoreValueCase": {
+                "required": true,
+                "type": "boolean",
+              },
+              "properties": {
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "SessionProperty",
+        },
+        "SimpleTime": {
+          "_id": "SimpleTime",
+          "config": {
+            "properties": {
+              "endDate": {
+                "type": "string",
+              },
+              "endDay": {
+                "type": "string",
+              },
+              "endTime": {
+                "type": "string",
+              },
+              "enforcementTimeZone": {
+                "type": "string",
+              },
+              "startDate": {
+                "type": "string",
+              },
+              "startDay": {
+                "type": "string",
+              },
+              "startTime": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "SimpleTime",
+        },
+        "Transaction": {
+          "_id": "Transaction",
+          "config": {
+            "properties": {
+              "authenticationStrategy": {
+                "type": "string",
+              },
+              "strategySpecifier": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Transaction",
+        },
+      },
+      "decisionCombiners": {
+        "DenyOverride": {
+          "_id": "DenyOverride",
+          "title": "DenyOverride",
+        },
+      },
+      "secrets": {},
+      "subjectAttributes": {
+        "undefined": "iplanet-am-user-login-status",
+      },
+      "subjectTypes": {
+        "AND": {
+          "_id": "AND",
+          "config": {
+            "properties": {
+              "subjects": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "AND",
+        },
+        "AuthenticatedUsers": {
+          "_id": "AuthenticatedUsers",
+          "config": {
+            "properties": {},
+            "type": "object",
+          },
+          "logical": false,
+          "title": "AuthenticatedUsers",
+        },
+        "Identity": {
+          "_id": "Identity",
+          "config": {
+            "properties": {
+              "subjectValues": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Identity",
+        },
+        "JwtClaim": {
+          "_id": "JwtClaim",
+          "config": {
+            "properties": {
+              "claimName": {
+                "type": "string",
+              },
+              "claimValue": {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "JwtClaim",
+        },
+        "NONE": {
+          "_id": "NONE",
+          "config": {
+            "properties": {},
+            "type": "object",
+          },
+          "logical": false,
+          "title": "NONE",
+        },
+        "NOT": {
+          "_id": "NOT",
+          "config": {
+            "properties": {
+              "subject": {
+                "properties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "NOT",
+        },
+        "OR": {
+          "_id": "OR",
+          "config": {
+            "properties": {
+              "subjects": {
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": true,
+          "title": "OR",
+        },
+        "Policy": {
+          "_id": "Policy",
+          "config": {
+            "properties": {
+              "className": {
+                "type": "string",
+              },
+              "name": {
+                "type": "string",
+              },
+              "values": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "logical": false,
+          "title": "Policy",
+        },
+      },
+      "webhookService": {},
+      "wsEntity": {},
+    },
+  },
+}
+`;


### PR DESCRIPTION
This PR has a bunch of other AM config exports and imports. The majority of the config is read only and doesn't get imported, but some of it can be imported. In order to prevent having separate files for all the exports and imports, I created a more generalized way to handle them. In the future, if we want to have special functionality for them beyond simply exporting/importing their config, we will likely want to separate them out into their own files like with the other exports and imports.

I used a script to scrape endpoint and resource version information from Amster. The goal was to export/import as much as we could that Amster handles and that is missing from Frodo. Resource versions are based on the latest ones contained in the documentation as of version 7.5 (see the [Amster entity reference documentation](https://backstage.forgerock.com/docs/amster/7.5/entity-reference/preface.html) for more information).

This PR should be merged in prior to the PR named "Update Full Config Export with new Imports and Exports" that updates the full config export/import since that PR will rely on the changes from this PR.