### PR TITLE
Feature/promotion tool

### DIFF
--- a/src/utils/ForgeRockUtils.ts
+++ b/src/utils/ForgeRockUtils.ts
@@ -9,6 +9,7 @@ export type FRUtils = {
   getCurrentRealmName(): string;
   getCurrentRealmManagedUser(): string;
   getRealmName(realm: string): string;
+  getRealmUsingExportFormat(realm: string): string;
   /**
    * Gets the list of realms to be used for exports in special format.
    * e.g. if the realm is normally '/first/second', then it will return 'root-first-second'.
@@ -79,6 +80,9 @@ export default (state: State): FRUtils => {
     },
     getIdmBaseUrl(): string {
       return getIdmBaseUrl(state);
+    },
+    getRealmUsingExportFormat(realm: string): string {
+      return getRealmUsingExportFormat(realm);
     },
 
     // deprecated

--- a/src/utils/ForgeRockUtils.ts
+++ b/src/utils/ForgeRockUtils.ts
@@ -81,10 +81,6 @@ export default (state: State): FRUtils => {
     getIdmBaseUrl(): string {
       return getIdmBaseUrl(state);
     },
-    getRealmUsingExportFormat(realm: string): string {
-      return getRealmUsingExportFormat(realm);
-    },
-
     // deprecated
 
     getHostBaseUrl(url: string): string {

--- a/src/utils/SetupPollyForFrodoLib.ts
+++ b/src/utils/SetupPollyForFrodoLib.ts
@@ -14,6 +14,10 @@ import {
   Recording,
 } from './PollyUtils';
 
+const FRODO_TEST_NAME = process.env.FRODO_TEST_NAME 
+  ? process.env.FRODO_TEST_NAME
+  : null
+
 const FRODO_MOCK_HOSTS = process.env.FRODO_MOCK_HOSTS
   ? process.env.FRODO_MOCK_HOSTS.split(',')
   : [
@@ -102,7 +106,13 @@ function getFrodoArgsId({ start, state }: { start: number; state: State }) {
   result.push(`${args.length}`);
   const paramsId = params.join('_');
   if (paramsId) result.push(paramsId);
-  const argsId = result.join('_');
+  const argsId = (process.env.FRODO_TEST_NAME) ? FRODO_TEST_NAME : result.join('_');
+  if(process.env.FRODO_TEST_NAME) {
+    debugMessage({
+      message: `FRODO_TEST_NAME=${FRODO_TEST_NAME}`,
+      state
+    })
+  }
   if (mode !== MODES.RECORD)
     debugMessage({
       message: `SetupPollyForFrodoLib.getFrodoArgsId: argsId=${argsId}`,


### PR DESCRIPTION
This pr is to add in functionality necessary from the library for the promotion tool to work. It adds 2 features:

1. The ability to get the realm name in the format necessary so commands can be run in that realm
2. The ability to specify a specific folder for the mocks to be stored within, allowing for multiple mocks to be stored for a command with the same flags.