### PR TITLE
Fix bug with Journey Imports

### DIFF
--- a/src/ops/JourneyOps.ts
+++ b/src/ops/JourneyOps.ts
@@ -1272,7 +1272,8 @@ export async function exportJourney({
             });
           scriptObject.script = useStringArrays
             ? convertBase64TextToArray(scriptObject.script)
-            : JSON.stringify(decode(scriptObject.script));
+            : // Stringify necessary to export journey scripts in the same format as Ping AIC
+              JSON.stringify(decode(scriptObject.script));
           exportData.scripts[scriptObject._id] = scriptObject;
 
           // handle library scripts
@@ -1286,7 +1287,8 @@ export async function exportJourney({
               name2uuid[scriptName] = libScriptObject._id;
               libScriptObject.script = useStringArrays
                 ? convertBase64TextToArray(libScriptObject.script as string)
-                : JSON.stringify(decode(scriptObject.script));
+                : // Stringify necessary to export journey scripts in the same format as Ping AIC
+                  JSON.stringify(decode(scriptObject.script));
               exportData.scripts[libScriptObject._id] = libScriptObject;
             }
           }
@@ -1566,7 +1568,8 @@ export async function importJourney({
             scriptObject['script']
           );
         } else if (!isBase64Encoded(scriptObject['script'])) {
-          scriptObject['script'] = encode(scriptObject['script']);
+          // JSON.parse is necessary to import scripts, otherwise it imports them as a single string
+          scriptObject['script'] = encode(JSON.parse(scriptObject['script']));
         }
         try {
           await updateScript({ scriptId, scriptData: scriptObject, state });

--- a/src/test/mock-recordings/JourneyOps_2291468013/importJourney_541402267/2-Import-journey-FrodoTestJourney5-w_1119246922/dependencies_1379947466/recording.har
+++ b/src/test/mock-recordings/JourneyOps_2291468013/importJourney_541402267/2-Import-journey-FrodoTestJourney5-w_1119246922/dependencies_1379947466/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "79dd21f5d9374578b44f36c0861db170",
+        "_id": "3cf0bca719c02f5772c5c178b5d58b4d",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1007,
+          "bodySize": 967,
           "cookies": [],
           "headers": [
             {
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
@@ -41,7 +41,7 @@
             },
             {
               "name": "content-length",
-              "value": "1007"
+              "value": "967"
             },
             {
               "name": "accept-encoding",
@@ -52,23 +52,23 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1980,
+          "headersSize": 2021,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"name\":\"Check Username\",\"description\":\"Check if username has already been collected.\",\"script\":\"Ii8qIENoZWNrIFVzZXJuYW1lXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBDaGVjayBpZiB1c2VybmFtZSBoYXMgYWxyZWFkeSBiZWVuIGNvbGxlY3RlZC5cbiAqIFJldHVybiBcImtub3duXCIgaWYgeWVzLCBcInVua25vd25cIiBvdGhlcndpc2UuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0ga25vd25cbiAqIC0gdW5rbm93blxuICovXG4oZnVuY3Rpb24gKCkge1xuICAgIGlmIChudWxsICE9IHNoYXJlZFN0YXRlLmdldChcInVzZXJuYW1lXCIpKSB7XG4gICAgICAgIG91dGNvbWUgPSBcImtub3duXCI7XG4gICAgfVxuICAgIGVsc2Uge1xuICAgICAgICBvdXRjb21lID0gXCJ1bmtub3duXCI7XG4gICAgfVxufSgpKTsi\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0}"
+            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"name\":\"Check Username\",\"description\":\"Check if username has already been collected.\",\"script\":\"LyogQ2hlY2sgVXNlcm5hbWUKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogQ2hlY2sgaWYgdXNlcm5hbWUgaGFzIGFscmVhZHkgYmVlbiBjb2xsZWN0ZWQuCiAqIFJldHVybiAia25vd24iIGlmIHllcywgInVua25vd24iIG90aGVyd2lzZS4KICogCiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuCiAqIAogKiBUaGUgU2NyaXB0ZWQgRGVjaXNpb24gTm9kZSBuZWVkcyB0aGUgZm9sbG93aW5nIG91dGNvbWVzIGRlZmluZWQ6CiAqIC0ga25vd24KICogLSB1bmtub3duCiAqLwooZnVuY3Rpb24gKCkgewogICAgaWYgKG51bGwgIT0gc2hhcmVkU3RhdGUuZ2V0KCJ1c2VybmFtZSIpKSB7CiAgICAgICAgb3V0Y29tZSA9ICJrbm93biI7CiAgICB9CiAgICBlbHNlIHsKICAgICAgICBvdXRjb21lID0gInVua25vd24iOwogICAgfQp9KCkpOw==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/739bdc48-fd24-4c52-b353-88706d75558a"
         },
         "response": {
-          "bodySize": 1100,
+          "bodySize": 1060,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1100,
-            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"name\":\"Check Username\",\"description\":\"Check if username has already been collected.\",\"script\":\"Ii8qIENoZWNrIFVzZXJuYW1lXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBDaGVjayBpZiB1c2VybmFtZSBoYXMgYWxyZWFkeSBiZWVuIGNvbGxlY3RlZC5cbiAqIFJldHVybiBcImtub3duXCIgaWYgeWVzLCBcInVua25vd25cIiBvdGhlcndpc2UuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0ga25vd25cbiAqIC0gdW5rbm93blxuICovXG4oZnVuY3Rpb24gKCkge1xuICAgIGlmIChudWxsICE9IHNoYXJlZFN0YXRlLmdldChcInVzZXJuYW1lXCIpKSB7XG4gICAgICAgIG91dGNvbWUgPSBcImtub3duXCI7XG4gICAgfVxuICAgIGVsc2Uge1xuICAgICAgICBvdXRjb21lID0gXCJ1bmtub3duXCI7XG4gICAgfVxufSgpKTsi\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1725915625427,\"evaluatorVersion\":\"1.0\"}"
+            "size": 1060,
+            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"name\":\"Check Username\",\"description\":\"Check if username has already been collected.\",\"script\":\"LyogQ2hlY2sgVXNlcm5hbWUKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogQ2hlY2sgaWYgdXNlcm5hbWUgaGFzIGFscmVhZHkgYmVlbiBjb2xsZWN0ZWQuCiAqIFJldHVybiAia25vd24iIGlmIHllcywgInVua25vd24iIG90aGVyd2lzZS4KICogCiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuCiAqIAogKiBUaGUgU2NyaXB0ZWQgRGVjaXNpb24gTm9kZSBuZWVkcyB0aGUgZm9sbG93aW5nIG91dGNvbWVzIGRlZmluZWQ6CiAqIC0ga25vd24KICogLSB1bmtub3duCiAqLwooZnVuY3Rpb24gKCkgewogICAgaWYgKG51bGwgIT0gc2hhcmVkU3RhdGUuZ2V0KCJ1c2VybmFtZSIpKSB7CiAgICAgICAgb3V0Y29tZSA9ICJrbm93biI7CiAgICB9CiAgICBlbHNlIHsKICAgICAgICBvdXRjb21lID0gInVua25vd24iOwogICAgfQp9KCkpOw==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329044425,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -118,15 +118,15 @@
             },
             {
               "name": "content-length",
-              "value": "1100"
+              "value": "1060"
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:24 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -151,8 +151,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.369Z",
-        "time": 90,
+        "startedDateTime": "2024-12-04T16:17:24.371Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -160,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 90
+          "wait": 77
         }
       },
       {
-        "_id": "98828fc7c17367ac07f839a1440a211e",
+        "_id": "821baa6d943a31dab6b8b62d944a02dd",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 3068,
+          "bodySize": 2988,
           "cookies": [],
           "headers": [
             {
@@ -181,11 +181,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
@@ -197,7 +197,7 @@
             },
             {
               "name": "content-length",
-              "value": "3068"
+              "value": "2988"
             },
             {
               "name": "accept-encoding",
@@ -208,23 +208,23 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1979,
+          "headersSize": 2021,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"name\":\"Normalized Profile to Managed User\",\"description\":\"Converts a normalized social profile into a managed user\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5pbXBvcnQgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuXG5Kc29uVmFsdWUgbWFuYWdlZFVzZXIgPSBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcbiAgICAgICAgZmllbGQoXCJzblwiLCBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJtYWlsXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VyTmFtZVwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxuXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQWRkcmVzcy5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwicG9zdGFsQWRkcmVzc1wiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwiY2l0eVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwic3RhdGVQcm92aW5jZVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzUmVnaW9uKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbENvZGUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInBvc3RhbENvZGVcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcbmlmIChub3JtYWxpemVkUHJvZmlsZS5jb3VudHJ5LmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXCJjb3VudHJ5XCIsIG5vcm1hbGl6ZWRQcm9maWxlLmNvdW50cnkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInRlbGVwaG9uZU51bWJlclwiLCBub3JtYWxpemVkUHJvZmlsZS5waG9uZSlcblxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XG4vLyB0aGVuIGFkZCBhIGJvb2xlYW4gZmxhZyB0byB0aGUgc2hhcmVkIHN0YXRlIHRvIGluZGljYXRlIG5hbWVzIGFyZSBub3QgcHJlc2VudFxuLy8gdGhpcyBjb3VsZCBiZSB1c2VkIGVsc2V3aGVyZVxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcbi8vIHRoZSB1c2VyIG9iamVjdCB3aXRoIGJsYW5rIHZhbHVlcyB3aGVuIGdpdmVuTmFtZSAgYW5kIGZhbWlseU5hbWUgaXMgbm90IHByZXNlbnRcbmJvb2xlYW4gbm9HaXZlbk5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuaXNOdWxsKCkgfHwgKCFub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuYXNTdHJpbmcoKT8udHJpbSgpKVxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXG5zaGFyZWRTdGF0ZS5wdXQoXCJuYW1lRW1wdHlPck51bGxcIiwgbm9HaXZlbk5hbWUgJiYgbm9GYW1pbHlOYW1lKVxuXG5yZXR1cm4gbWFuYWdlZFVzZXJcbiI=\",\"default\":true,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0}"
+            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"name\":\"Normalized Profile to Managed User\",\"description\":\"Converts a normalized social profile into a managed user\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjAgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmltcG9ydCBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlCgpKc29uVmFsdWUgbWFuYWdlZFVzZXIgPSBqc29uKG9iamVjdCgKICAgICAgICBmaWVsZCgiZ2l2ZW5OYW1lIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSwKICAgICAgICBmaWVsZCgic24iLCBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lKSwKICAgICAgICBmaWVsZCgibWFpbCIsIG5vcm1hbGl6ZWRQcm9maWxlLmVtYWlsKSwKICAgICAgICBmaWVsZCgidXNlck5hbWUiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKQoKaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbEFkZHJlc3MuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dCgicG9zdGFsQWRkcmVzcyIsIG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbEFkZHJlc3MpCmlmIChub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dCgiY2l0eSIsIG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eSkKaWYgKG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NSZWdpb24uaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dCgic3RhdGVQcm92aW5jZSIsIG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NSZWdpb24pCmlmIChub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxDb2RlLmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoInBvc3RhbENvZGUiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxDb2RlKQppZiAobm9ybWFsaXplZFByb2ZpbGUuY291bnRyeS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KCJjb3VudHJ5Iiwgbm9ybWFsaXplZFByb2ZpbGUuY291bnRyeSkKaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBob25lLmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoInRlbGVwaG9uZU51bWJlciIsIG5vcm1hbGl6ZWRQcm9maWxlLnBob25lKQoKLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5Ci8vIHRoZW4gYWRkIGEgYm9vbGVhbiBmbGFnIHRvIHRoZSBzaGFyZWQgc3RhdGUgdG8gaW5kaWNhdGUgbmFtZXMgYXJlIG5vdCBwcmVzZW50Ci8vIHRoaXMgY291bGQgYmUgdXNlZCBlbHNld2hlcmUKLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmcKLy8gdGhlIHVzZXIgb2JqZWN0IHdpdGggYmxhbmsgdmFsdWVzIHdoZW4gZ2l2ZW5OYW1lICBhbmQgZmFtaWx5TmFtZSBpcyBub3QgcHJlc2VudApib29sZWFuIG5vR2l2ZW5OYW1lID0gbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lLmFzU3RyaW5nKCk/LnRyaW0oKSkKYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpCnNoYXJlZFN0YXRlLnB1dCgibmFtZUVtcHR5T3JOdWxsIiwgbm9HaXZlbk5hbWUgJiYgbm9GYW1pbHlOYW1lKQoKcmV0dXJuIG1hbmFnZWRVc2VyCg==\",\"default\":true,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/58c824ae-84ed-4724-82cd-db128fc3f6c"
         },
         "response": {
-          "bodySize": 3162,
+          "bodySize": 3082,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 3162,
-            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"name\":\"Normalized Profile to Managed User\",\"description\":\"Converts a normalized social profile into a managed user\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5pbXBvcnQgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuXG5Kc29uVmFsdWUgbWFuYWdlZFVzZXIgPSBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcbiAgICAgICAgZmllbGQoXCJzblwiLCBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJtYWlsXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VyTmFtZVwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxuXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQWRkcmVzcy5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwicG9zdGFsQWRkcmVzc1wiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwiY2l0eVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwic3RhdGVQcm92aW5jZVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzUmVnaW9uKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbENvZGUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInBvc3RhbENvZGVcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcbmlmIChub3JtYWxpemVkUHJvZmlsZS5jb3VudHJ5LmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXCJjb3VudHJ5XCIsIG5vcm1hbGl6ZWRQcm9maWxlLmNvdW50cnkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInRlbGVwaG9uZU51bWJlclwiLCBub3JtYWxpemVkUHJvZmlsZS5waG9uZSlcblxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XG4vLyB0aGVuIGFkZCBhIGJvb2xlYW4gZmxhZyB0byB0aGUgc2hhcmVkIHN0YXRlIHRvIGluZGljYXRlIG5hbWVzIGFyZSBub3QgcHJlc2VudFxuLy8gdGhpcyBjb3VsZCBiZSB1c2VkIGVsc2V3aGVyZVxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcbi8vIHRoZSB1c2VyIG9iamVjdCB3aXRoIGJsYW5rIHZhbHVlcyB3aGVuIGdpdmVuTmFtZSAgYW5kIGZhbWlseU5hbWUgaXMgbm90IHByZXNlbnRcbmJvb2xlYW4gbm9HaXZlbk5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuaXNOdWxsKCkgfHwgKCFub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuYXNTdHJpbmcoKT8udHJpbSgpKVxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXG5zaGFyZWRTdGF0ZS5wdXQoXCJuYW1lRW1wdHlPck51bGxcIiwgbm9HaXZlbk5hbWUgJiYgbm9GYW1pbHlOYW1lKVxuXG5yZXR1cm4gbWFuYWdlZFVzZXJcbiI=\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1725915625513,\"evaluatorVersion\":\"1.0\"}"
+            "size": 3082,
+            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"name\":\"Normalized Profile to Managed User\",\"description\":\"Converts a normalized social profile into a managed user\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjAgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmltcG9ydCBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlCgpKc29uVmFsdWUgbWFuYWdlZFVzZXIgPSBqc29uKG9iamVjdCgKICAgICAgICBmaWVsZCgiZ2l2ZW5OYW1lIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSwKICAgICAgICBmaWVsZCgic24iLCBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lKSwKICAgICAgICBmaWVsZCgibWFpbCIsIG5vcm1hbGl6ZWRQcm9maWxlLmVtYWlsKSwKICAgICAgICBmaWVsZCgidXNlck5hbWUiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKQoKaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbEFkZHJlc3MuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dCgicG9zdGFsQWRkcmVzcyIsIG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbEFkZHJlc3MpCmlmIChub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dCgiY2l0eSIsIG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eSkKaWYgKG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NSZWdpb24uaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dCgic3RhdGVQcm92aW5jZSIsIG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NSZWdpb24pCmlmIChub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxDb2RlLmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoInBvc3RhbENvZGUiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxDb2RlKQppZiAobm9ybWFsaXplZFByb2ZpbGUuY291bnRyeS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KCJjb3VudHJ5Iiwgbm9ybWFsaXplZFByb2ZpbGUuY291bnRyeSkKaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBob25lLmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoInRlbGVwaG9uZU51bWJlciIsIG5vcm1hbGl6ZWRQcm9maWxlLnBob25lKQoKLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5Ci8vIHRoZW4gYWRkIGEgYm9vbGVhbiBmbGFnIHRvIHRoZSBzaGFyZWQgc3RhdGUgdG8gaW5kaWNhdGUgbmFtZXMgYXJlIG5vdCBwcmVzZW50Ci8vIHRoaXMgY291bGQgYmUgdXNlZCBlbHNld2hlcmUKLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmcKLy8gdGhlIHVzZXIgb2JqZWN0IHdpdGggYmxhbmsgdmFsdWVzIHdoZW4gZ2l2ZW5OYW1lICBhbmQgZmFtaWx5TmFtZSBpcyBub3QgcHJlc2VudApib29sZWFuIG5vR2l2ZW5OYW1lID0gbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lLmFzU3RyaW5nKCk/LnRyaW0oKSkKYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpCnNoYXJlZFN0YXRlLnB1dCgibmFtZUVtcHR5T3JOdWxsIiwgbm9HaXZlbk5hbWUgJiYgbm9GYW1pbHlOYW1lKQoKcmV0dXJuIG1hbmFnZWRVc2VyCg==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329044523,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -274,15 +274,15 @@
             },
             {
               "name": "content-length",
-              "value": "3162"
+              "value": "3082"
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:24 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -307,8 +307,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.464Z",
-        "time": 84,
+        "startedDateTime": "2024-12-04T16:17:24.457Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -316,15 +316,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 88
         }
       },
       {
-        "_id": "dc6cb455029efa3bca873d64b284a788",
+        "_id": "e97ae6a12c900c7aa9e0edf4c6ce5810",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1460,
+          "bodySize": 1408,
           "cookies": [],
           "headers": [
             {
@@ -337,11 +337,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
@@ -353,7 +353,7 @@
             },
             {
               "name": "content-length",
-              "value": "1460"
+              "value": "1408"
             },
             {
               "name": "accept-encoding",
@@ -364,23 +364,23 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1980,
+          "headersSize": 2022,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"name\":\"GitHub Profile Normalization (VS)\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIkdpdEh1YiByYXdQcm9maWxlOiBcIityYXdQcm9maWxlKVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5pZCksXG4gICAgICAgIGZpZWxkKFwiZGlzcGxheU5hbWVcIiwgcmF3UHJvZmlsZS5uYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5maXJzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJmYW1pbHlOYW1lXCIsIHJhd1Byb2ZpbGUubGFzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUuZGF0YS51cmwpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpKSki\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0}"
+            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"name\":\"GitHub Profile Normalization (VS)\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjAgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmxvZ2dlci53YXJuaW5nKCJHaXRIdWIgcmF3UHJvZmlsZTogIityYXdQcm9maWxlKQoKcmV0dXJuIGpzb24ob2JqZWN0KAogICAgICAgIGZpZWxkKCJpZCIsIHJhd1Byb2ZpbGUuaWQpLAogICAgICAgIGZpZWxkKCJkaXNwbGF5TmFtZSIsIHJhd1Byb2ZpbGUubmFtZSksCiAgICAgICAgZmllbGQoImdpdmVuTmFtZSIsIHJhd1Byb2ZpbGUuZmlyc3RfbmFtZSksCiAgICAgICAgZmllbGQoImZhbWlseU5hbWUiLCByYXdQcm9maWxlLmxhc3RfbmFtZSksCiAgICAgICAgZmllbGQoInBob3RvVXJsIiwgcmF3UHJvZmlsZS5waWN0dXJlLmRhdGEudXJsKSwKICAgICAgICBmaWVsZCgiZW1haWwiLCByYXdQcm9maWxlLmVtYWlsKSwKICAgICAgICBmaWVsZCgidXNlcm5hbWUiLCByYXdQcm9maWxlLmVtYWlsKSkp\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/23143919-6b78-40c3-b25e-beca19b229e0"
         },
         "response": {
-          "bodySize": 1553,
+          "bodySize": 1501,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1553,
-            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"name\":\"GitHub Profile Normalization (VS)\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIkdpdEh1YiByYXdQcm9maWxlOiBcIityYXdQcm9maWxlKVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5pZCksXG4gICAgICAgIGZpZWxkKFwiZGlzcGxheU5hbWVcIiwgcmF3UHJvZmlsZS5uYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5maXJzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJmYW1pbHlOYW1lXCIsIHJhd1Byb2ZpbGUubGFzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUuZGF0YS51cmwpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpKSki\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1725915625618,\"evaluatorVersion\":\"1.0\"}"
+            "size": 1501,
+            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"name\":\"GitHub Profile Normalization (VS)\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjAgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmxvZ2dlci53YXJuaW5nKCJHaXRIdWIgcmF3UHJvZmlsZTogIityYXdQcm9maWxlKQoKcmV0dXJuIGpzb24ob2JqZWN0KAogICAgICAgIGZpZWxkKCJpZCIsIHJhd1Byb2ZpbGUuaWQpLAogICAgICAgIGZpZWxkKCJkaXNwbGF5TmFtZSIsIHJhd1Byb2ZpbGUubmFtZSksCiAgICAgICAgZmllbGQoImdpdmVuTmFtZSIsIHJhd1Byb2ZpbGUuZmlyc3RfbmFtZSksCiAgICAgICAgZmllbGQoImZhbWlseU5hbWUiLCByYXdQcm9maWxlLmxhc3RfbmFtZSksCiAgICAgICAgZmllbGQoInBob3RvVXJsIiwgcmF3UHJvZmlsZS5waWN0dXJlLmRhdGEudXJsKSwKICAgICAgICBmaWVsZCgiZW1haWwiLCByYXdQcm9maWxlLmVtYWlsKSwKICAgICAgICBmaWVsZCgidXNlcm5hbWUiLCByYXdQcm9maWxlLmVtYWlsKSkp\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329044617,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -430,15 +430,15 @@
             },
             {
               "name": "content-length",
-              "value": "1553"
+              "value": "1501"
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:24 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -463,8 +463,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.555Z",
-        "time": 94,
+        "startedDateTime": "2024-12-04T16:17:24.551Z",
+        "time": 87,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -472,15 +472,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 94
+          "wait": 87
         }
       },
       {
-        "_id": "15f56d418c49da89ffd84951232da6e9",
+        "_id": "42b327c90dca66544924f7923ac4d92a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 7356,
+          "bodySize": 7188,
           "cookies": [],
           "headers": [
             {
@@ -493,11 +493,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
@@ -509,7 +509,7 @@
             },
             {
               "name": "content-length",
-              "value": "7356"
+              "value": "7188"
             },
             {
               "name": "accept-encoding",
@@ -520,23 +520,23 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1980,
+          "headersSize": 2022,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqL1xuXG4vKlxuICogVGhpcyBzY3JpcHQgcmV0dXJucyB0aGUgc29jaWFsIGlkZW50aXR5IHByb2ZpbGUgaW5mb3JtYXRpb24gZm9yIHRoZSBhdXRoZW50aWNhdGluZyB1c2VyXG4gKiBpbiBhIHN0YW5kYXJkIGZvcm0gZXhwZWN0ZWQgYnkgdGhlIFNvY2lhbCBQcm92aWRlciBIYW5kbGVyIE5vZGUuXG4gKlxuICogRGVmaW5lZCB2YXJpYWJsZXM6XG4gKiByYXdQcm9maWxlIC0gVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBwcm9maWxlIGluZm9ybWF0aW9uIGZvciB0aGUgYXV0aGVudGljYXRpbmcgdXNlci5cbiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLlxuICogbG9nZ2VyIC0gVGhlIGRlYnVnIGxvZ2dlciBpbnN0YW5jZTpcbiAqICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L3NjcmlwdGluZy1ndWlkZS9zY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuaHRtbCNzY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuXG4gKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS5cbiAqICAgICAgICAgVGhlIG5hbWUgb2YgdGhlIHJlYWxtIHRoZSB1c2VyIGlzIGF1dGhlbnRpY2F0aW5nIHRvLlxuICogcmVxdWVzdEhlYWRlcnMgLSBUcmVlTWFwICgyKS5cbiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OlxuICogICAgICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoZW50aWNhdGlvbi1ndWlkZS9zY3JpcHRpbmctYXBpLW5vZGUuaHRtbCNzY3JpcHRpbmctYXBpLW5vZGUtcmVxdWVzdEhlYWRlcnMuXG4gKiByZXF1ZXN0UGFyYW1ldGVycyAtIFRyZWVNYXAgKDIpLlxuICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy5cbiAqIHNlbGVjdGVkSWRwIC0gU3RyaW5nIChwcmltaXRpdmUpLlxuICogICAgICAgICAgICAgICBUaGUgc29jaWFsIGlkZW50aXR5IHByb3ZpZGVyIG5hbWUuIEZvciBleGFtcGxlOiBnb29nbGUuXG4gKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLlxuICogICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgaG9sZHMgdGhlIHN0YXRlIG9mIHRoZSBhdXRoZW50aWNhdGlvbiB0cmVlIGFuZCBhbGxvd3MgZGF0YSBleGNoYW5nZSBiZXR3ZWVuIHRoZSBzdGF0ZWxlc3Mgbm9kZXM6XG4gKiAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuXG4gKiAgICAgICAgICAgICAgICAgIFRoZSBvYmplY3QgZm9yIHN0b3Jpbmcgc2Vuc2l0aXZlIGluZm9ybWF0aW9uIHRoYXQgbXVzdCBub3QgbGVhdmUgdGhlIHNlcnZlciB1bmVuY3J5cHRlZCxcbiAqICAgICAgICAgICAgICAgICAgYW5kIHRoYXQgbWF5IG5vdCBuZWVkIHRvIHBlcnNpc3QgYmV0d2VlbiBhdXRoZW50aWNhdGlvbiByZXF1ZXN0cyBkdXJpbmcgdGhlIGF1dGhlbnRpY2F0aW9uIHNlc3Npb246XG4gKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqXG4gKiBSZXR1cm4gLSBhIEpzb25WYWx1ZSAoMSkuXG4gKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuXG4gKiAgICAgICAgICBDdXJyZW50bHksIHRoZSBJbW1lZGlhdGVseSBJbnZva2VkIEZ1bmN0aW9uIEV4cHJlc3Npb24gKGFsc28ga25vd24gYXMgU2VsZi1FeGVjdXRpbmcgQW5vbnltb3VzIEZ1bmN0aW9uKVxuICogICAgICAgICAgaXMgdGhlIGxhc3QgKGFuZCBvbmx5KSBzdGF0ZW1lbnQgaW4gdGhpcyBzY3JpcHQsIGFuZCBpdHMgcmV0dXJuIHZhbHVlIHdpbGwgYmVjb21lIHRoZSBzY3JpcHQgcmVzdWx0LlxuICogICAgICAgICAgRG8gbm90IHVzZSBcInJldHVybiB2YXJpYWJsZVwiIHN0YXRlbWVudCBvdXRzaWRlIG9mIGEgZnVuY3Rpb24gZGVmaW5pdGlvbi5cbiAqXG4gKiAgICAgICAgICBUaGlzIHNjcmlwdCdzIGxhc3Qgc3RhdGVtZW50IHNob3VsZCByZXN1bHQgaW4gYSBKc29uVmFsdWUgKDEpIHdpdGggdGhlIGZvbGxvd2luZyBrZXlzOlxuICogICAgICAgICAge1xuICogICAgICAgICAgICAgIHtcImRpc3BsYXlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZW1haWxcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJmYW1pbHlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZ2l2ZW5OYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiaWRcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJsb2NhbGVcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJwaG90b1VybFwiOiBcImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlXCJ9LFxuICogICAgICAgICAgICAgIHtcInVzZXJuYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn1cbiAqICAgICAgICAgIH1cbiAqXG4gKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC5cbiAqICAgICAgICAgIEZvciBleGFtcGxlLCB0aGUgc2NyaXB0IGFzc29jaWF0ZWQgd2l0aCB0aGUgU29jaWFsIFByb3ZpZGVyIEhhbmRsZXIgTm9kZSBhbmQsXG4gKiAgICAgICAgICB1bHRpbWF0ZWx5LCB0aGUgbWFuYWdlZCBvYmplY3QgY3JlYXRlZC91cGRhdGVkIHdpdGggdGhpcyBkYXRhXG4gKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLlxuICogICAgICAgICAgSW4gc29tZSBjb21tb24gZGVmYXVsdCBjb25maWd1cmF0aW9ucywgdGhlIGZvbGxvd2luZyBrZXlzIGFyZSByZXF1aXJlZCB0byBiZSBub3QgZW1wdHk6XG4gKiAgICAgICAgICB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cbiAqXG4gKiAgICAgICAgICBGcm9tIFJGQzQ1MTc6IEEgdmFsdWUgb2YgdGhlIERpcmVjdG9yeSBTdHJpbmcgc3ludGF4IGlzIGEgc3RyaW5nIG9mIG9uZSBvciBtb3JlXG4gKiAgICAgICAgICBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cbiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLlxuICpcbiAqICgxKSBKc29uVmFsdWUgLSBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hcGlkb2NzL29yZy9mb3JnZXJvY2svanNvbi9Kc29uVmFsdWUuaHRtbC5cbiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuXG4gKiAoMykgTGlua2VkSGFzaE1hcCAtIGh0dHBzOi8vZG9jcy5vcmFjbGUuY29tL2VuL2phdmEvamF2YXNlLzExL2RvY3MvYXBpL2phdmEuYmFzZS9qYXZhL3V0aWwvTGlua2VkSGFzaE1hcC5odG1sLlxuICovXG5cbihmdW5jdGlvbiAoKSB7XG4gICAgdmFyIGZySmF2YSA9IEphdmFJbXBvcnRlcihcbiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuICAgICk7XG5cbiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpO1xuICBcbiAgXHQvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTtcblxuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2lkJywgcmF3UHJvZmlsZS5nZXQoJ3N1YicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdlbWFpbCcsIHJhd1Byb2ZpbGUuZ2V0KCdtYWlsJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZ2l2ZW5OYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCd1c2VybmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCd1cG4nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdyb2xlcycsIHJhd1Byb2ZpbGUuZ2V0KCdyb2xlcycpLmFzU3RyaW5nKCkpO1xuICBcbiAgXHQvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gbm9ybWFsaXplZFByb2ZpbGVEYXRhOiAnK25vcm1hbGl6ZWRQcm9maWxlRGF0YSk7XG5cbiAgICByZXR1cm4gbm9ybWFsaXplZFByb2ZpbGVEYXRhO1xufSgpKTsi\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0}"
+            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogIAkvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAJLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/dbe0bf9a-72aa-49d5-8483-9db147985a47"
         },
         "response": {
-          "bodySize": 7449,
+          "bodySize": 7281,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 7449,
-            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqL1xuXG4vKlxuICogVGhpcyBzY3JpcHQgcmV0dXJucyB0aGUgc29jaWFsIGlkZW50aXR5IHByb2ZpbGUgaW5mb3JtYXRpb24gZm9yIHRoZSBhdXRoZW50aWNhdGluZyB1c2VyXG4gKiBpbiBhIHN0YW5kYXJkIGZvcm0gZXhwZWN0ZWQgYnkgdGhlIFNvY2lhbCBQcm92aWRlciBIYW5kbGVyIE5vZGUuXG4gKlxuICogRGVmaW5lZCB2YXJpYWJsZXM6XG4gKiByYXdQcm9maWxlIC0gVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBwcm9maWxlIGluZm9ybWF0aW9uIGZvciB0aGUgYXV0aGVudGljYXRpbmcgdXNlci5cbiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLlxuICogbG9nZ2VyIC0gVGhlIGRlYnVnIGxvZ2dlciBpbnN0YW5jZTpcbiAqICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L3NjcmlwdGluZy1ndWlkZS9zY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuaHRtbCNzY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuXG4gKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS5cbiAqICAgICAgICAgVGhlIG5hbWUgb2YgdGhlIHJlYWxtIHRoZSB1c2VyIGlzIGF1dGhlbnRpY2F0aW5nIHRvLlxuICogcmVxdWVzdEhlYWRlcnMgLSBUcmVlTWFwICgyKS5cbiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OlxuICogICAgICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoZW50aWNhdGlvbi1ndWlkZS9zY3JpcHRpbmctYXBpLW5vZGUuaHRtbCNzY3JpcHRpbmctYXBpLW5vZGUtcmVxdWVzdEhlYWRlcnMuXG4gKiByZXF1ZXN0UGFyYW1ldGVycyAtIFRyZWVNYXAgKDIpLlxuICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy5cbiAqIHNlbGVjdGVkSWRwIC0gU3RyaW5nIChwcmltaXRpdmUpLlxuICogICAgICAgICAgICAgICBUaGUgc29jaWFsIGlkZW50aXR5IHByb3ZpZGVyIG5hbWUuIEZvciBleGFtcGxlOiBnb29nbGUuXG4gKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLlxuICogICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgaG9sZHMgdGhlIHN0YXRlIG9mIHRoZSBhdXRoZW50aWNhdGlvbiB0cmVlIGFuZCBhbGxvd3MgZGF0YSBleGNoYW5nZSBiZXR3ZWVuIHRoZSBzdGF0ZWxlc3Mgbm9kZXM6XG4gKiAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuXG4gKiAgICAgICAgICAgICAgICAgIFRoZSBvYmplY3QgZm9yIHN0b3Jpbmcgc2Vuc2l0aXZlIGluZm9ybWF0aW9uIHRoYXQgbXVzdCBub3QgbGVhdmUgdGhlIHNlcnZlciB1bmVuY3J5cHRlZCxcbiAqICAgICAgICAgICAgICAgICAgYW5kIHRoYXQgbWF5IG5vdCBuZWVkIHRvIHBlcnNpc3QgYmV0d2VlbiBhdXRoZW50aWNhdGlvbiByZXF1ZXN0cyBkdXJpbmcgdGhlIGF1dGhlbnRpY2F0aW9uIHNlc3Npb246XG4gKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqXG4gKiBSZXR1cm4gLSBhIEpzb25WYWx1ZSAoMSkuXG4gKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuXG4gKiAgICAgICAgICBDdXJyZW50bHksIHRoZSBJbW1lZGlhdGVseSBJbnZva2VkIEZ1bmN0aW9uIEV4cHJlc3Npb24gKGFsc28ga25vd24gYXMgU2VsZi1FeGVjdXRpbmcgQW5vbnltb3VzIEZ1bmN0aW9uKVxuICogICAgICAgICAgaXMgdGhlIGxhc3QgKGFuZCBvbmx5KSBzdGF0ZW1lbnQgaW4gdGhpcyBzY3JpcHQsIGFuZCBpdHMgcmV0dXJuIHZhbHVlIHdpbGwgYmVjb21lIHRoZSBzY3JpcHQgcmVzdWx0LlxuICogICAgICAgICAgRG8gbm90IHVzZSBcInJldHVybiB2YXJpYWJsZVwiIHN0YXRlbWVudCBvdXRzaWRlIG9mIGEgZnVuY3Rpb24gZGVmaW5pdGlvbi5cbiAqXG4gKiAgICAgICAgICBUaGlzIHNjcmlwdCdzIGxhc3Qgc3RhdGVtZW50IHNob3VsZCByZXN1bHQgaW4gYSBKc29uVmFsdWUgKDEpIHdpdGggdGhlIGZvbGxvd2luZyBrZXlzOlxuICogICAgICAgICAge1xuICogICAgICAgICAgICAgIHtcImRpc3BsYXlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZW1haWxcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJmYW1pbHlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZ2l2ZW5OYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiaWRcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJsb2NhbGVcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJwaG90b1VybFwiOiBcImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlXCJ9LFxuICogICAgICAgICAgICAgIHtcInVzZXJuYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn1cbiAqICAgICAgICAgIH1cbiAqXG4gKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC5cbiAqICAgICAgICAgIEZvciBleGFtcGxlLCB0aGUgc2NyaXB0IGFzc29jaWF0ZWQgd2l0aCB0aGUgU29jaWFsIFByb3ZpZGVyIEhhbmRsZXIgTm9kZSBhbmQsXG4gKiAgICAgICAgICB1bHRpbWF0ZWx5LCB0aGUgbWFuYWdlZCBvYmplY3QgY3JlYXRlZC91cGRhdGVkIHdpdGggdGhpcyBkYXRhXG4gKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLlxuICogICAgICAgICAgSW4gc29tZSBjb21tb24gZGVmYXVsdCBjb25maWd1cmF0aW9ucywgdGhlIGZvbGxvd2luZyBrZXlzIGFyZSByZXF1aXJlZCB0byBiZSBub3QgZW1wdHk6XG4gKiAgICAgICAgICB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cbiAqXG4gKiAgICAgICAgICBGcm9tIFJGQzQ1MTc6IEEgdmFsdWUgb2YgdGhlIERpcmVjdG9yeSBTdHJpbmcgc3ludGF4IGlzIGEgc3RyaW5nIG9mIG9uZSBvciBtb3JlXG4gKiAgICAgICAgICBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cbiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLlxuICpcbiAqICgxKSBKc29uVmFsdWUgLSBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hcGlkb2NzL29yZy9mb3JnZXJvY2svanNvbi9Kc29uVmFsdWUuaHRtbC5cbiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuXG4gKiAoMykgTGlua2VkSGFzaE1hcCAtIGh0dHBzOi8vZG9jcy5vcmFjbGUuY29tL2VuL2phdmEvamF2YXNlLzExL2RvY3MvYXBpL2phdmEuYmFzZS9qYXZhL3V0aWwvTGlua2VkSGFzaE1hcC5odG1sLlxuICovXG5cbihmdW5jdGlvbiAoKSB7XG4gICAgdmFyIGZySmF2YSA9IEphdmFJbXBvcnRlcihcbiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuICAgICk7XG5cbiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpO1xuICBcbiAgXHQvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTtcblxuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2lkJywgcmF3UHJvZmlsZS5nZXQoJ3N1YicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdlbWFpbCcsIHJhd1Byb2ZpbGUuZ2V0KCdtYWlsJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZ2l2ZW5OYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCd1c2VybmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCd1cG4nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdyb2xlcycsIHJhd1Byb2ZpbGUuZ2V0KCdyb2xlcycpLmFzU3RyaW5nKCkpO1xuICBcbiAgXHQvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gbm9ybWFsaXplZFByb2ZpbGVEYXRhOiAnK25vcm1hbGl6ZWRQcm9maWxlRGF0YSk7XG5cbiAgICByZXR1cm4gbm9ybWFsaXplZFByb2ZpbGVEYXRhO1xufSgpKTsi\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1725915625705,\"evaluatorVersion\":\"1.0\"}"
+            "size": 7281,
+            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogIAkvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAJLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329044712,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -586,15 +586,15 @@
             },
             {
               "name": "content-length",
-              "value": "7449"
+              "value": "7281"
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:24 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -619,8 +619,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.660Z",
-        "time": 76,
+        "startedDateTime": "2024-12-04T16:17:24.648Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -628,7 +628,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 76
+          "wait": 86
         }
       },
       {
@@ -649,11 +649,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "authorization",
@@ -672,7 +672,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1891,
+          "headersSize": 1933,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -698,7 +698,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:24 GMT"
             },
             {
               "name": "cache-control",
@@ -742,7 +742,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -767,8 +767,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.743Z",
-        "time": 61,
+        "startedDateTime": "2024-12-04T16:17:24.741Z",
+        "time": 71,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -776,7 +776,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 61
+          "wait": 71
         }
       },
       {
@@ -797,11 +797,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
@@ -824,7 +824,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2001,
+          "headersSize": 2043,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -898,11 +898,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:24 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -927,8 +927,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.809Z",
-        "time": 75,
+        "startedDateTime": "2024-12-04T16:17:24.820Z",
+        "time": 82,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -936,7 +936,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 75
+          "wait": 82
         }
       },
       {
@@ -957,11 +957,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
@@ -984,7 +984,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1997,
+          "headersSize": 2039,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -1058,11 +1058,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:24 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -1087,8 +1087,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.891Z",
-        "time": 80,
+        "startedDateTime": "2024-12-04T16:17:24.907Z",
+        "time": 93,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1096,7 +1096,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 80
+          "wait": 93
         }
       },
       {
@@ -1117,11 +1117,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
@@ -1140,7 +1140,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1993,
+          "headersSize": 2035,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1214,11 +1214,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -1243,8 +1243,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.980Z",
-        "time": 59,
+        "startedDateTime": "2024-12-04T16:17:25.008Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1252,7 +1252,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 59
+          "wait": 73
         }
       },
       {
@@ -1273,11 +1273,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
@@ -1300,7 +1300,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1973,
+          "headersSize": 2015,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -1312,11 +1312,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/saml2/hosted/aVNQQXp1cmU"
         },
         "response": {
-          "bodySize": 3964,
+          "bodySize": 3991,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 3964,
-            "text": "{\"_id\":\"aVNQQXp1cmU\",\"_rev\":\"1379466460\",\"entityId\":\"iSPAzure\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName\"]},\"authenticationContext\":{\"authenticationContextMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAuthnContextMapper\",\"authContextItems\":[{\"contextReference\":\"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport\",\"level\":0,\"defaultItem\":true}],\"authenticationComparisonType\":\"Exact\",\"includeRequestedAuthenticationContext\":true},\"assertionTimeSkew\":300,\"basicAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAttributeMapper\",\"attributeMap\":[{\"key\":\"http://schemas.microsoft.com/identity/claims/displayname\",\"value\":\"cn\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\",\"value\":\"givenName\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\",\"value\":\"sn\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\",\"value\":\"mail\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\",\"value\":\"uid\"}]},\"autoFederation\":{\"autoFedEnabled\":false},\"accountMapping\":{\"spAccountMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAccountMapper\",\"useNameIDAsSPUserID\":true},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"},\"url\":{},\"adapter\":{}},\"services\":{\"metaAlias\":\"/alpha/iSPAzure\",\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\",\"location\":\"https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\",\"location\":\"https://idc.scheuber.io/am/SPSloSoap/metaAlias/alpha/iSPAzure\"}],\"nameIdService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\",\"location\":\"https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\",\"location\":\"https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact\",\"location\":\"https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://idc.scheuber.io/am/Consumer/ECP/metaAlias/alpha/iSPAzure\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{\"spUrl\":\"https://idc.scheuber.io/am/spsaehandler/metaAlias/alpha/iSPAzure\"},\"ecpConfiguration\":{\"ecpRequestIdpListFinderImpl\":\"com.sun.identity.saml2.plugins.ECPIDPFinder\"},\"idpProxy\":{},\"relayStateUrlList\":{}}}}"
+            "size": 3991,
+            "text": "{\"_id\":\"aVNQQXp1cmU\",\"_rev\":\"-1533212691\",\"entityId\":\"iSPAzure\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName\"]},\"authenticationContext\":{\"authenticationContextMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAuthnContextMapper\",\"authContextItems\":[{\"contextReference\":\"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport\",\"level\":0,\"defaultItem\":true}],\"authenticationComparisonType\":\"Exact\",\"includeRequestedAuthenticationContext\":true},\"assertionTimeSkew\":300,\"basicAuthentication\":{},\"clientAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAttributeMapper\",\"attributeMap\":[{\"key\":\"http://schemas.microsoft.com/identity/claims/displayname\",\"value\":\"cn\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\",\"value\":\"givenName\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\",\"value\":\"sn\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\",\"value\":\"mail\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\",\"value\":\"uid\"}]},\"autoFederation\":{\"autoFedEnabled\":false},\"accountMapping\":{\"spAccountMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAccountMapper\",\"useNameIDAsSPUserID\":true},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"},\"url\":{},\"adapter\":{}},\"services\":{\"metaAlias\":\"/alpha/iSPAzure\",\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\",\"location\":\"https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\",\"location\":\"https://idc.scheuber.io/am/SPSloSoap/metaAlias/alpha/iSPAzure\"}],\"nameIdService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\",\"location\":\"https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\",\"location\":\"https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact\",\"location\":\"https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://idc.scheuber.io/am/Consumer/ECP/metaAlias/alpha/iSPAzure\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{\"spUrl\":\"https://idc.scheuber.io/am/spsaehandler/metaAlias/alpha/iSPAzure\"},\"ecpConfiguration\":{\"ecpRequestIdpListFinderImpl\":\"com.sun.identity.saml2.plugins.ECPIDPFinder\"},\"idpProxy\":{},\"relayStateUrlList\":{}}}}"
           },
           "cookies": [],
           "headers": [
@@ -1354,7 +1354,7 @@
             },
             {
               "name": "etag",
-              "value": "\"1379466460\""
+              "value": "\"-1533212691\""
             },
             {
               "name": "expires",
@@ -1370,15 +1370,15 @@
             },
             {
               "name": "content-length",
-              "value": "3964"
+              "value": "3991"
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -1397,14 +1397,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 787,
+          "headersSize": 788,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:26.045Z",
-        "time": 94,
+        "startedDateTime": "2024-12-04T16:17:25.088Z",
+        "time": 121,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1412,7 +1412,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 94
+          "wait": 121
         }
       },
       {
@@ -1433,11 +1433,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
@@ -1456,7 +1456,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2019,
+          "headersSize": 2061,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1530,11 +1530,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -1559,8 +1559,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:26.143Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:17:25.215Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1568,7 +1568,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 76
         }
       },
       {
@@ -1589,11 +1589,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
@@ -1616,7 +1616,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2002,
+          "headersSize": 2044,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -1628,11 +1628,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/saml2/remote/dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l"
         },
         "response": {
-          "bodySize": 1562,
+          "bodySize": 1604,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1562,
-            "text": "{\"_id\":\"dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l\",\"_rev\":\"2050716030\",\"entityId\":\"urn:federation:MicrosoftOnline\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{\"assertion\":true},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:mace:shibboleth:1.0:nameIdentifier\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\"]},\"secrets\":{},\"basicAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMap\":[{\"samlAttribute\":\"IDPEmail\",\"localAttribute\":\"mail\",\"binary\":false},{\"samlAttribute\":\"UOPClassID\",\"localAttribute\":\"UOPClassID\",\"binary\":false}]},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"}},\"services\":{\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{},\"idpProxy\":{}}}}"
+            "size": 1604,
+            "text": "{\"_id\":\"dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l\",\"_rev\":\"-901720656\",\"entityId\":\"urn:federation:MicrosoftOnline\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{\"assertion\":true},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:mace:shibboleth:1.0:nameIdentifier\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\"]},\"secrets\":{},\"basicAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMap\":[{\"samlAttribute\":\"IDPEmail\",\"localAttribute\":\"mail\",\"binary\":false},{\"samlAttribute\":\"UOPClassID\",\"localAttribute\":\"UOPClassID\",\"binary\":false}]},\"accountMapper\":{},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"}},\"services\":{\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{},\"idpProxy\":{},\"treeConfiguration\":{}}}}"
           },
           "cookies": [],
           "headers": [
@@ -1670,7 +1670,7 @@
             },
             {
               "name": "etag",
-              "value": "\"2050716030\""
+              "value": "\"-901720656\""
             },
             {
               "name": "expires",
@@ -1686,15 +1686,15 @@
             },
             {
               "name": "content-length",
-              "value": "1562"
+              "value": "1604"
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -1719,8 +1719,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:26.213Z",
-        "time": 113,
+        "startedDateTime": "2024-12-04T16:17:25.301Z",
+        "time": 110,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1728,7 +1728,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 113
+          "wait": 110
         }
       },
       {
@@ -1749,15 +1749,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1776,7 +1776,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1990,
+          "headersSize": 2032,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1819,7 +1819,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1851,11 +1851,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -1880,8 +1880,8 @@
           "status": 409,
           "statusText": "Conflict"
         },
