### PR TITLE
Create new type to support split out managed.json file

### DIFF
--- a/src/ops/MappingOps.ts
+++ b/src/ops/MappingOps.ts
@@ -276,6 +276,10 @@ export type SyncSkeleton = IdObjectSkeletonInterface & {
   mappings: MappingSkeleton[];
 };
 
+export type ManagedSkeleton = IdObjectSkeletonInterface & {
+  objects: MappingSkeleton[];
+};
+
 export interface MappingExportInterface {
   meta?: ExportMetaData;
   mapping: Record<string, MappingSkeleton>;


### PR DESCRIPTION
Adds a new type to support changes introduced in this PR that allow splitting out the managed.json file into separate files per object: https://github.com/rockcarver/frodo-cli/pull/461