### PR TITLE
Fix lint and pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3841,11 +3841,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4923,11 +4922,10 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4948,7 +4946,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -4963,6 +4961,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -8166,11 +8168,10 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/src/ops/InternalRoleOps.ts
+++ b/src/ops/InternalRoleOps.ts
@@ -74,17 +74,13 @@ export type InternalRole = {
    * @param {string} roleId internal role uuid
    * @returns {Promise<InternalRoleSkeleton>} a promise that resolves to an internal role object
    */
-  deleteInternalRole(
-    roleId: string
-  ): Promise<InternalRoleSkeleton>;
+  deleteInternalRole(roleId: string): Promise<InternalRoleSkeleton>;
   /**
    * Delete internal role by name
    * @param {string} roleName internal role name
    * @returns {Promise<InternalRoleSkeleton>} a promise that resolves to an internal role object
    */
-  deleteInternalRoleByName(
-    roleName: string
-  ): Promise<InternalRoleSkeleton>;
+  deleteInternalRoleByName(roleName: string): Promise<InternalRoleSkeleton>;
   /**
    * Delete all internal roles
    * @returns {Promise<InternalRoleSkeleton[]>} a promise that resolves to an array of internal role objects


### PR DESCRIPTION
A fix for the pipeline so that PR's can run it again. I simply ran `npm audit fix`, and also `npm run lint:fix` to fix the lint problem as well. I originally had this commit in [this](https://github.com/rockcarver/frodo-lib/pull/475) PR, but I decided to put it in a separate PR since it's unrelated to journey imports.

This PR should be merged in first, so that the pipeline can pass for all the other PRs currently waiting to be merged in.