-        "startedDateTime": "2024-09-09T21:00:26.331Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:17:25.418Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1889,7 +1889,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 79
         }
       },
       {
@@ -1910,15 +1910,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1937,7 +1937,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1982,
+          "headersSize": 2024,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -1975,7 +1975,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2011,11 +2011,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -2040,8 +2040,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:26.404Z",
-        "time": 77,
+        "startedDateTime": "2024-12-04T16:17:25.503Z",
+        "time": 85,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2049,7 +2049,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 77
+          "wait": 85
         }
       },
       {
@@ -2070,15 +2070,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2097,7 +2097,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2047,
+          "headersSize": 2089,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2135,7 +2135,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2175,11 +2175,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -2204,8 +2204,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:26.487Z",
-        "time": 172,
+        "startedDateTime": "2024-12-04T16:17:25.595Z",
+        "time": 173,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2213,7 +2213,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 172
+          "wait": 173
         }
       },
       {
@@ -2234,15 +2234,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2261,7 +2261,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2039,
+          "headersSize": 2081,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2299,7 +2299,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2339,11 +2339,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -2368,8 +2368,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:26.666Z",
-        "time": 172,
+        "startedDateTime": "2024-12-04T16:17:25.773Z",
+        "time": 176,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2377,7 +2377,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 172
+          "wait": 176
         }
       },
       {
@@ -2398,15 +2398,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2425,7 +2425,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2047,
+          "headersSize": 2089,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2463,7 +2463,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2503,11 +2503,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -2532,8 +2532,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:26.843Z",
-        "time": 181,
+        "startedDateTime": "2024-12-04T16:17:25.953Z",
+        "time": 182,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2541,7 +2541,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 181
+          "wait": 182
         }
       },
       {
@@ -2562,15 +2562,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2589,7 +2589,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2047,
+          "headersSize": 2089,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2627,7 +2627,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2667,11 +2667,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -2696,8 +2696,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.031Z",
-        "time": 174,
+        "startedDateTime": "2024-12-04T16:17:26.140Z",
+        "time": 182,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2705,7 +2705,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 174
+          "wait": 182
         }
       },
       {
@@ -2726,15 +2726,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2753,7 +2753,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2039,
+          "headersSize": 2081,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2791,7 +2791,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2831,11 +2831,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -2860,8 +2860,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.210Z",
-        "time": 171,
+        "startedDateTime": "2024-12-04T16:17:26.328Z",
+        "time": 197,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2869,7 +2869,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 171
+          "wait": 197
         }
       },
       {
@@ -2890,15 +2890,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2917,7 +2917,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2034,
+          "headersSize": 2076,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2955,7 +2955,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2995,11 +2995,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -3024,8 +3024,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.387Z",
-        "time": 172,
+        "startedDateTime": "2024-12-04T16:17:26.534Z",
+        "time": 181,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3033,7 +3033,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 172
+          "wait": 181
         }
       },
       {
@@ -3054,15 +3054,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3081,7 +3081,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2043,
+          "headersSize": 2085,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3119,7 +3119,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3159,11 +3159,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -3188,8 +3188,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.563Z",
-        "time": 172,
+        "startedDateTime": "2024-12-04T16:17:26.720Z",
+        "time": 182,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3197,7 +3197,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 172
+          "wait": 182
         }
       },
       {
@@ -3218,15 +3218,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3245,7 +3245,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2043,
+          "headersSize": 2085,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3283,7 +3283,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3323,11 +3323,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -3352,7 +3352,7 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.739Z",
+        "startedDateTime": "2024-12-04T16:17:26.908Z",
         "time": 176,
         "timings": {
           "blocked": -1,
@@ -3382,15 +3382,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3409,7 +3409,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2048,
+          "headersSize": 2090,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3447,7 +3447,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3487,11 +3487,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -3516,8 +3516,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.920Z",
-        "time": 196,
+        "startedDateTime": "2024-12-04T16:17:27.091Z",
+        "time": 204,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3525,7 +3525,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 196
+          "wait": 204
         }
       },
       {
@@ -3546,15 +3546,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3573,7 +3573,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2046,
+          "headersSize": 2088,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3611,7 +3611,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3651,11 +3651,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:28 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -3680,8 +3680,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:28.121Z",
-        "time": 191,
+        "startedDateTime": "2024-12-04T16:17:27.300Z",
+        "time": 181,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3689,7 +3689,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 191
+          "wait": 181
         }
       },
       {
@@ -3710,15 +3710,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3737,7 +3737,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2051,
+          "headersSize": 2093,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3775,7 +3775,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3815,11 +3815,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:28 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -3844,8 +3844,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:28.315Z",
-        "time": 175,
+        "startedDateTime": "2024-12-04T16:17:27.487Z",
+        "time": 188,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3853,7 +3853,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 175
+          "wait": 188
         }
       },
       {
@@ -3874,15 +3874,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3901,7 +3901,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2034,
+          "headersSize": 2076,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3939,7 +3939,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3979,11 +3979,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:28 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -4008,8 +4008,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:28.495Z",
-        "time": 202,
+        "startedDateTime": "2024-12-04T16:17:27.682Z",
+        "time": 179,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4017,7 +4017,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 202
+          "wait": 179
         }
       },
       {
@@ -4038,15 +4038,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4065,7 +4065,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2051,
+          "headersSize": 2093,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -4103,7 +4103,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -4143,11 +4143,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:28 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -4172,8 +4172,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:28.702Z",
-        "time": 177,
+        "startedDateTime": "2024-12-04T16:17:27.867Z",
+        "time": 186,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4181,7 +4181,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 177
+          "wait": 186
         }
       },
       {
@@ -4202,15 +4202,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4229,7 +4229,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2007,
+          "headersSize": 2049,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -4241,11 +4241,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/FrodoTestJourney5"
         },
         "response": {
-          "bodySize": 2662,
+          "bodySize": 2677,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 2662,
-            "text": "{\"_id\":\"FrodoTestJourney5\",\"_rev\":\"-2052317947\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Frodo\\\",\\\"Prototype\\\"]\"},\"entryNodeId\":\"94299dce-b606-409f-8be0-66d23061692f\",\"innerTreeOnly\":false,\"nodes\":{\"ef8f26a5-a85f-4929-acf6-842e24d89493\":{\"x\":440,\"y\":424,\"connections\":{\"localAuthentication\":\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\",\"socialAuthentication\":\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\"},\"nodeType\":\"PageNode\",\"displayName\":\"Login Page\"},\"c89fb4c7-0122-42c0-817a-a0451b67bcdc\":{\"x\":915,\"y\":309.3333333333333,\"connections\":{\"EMAIL_NOT_SENT\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EMAIL_SENT\":\"58f762af-8e19-4d96-aae0-73b48e8f95d4\"},\"nodeType\":\"EmailTemplateNode\",\"displayName\":\"Email Template Node\"},\"58f762af-8e19-4d96-aae0-73b48e8f95d4\":{\"x\":1163,\"y\":305.5,\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"nodeType\":\"product-Saml2Node\",\"displayName\":\"SAML2 Authentication\"},\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\":{\"x\":915,\"y\":168.66666666666669,\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"nodeType\":\"InnerTreeEvaluatorNode\",\"displayName\":\"Login\"},\"94299dce-b606-409f-8be0-66d23061692f\":{\"x\":210,\"y\":305.5,\"connections\":{\"unknown\":\"da49467f-a848-4e41-a175-5a0502c5d2af\",\"known\":\"ef8f26a5-a85f-4929-acf6-842e24d89493\"},\"nodeType\":\"ScriptedDecisionNode\",\"displayName\":\"Check Username\"},\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\":{\"x\":685,\"y\":143.66666666666666,\"connections\":{\"CANCELLED\":\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\",\"EXPIRED\":\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"nodeType\":\"IdentityStoreDecisionNode\",\"displayName\":\"Validate Creds\"},\"da49467f-a848-4e41-a175-5a0502c5d2af\":{\"x\":440,\"y\":80,\"connections\":{\"localAuthentication\":\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\",\"socialAuthentication\":\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\"},\"nodeType\":\"PageNode\",\"displayName\":\"Login Page\"},\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\":{\"x\":685,\"y\":371.8333333333333,\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"c89fb4c7-0122-42c0-817a-a0451b67bcdc\"},\"nodeType\":\"SocialProviderHandlerNode\",\"displayName\":\"Social Login\"}},\"staticNodes\":{\"startNode\":{\"x\":70,\"y\":323},\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1417,\"y\":192},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1417,\"y\":286}},\"description\":\"Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.\",\"enabled\":true}"
+            "size": 2677,
+            "text": "{\"_id\":\"FrodoTestJourney5\",\"_rev\":\"-639311844\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Frodo\\\",\\\"Prototype\\\"]\"},\"entryNodeId\":\"94299dce-b606-409f-8be0-66d23061692f\",\"innerTreeOnly\":false,\"nodes\":{\"ef8f26a5-a85f-4929-acf6-842e24d89493\":{\"x\":440,\"y\":424,\"connections\":{\"localAuthentication\":\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\",\"socialAuthentication\":\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\"},\"nodeType\":\"PageNode\",\"displayName\":\"Login Page\"},\"c89fb4c7-0122-42c0-817a-a0451b67bcdc\":{\"x\":915,\"y\":309.3333333333333,\"connections\":{\"EMAIL_NOT_SENT\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EMAIL_SENT\":\"58f762af-8e19-4d96-aae0-73b48e8f95d4\"},\"nodeType\":\"EmailTemplateNode\",\"displayName\":\"Email Template Node\"},\"58f762af-8e19-4d96-aae0-73b48e8f95d4\":{\"x\":1163,\"y\":305.5,\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"nodeType\":\"product-Saml2Node\",\"displayName\":\"SAML2 Authentication\"},\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\":{\"x\":915,\"y\":168.66666666666669,\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"nodeType\":\"InnerTreeEvaluatorNode\",\"displayName\":\"Login\"},\"94299dce-b606-409f-8be0-66d23061692f\":{\"x\":210,\"y\":305.5,\"connections\":{\"unknown\":\"da49467f-a848-4e41-a175-5a0502c5d2af\",\"known\":\"ef8f26a5-a85f-4929-acf6-842e24d89493\"},\"nodeType\":\"ScriptedDecisionNode\",\"displayName\":\"Check Username\"},\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\":{\"x\":685,\"y\":143.66666666666666,\"connections\":{\"CANCELLED\":\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\",\"EXPIRED\":\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"nodeType\":\"IdentityStoreDecisionNode\",\"displayName\":\"Validate Creds\"},\"da49467f-a848-4e41-a175-5a0502c5d2af\":{\"x\":440,\"y\":80,\"connections\":{\"localAuthentication\":\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\",\"socialAuthentication\":\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\"},\"nodeType\":\"PageNode\",\"displayName\":\"Login Page\"},\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\":{\"x\":685,\"y\":371.8333333333333,\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"c89fb4c7-0122-42c0-817a-a0451b67bcdc\"},\"nodeType\":\"SocialProviderHandlerNode\",\"displayName\":\"Social Login\"}},\"staticNodes\":{\"startNode\":{\"x\":70,\"y\":323},\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1417,\"y\":192},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1417,\"y\":286}},\"description\":\"Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.\",\"mustRun\":false,\"enabled\":true}"
           },
           "cookies": [],
           "headers": [
@@ -4267,7 +4267,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -4283,7 +4283,7 @@
             },
             {
               "name": "etag",
-              "value": "\"-2052317947\""
+              "value": "\"-639311844\""
             },
             {
               "name": "expires",
@@ -4303,15 +4303,15 @@
             },
             {
               "name": "content-length",
-              "value": "2662"
+              "value": "2677"
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:28 GMT"
+              "value": "Wed, 04 Dec 2024 16:17:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-2d9c5a64-06ed-4355-a17e-0d50bffd2831"
             },
             {
               "name": "strict-transport-security",
@@ -4330,14 +4330,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 945,
+          "headersSize": 944,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/FrodoTestJourney5",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:28.884Z",
-        "time": 76,
+        "startedDateTime": "2024-12-04T16:17:28.059Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4345,7 +4345,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 76
+          "wait": 84
         }
       }
     ],


### PR DESCRIPTION
Fixes the bug mentioned in this issue: https://github.com/rockcarver/frodo-cli/issues/457

A few comments were also added to clarify why we use `JSON.stringify` and `JSON.parse` for scripts in journey exports and imports.

This update broke a few of the journey import tests in frodo-cli, so I made a [PR](https://github.com/rockcarver/frodo-cli/pull/460) there as well to fix those tests.