### PR TITLE
Fix bug with IdP Imports 

### DIFF
--- a/src/api/ServiceApi.ts
+++ b/src/api/ServiceApi.ts
@@ -190,6 +190,14 @@ export async function putServiceNextDescendent({
   globalConfig?: boolean;
   state: State;
 }): Promise<ServiceNextDescendent> {
+  // If performing an update (not create), idp updates will throw an HTTP 500 error unless the redirectAfterFormPostURI attribute has a value.
+  // If no redirectAfterFormPostURI is provided, importing with an empty string as its value will perform the same function without the 500 error.
+  if (
+    serviceId === 'SocialIdentityProviders' &&
+    serviceNextDescendentData.redirectAfterFormPostURI === undefined
+  ) {
+    serviceNextDescendentData.redirectAfterFormPostURI = '';
+  }
   const urlString = util.format(
     serviceURLNextDescendentTemplate,
     state.getHost(),

--- a/src/ops/IdpOps.ts
+++ b/src/ops/IdpOps.ts
@@ -1,4 +1,3 @@
-import { type NoIdObjectSkeletonInterface } from '../api/ApiTypes';
 import { getScript, type ScriptSkeleton } from '../api/ScriptApi';
 import {
   deleteProviderByTypeAndId,
@@ -463,7 +462,7 @@ export async function createSocialIdentityProvider({
 }: {
   providerType: string;
   providerId: string;
-  providerData: SocialIdpSkeleton | NoIdObjectSkeletonInterface;
+  providerData: SocialIdpSkeleton;
   state: State;
 }): Promise<SocialIdpSkeleton> {
   debugMessage({
@@ -500,7 +499,7 @@ export async function updateSocialIdentityProvider({
 }: {
   providerType: string;
   providerId: string;
-  providerData: SocialIdpSkeleton | NoIdObjectSkeletonInterface;
+  providerData: SocialIdpSkeleton;
   state: State;
 }): Promise<SocialIdpSkeleton> {
   debugMessage({

--- a/src/test/mock-recordings/IdpOps_3439825948/1-Import-all-social-providers_3947928337/recording.har
+++ b/src/test/mock-recordings/IdpOps_3439825948/1-Import-all-social-providers_3947928337/recording.har
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-661b718b-7808-4fa3-8279-4b6813d715de"
             },
             {
               "name": "accept-api-version",
@@ -41,14 +41,18 @@
             },
             {
               "name": "content-length",
-              "value": 7196
+              "value": "7196"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1636,
+          "headersSize": 2022,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -64,7 +68,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 7289,
-            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogICAgICAvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=76618ff6-e851-433e-9704-9d2852a17b7a,ou=user,ou=am-config\",\"lastModifiedDate\":1703121249306,\"evaluatorVersion\":\"1.0\"}"
+            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogICAgICAvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733777864214,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -118,15 +122,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:09 GMT"
+              "value": "Mon, 09 Dec 2024 20:57:44 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-661b718b-7808-4fa3-8279-4b6813d715de"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -137,14 +145,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 747,
+          "headersSize": 767,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-21T01:14:09.254Z",
-        "time": 79,
+        "startedDateTime": "2024-12-09T20:57:44.167Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -152,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 79
+          "wait": 68
         }
       },
       {
-        "_id": "edf84d02001baf38660f2486818d006a",
+        "_id": "aad41c04f2a52a2f2fb4850817fd821a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1585,
+          "bodySize": 1615,
           "cookies": [],
           "headers": [
             {
@@ -173,11 +181,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-661b718b-7808-4fa3-8279-4b6813d715de"
             },
             {
               "name": "accept-api-version",
@@ -189,20 +197,24 @@
             },
             {
               "name": "content-length",
-              "value": 1585
+              "value": "1615"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1662,
+          "headersSize": 2048,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp7\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true}}"
+            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp7\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true},\"redirectAfterFormPostURI\":\"\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp7"
@@ -274,15 +286,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:09 GMT"
+              "value": "Mon, 09 Dec 2024 20:57:44 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-661b718b-7808-4fa3-8279-4b6813d715de"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -293,14 +309,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 923,
+          "headersSize": 943,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp7",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-12-21T01:14:09.344Z",
-        "time": 188,
+        "startedDateTime": "2024-12-09T20:57:44.241Z",
+        "time": 174,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -308,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 188
+          "wait": 174
         }
       },
       {
@@ -329,11 +345,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-661b718b-7808-4fa3-8279-4b6813d715de"
             },
             {
               "name": "accept-api-version",
@@ -345,14 +361,18 @@
             },
             {
               "name": "content-length",
-              "value": 2780
+              "value": "2780"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1636,
+          "headersSize": 2022,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -368,7 +388,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 2874,
-            "text": "{\"_id\":\"484e6246-dbc6-4288-97e6-54e55431402e\",\"name\":\"Apple Profile Normalization\",\"description\":\"Normalizes raw profile data from Apple\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjEtMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWQKICoKICogVXNlIG9mIHRoaXMgY29kZSByZXF1aXJlcyBhIGNvbW1lcmNpYWwgc29mdHdhcmUgbGljZW5zZSB3aXRoIEZvcmdlUm9jayBBUy4KICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICoKICogSW4gc29tZSBjb21tb24gZGVmYXVsdCBjb25maWd1cmF0aW9ucywgdGhlIGZvbGxvd2luZyBrZXlzIGFyZSByZXF1aXJlZCB0byBiZSBub3QgZW1wdHk6CiAqIHVzZXJuYW1lLCBnaXZlbk5hbWUsIGZhbWlseU5hbWUsIGVtYWlsLgogKgogKiBGcm9tIFJGQzQ1MTc6IEEgdmFsdWUgb2YgdGhlIERpcmVjdG9yeSBTdHJpbmcgc3ludGF4IGlzIGEgc3RyaW5nIG9mIG9uZSBvciBtb3JlCiAqIGFyYml0cmFyeSBjaGFyYWN0ZXJzIGZyb20gdGhlIFVuaXZlcnNhbCBDaGFyYWN0ZXIgU2V0IChVQ1MpLgogKiBBIHplcm8tbGVuZ3RoIGNoYXJhY3RlciBzdHJpbmcgaXMgbm90IHBlcm1pdHRlZC4KICovCgppbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuZmllbGQKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmpzb24KaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdAoKU3RyaW5nIGVtYWlsID0gImNoYW5nZUBtZS5jb20iClN0cmluZyBzdWJqZWN0SWQgPSByYXdQcm9maWxlLnN1YgpTdHJpbmcgZmlyc3ROYW1lID0gIiAiClN0cmluZyBsYXN0TmFtZSA9ICIgIgpTdHJpbmcgdXNlcm5hbWUgPSBzdWJqZWN0SWQKU3RyaW5nIG5hbWUKCmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZCgiZW1haWwiKSAmJiByYXdQcm9maWxlLmVtYWlsLmlzTm90TnVsbCgpKXsgLy8gVXNlciBjYW4gZWxlY3QgdG8gbm90IHNoYXJlIHRoZWlyIGVtYWlsCiAgICBlbWFpbCA9IHJhd1Byb2ZpbGUuZW1haWwuYXNTdHJpbmcoKQogICAgdXNlcm5hbWUgPSBlbWFpbAp9CmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZCgibmFtZSIpICYmIHJhd1Byb2ZpbGUubmFtZS5pc05vdE51bGwoKSkgewogICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoImZpcnN0TmFtZSIpICYmIHJhd1Byb2ZpbGUubmFtZS5maXJzdE5hbWUuaXNOb3ROdWxsKCkpIHsKICAgICAgICBmaXJzdE5hbWUgPSByYXdQcm9maWxlLm5hbWUuZmlyc3ROYW1lLmFzU3RyaW5nKCkKICAgIH0KICAgIGlmIChyYXdQcm9maWxlLm5hbWUuaXNEZWZpbmVkKCJsYXN0TmFtZSIpICYmIHJhd1Byb2ZpbGUubmFtZS5sYXN0TmFtZS5pc05vdE51bGwoKSkgewogICAgICAgIGxhc3ROYW1lID0gcmF3UHJvZmlsZS5uYW1lLmxhc3ROYW1lLmFzU3RyaW5nKCkKICAgIH0KfQoKbmFtZSA9IChmaXJzdE5hbWU/LnRyaW0oKSA/IGZpcnN0TmFtZSA6ICIiKSArIChsYXN0TmFtZT8udHJpbSgpID8gKChmaXJzdE5hbWU/LnRyaW0oKSA/ICIgIiA6ICIiKSArIGxhc3ROYW1lKSA6ICIiKQpuYW1lID0gICghbmFtZT8udHJpbSgpKSA/ICIgIiA6IG5hbWUKCnJldHVybiBqc29uKG9iamVjdCgKICAgICAgICBmaWVsZCgiaWQiLCBzdWJqZWN0SWQpLAogICAgICAgIGZpZWxkKCJkaXNwbGF5TmFtZSIsIG5hbWUpLAogICAgICAgIGZpZWxkKCJlbWFpbCIsIGVtYWlsKSwKICAgICAgICBmaWVsZCgiZ2l2ZW5OYW1lIiwgZmlyc3ROYW1lKSwKICAgICAgICBmaWVsZCgiZmFtaWx5TmFtZSIsIGxhc3ROYW1lKSwKICAgICAgICBmaWVsZCgidXNlcm5hbWUiLCB1c2VybmFtZSkpKQ==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=76618ff6-e851-433e-9704-9d2852a17b7a,ou=user,ou=am-config\",\"lastModifiedDate\":1703121249587,\"evaluatorVersion\":\"1.0\"}"
+            "text": "{\"_id\":\"484e6246-dbc6-4288-97e6-54e55431402e\",\"name\":\"Apple Profile Normalization\",\"description\":\"Normalizes raw profile data from Apple\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjEtMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWQKICoKICogVXNlIG9mIHRoaXMgY29kZSByZXF1aXJlcyBhIGNvbW1lcmNpYWwgc29mdHdhcmUgbGljZW5zZSB3aXRoIEZvcmdlUm9jayBBUy4KICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICoKICogSW4gc29tZSBjb21tb24gZGVmYXVsdCBjb25maWd1cmF0aW9ucywgdGhlIGZvbGxvd2luZyBrZXlzIGFyZSByZXF1aXJlZCB0byBiZSBub3QgZW1wdHk6CiAqIHVzZXJuYW1lLCBnaXZlbk5hbWUsIGZhbWlseU5hbWUsIGVtYWlsLgogKgogKiBGcm9tIFJGQzQ1MTc6IEEgdmFsdWUgb2YgdGhlIERpcmVjdG9yeSBTdHJpbmcgc3ludGF4IGlzIGEgc3RyaW5nIG9mIG9uZSBvciBtb3JlCiAqIGFyYml0cmFyeSBjaGFyYWN0ZXJzIGZyb20gdGhlIFVuaXZlcnNhbCBDaGFyYWN0ZXIgU2V0IChVQ1MpLgogKiBBIHplcm8tbGVuZ3RoIGNoYXJhY3RlciBzdHJpbmcgaXMgbm90IHBlcm1pdHRlZC4KICovCgppbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuZmllbGQKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmpzb24KaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdAoKU3RyaW5nIGVtYWlsID0gImNoYW5nZUBtZS5jb20iClN0cmluZyBzdWJqZWN0SWQgPSByYXdQcm9maWxlLnN1YgpTdHJpbmcgZmlyc3ROYW1lID0gIiAiClN0cmluZyBsYXN0TmFtZSA9ICIgIgpTdHJpbmcgdXNlcm5hbWUgPSBzdWJqZWN0SWQKU3RyaW5nIG5hbWUKCmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZCgiZW1haWwiKSAmJiByYXdQcm9maWxlLmVtYWlsLmlzTm90TnVsbCgpKXsgLy8gVXNlciBjYW4gZWxlY3QgdG8gbm90IHNoYXJlIHRoZWlyIGVtYWlsCiAgICBlbWFpbCA9IHJhd1Byb2ZpbGUuZW1haWwuYXNTdHJpbmcoKQogICAgdXNlcm5hbWUgPSBlbWFpbAp9CmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZCgibmFtZSIpICYmIHJhd1Byb2ZpbGUubmFtZS5pc05vdE51bGwoKSkgewogICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoImZpcnN0TmFtZSIpICYmIHJhd1Byb2ZpbGUubmFtZS5maXJzdE5hbWUuaXNOb3ROdWxsKCkpIHsKICAgICAgICBmaXJzdE5hbWUgPSByYXdQcm9maWxlLm5hbWUuZmlyc3ROYW1lLmFzU3RyaW5nKCkKICAgIH0KICAgIGlmIChyYXdQcm9maWxlLm5hbWUuaXNEZWZpbmVkKCJsYXN0TmFtZSIpICYmIHJhd1Byb2ZpbGUubmFtZS5sYXN0TmFtZS5pc05vdE51bGwoKSkgewogICAgICAgIGxhc3ROYW1lID0gcmF3UHJvZmlsZS5uYW1lLmxhc3ROYW1lLmFzU3RyaW5nKCkKICAgIH0KfQoKbmFtZSA9IChmaXJzdE5hbWU/LnRyaW0oKSA/IGZpcnN0TmFtZSA6ICIiKSArIChsYXN0TmFtZT8udHJpbSgpID8gKChmaXJzdE5hbWU/LnRyaW0oKSA/ICIgIiA6ICIiKSArIGxhc3ROYW1lKSA6ICIiKQpuYW1lID0gICghbmFtZT8udHJpbSgpKSA/ICIgIiA6IG5hbWUKCnJldHVybiBqc29uKG9iamVjdCgKICAgICAgICBmaWVsZCgiaWQiLCBzdWJqZWN0SWQpLAogICAgICAgIGZpZWxkKCJkaXNwbGF5TmFtZSIsIG5hbWUpLAogICAgICAgIGZpZWxkKCJlbWFpbCIsIGVtYWlsKSwKICAgICAgICBmaWVsZCgiZ2l2ZW5OYW1lIiwgZmlyc3ROYW1lKSwKICAgICAgICBmaWVsZCgiZmFtaWx5TmFtZSIsIGxhc3ROYW1lKSwKICAgICAgICBmaWVsZCgidXNlcm5hbWUiLCB1c2VybmFtZSkpKQ==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733777864465,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -422,15 +442,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:09 GMT"
+              "value": "Mon, 09 Dec 2024 20:57:44 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-661b718b-7808-4fa3-8279-4b6813d715de"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -441,14 +465,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 747,
+          "headersSize": 767,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-21T01:14:09.538Z",
-        "time": 81,
+        "startedDateTime": "2024-12-09T20:57:44.421Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -456,7 +480,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 65
         }
       },
       {
@@ -477,11 +501,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-661b718b-7808-4fa3-8279-4b6813d715de"
             },
             {
               "name": "accept-api-version",
@@ -493,14 +517,18 @@
             },
             {
               "name": "content-length",
-              "value": 1604
+              "value": "1604"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1663,
+          "headersSize": 2049,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -578,15 +606,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:09 GMT"
+              "value": "Mon, 09 Dec 2024 20:57:44 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-661b718b-7808-4fa3-8279-4b6813d715de"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -597,14 +629,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 925,
+          "headersSize": 945,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/appleConfig/FrodoTestIdp8",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-12-21T01:14:09.636Z",
-        "time": 194,
+        "startedDateTime": "2024-12-09T20:57:44.492Z",
+        "time": 171,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -612,7 +644,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 194
+          "wait": 171
         }
       }
     ],

--- a/src/test/mock-recordings/IdpOps_3439825948/2-Import-all-social-providers-no-deps_2811074177/recording.har
+++ b/src/test/mock-recordings/IdpOps_3439825948/2-Import-all-social-providers-no-deps_2811074177/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "edf84d02001baf38660f2486818d006a",
+        "_id": "aad41c04f2a52a2f2fb4850817fd821a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1585,
+          "bodySize": 1615,
           "cookies": [],
           "headers": [
             {
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-3c652ca1-3644-4b9d-9b3d-dceff417a01c"
             },
             {
               "name": "accept-api-version",
@@ -41,20 +41,24 @@
             },
             {
               "name": "content-length",
-              "value": 1585
+              "value": "1615"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1662,
+          "headersSize": 2048,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp7\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true}}"
+            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp7\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true},\"redirectAfterFormPostURI\":\"\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp7"
@@ -109,6 +113,10 @@
               "value": "0"
             },
             {
+              "name": "location",
+              "value": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp7"
+            },
+            {
               "name": "pragma",
               "value": "no-cache"
             },
@@ -122,15 +130,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:09 GMT"
+              "value": "Mon, 09 Dec 2024 20:58:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-3c652ca1-3644-4b9d-9b3d-dceff417a01c"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -141,14 +153,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 767,
+          "headersSize": 943,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
+          "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp7",
+          "status": 201,
+          "statusText": "Created"
         },
-        "startedDateTime": "2023-12-21T01:14:09.858Z",
-        "time": 85,
+        "startedDateTime": "2024-12-09T20:58:00.873Z",
+        "time": 182,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -156,7 +168,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 85
+          "wait": 182
         }
       },
       {
@@ -177,11 +189,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-3c652ca1-3644-4b9d-9b3d-dceff417a01c"
             },
             {
               "name": "accept-api-version",
@@ -193,14 +205,18 @@
             },
             {
               "name": "content-length",
-              "value": 1604
+              "value": "1604"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1663,
+          "headersSize": 2049,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -261,6 +277,10 @@
               "value": "0"
             },
             {
+              "name": "location",
+              "value": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/appleConfig/FrodoTestIdp8"
+            },
+            {
               "name": "pragma",
               "value": "no-cache"
             },
@@ -274,15 +294,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:09 GMT"
+              "value": "Mon, 09 Dec 2024 20:58:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-3c652ca1-3644-4b9d-9b3d-dceff417a01c"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -293,14 +317,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 768,
+          "headersSize": 945,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
+          "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/appleConfig/FrodoTestIdp8",
+          "status": 201,
+          "statusText": "Created"
         },
-        "startedDateTime": "2023-12-21T01:14:09.957Z",
-        "time": 88,
+        "startedDateTime": "2024-12-09T20:58:01.064Z",
+        "time": 176,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -308,7 +332,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 88
+          "wait": 176
         }
       }
     ],

--- a/src/test/mock-recordings/IdpOps_3439825948/importFirstSocialIdentityProvider_2683774449/1-Import-first-social-provider_2525487989/recording.har
+++ b/src/test/mock-recordings/IdpOps_3439825948/importFirstSocialIdentityProvider_2683774449/1-Import-first-social-provider_2525487989/recording.har
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-5ab0be8f-ba29-4d11-b32e-d3728e880580"
             },
             {
               "name": "accept-api-version",
@@ -41,14 +41,18 @@
             },
             {
               "name": "content-length",
-              "value": 7196
+              "value": "7196"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1636,
+          "headersSize": 2022,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -64,7 +68,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 7289,
-            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogICAgICAvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=76618ff6-e851-433e-9704-9d2852a17b7a,ou=user,ou=am-config\",\"lastModifiedDate\":1703121248899,\"evaluatorVersion\":\"1.0\"}"
+            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogICAgICAvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733777920843,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -118,15 +122,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:08 GMT"
+              "value": "Mon, 09 Dec 2024 20:58:40 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-5ab0be8f-ba29-4d11-b32e-d3728e880580"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -137,14 +145,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 747,
+          "headersSize": 767,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-21T01:14:08.843Z",
-        "time": 83,
+        "startedDateTime": "2024-12-09T20:58:40.796Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -152,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 83
+          "wait": 69
         }
       },
       {
-        "_id": "436febaca469af47dd6e0d239cd6e406",
+        "_id": "62655b03f6f8bd9ad2d1a1527c768513",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1585,
+          "bodySize": 1615,
           "cookies": [],
           "headers": [
             {
@@ -173,11 +181,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-5ab0be8f-ba29-4d11-b32e-d3728e880580"
             },
             {
               "name": "accept-api-version",
@@ -189,20 +197,24 @@
             },
             {
               "name": "content-length",
-              "value": 1585
+              "value": "1615"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1662,
+          "headersSize": 2048,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp5\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true}}"
+            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp5\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true},\"redirectAfterFormPostURI\":\"\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp5"
@@ -274,15 +286,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:09 GMT"
+              "value": "Mon, 09 Dec 2024 20:58:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-5ab0be8f-ba29-4d11-b32e-d3728e880580"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -293,14 +309,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 923,
+          "headersSize": 943,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp5",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-12-21T01:14:08.938Z",
-        "time": 183,
+        "startedDateTime": "2024-12-09T20:58:40.873Z",
+        "time": 172,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -308,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 183
+          "wait": 172
         }
       }
     ],

--- a/src/test/mock-recordings/IdpOps_3439825948/importFirstSocialIdentityProvider_2683774449/2-Import-first-social-provider-no-deps_2236058431/recording.har
+++ b/src/test/mock-recordings/IdpOps_3439825948/importFirstSocialIdentityProvider_2683774449/2-Import-first-social-provider-no-deps_2236058431/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "436febaca469af47dd6e0d239cd6e406",
+        "_id": "62655b03f6f8bd9ad2d1a1527c768513",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1585,
+          "bodySize": 1615,
           "cookies": [],
           "headers": [
             {
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-b6250f87-55d7-4e1f-9566-073b988ab55e"
             },
             {
               "name": "accept-api-version",
@@ -41,20 +41,24 @@
             },
             {
               "name": "content-length",
-              "value": 1585
+              "value": "1615"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1662,
+          "headersSize": 2048,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp5\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true}}"
+            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp5\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true},\"redirectAfterFormPostURI\":\"\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp5"
@@ -109,6 +113,10 @@
               "value": "0"
             },
             {
+              "name": "location",
+              "value": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp5"
+            },
+            {
               "name": "pragma",
               "value": "no-cache"
             },
@@ -122,15 +130,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:09 GMT"
+              "value": "Mon, 09 Dec 2024 20:58:50 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-b6250f87-55d7-4e1f-9566-073b988ab55e"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -141,14 +153,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 767,
+          "headersSize": 943,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
+          "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp5",
+          "status": 201,
+          "statusText": "Created"
         },
-        "startedDateTime": "2023-12-21T01:14:09.148Z",
-        "time": 79,
+        "startedDateTime": "2024-12-09T20:58:50.382Z",
+        "time": 170,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -156,7 +168,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 79
+          "wait": 170
         }
       }
     ],

--- a/src/test/mock-recordings/IdpOps_3439825948/importSocialIdentityProvider_3861667235/1-Import-social-provider-FrodoTestIdp4_3635648402/recording.har
+++ b/src/test/mock-recordings/IdpOps_3439825948/importSocialIdentityProvider_3861667235/1-Import-social-provider-FrodoTestIdp4_3635648402/recording.har
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-1c8fbd6d-9373-407f-897c-c6493e029c28"
             },
             {
               "name": "accept-api-version",
@@ -41,14 +41,18 @@
             },
             {
               "name": "content-length",
-              "value": 7196
+              "value": "7196"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1636,
+          "headersSize": 2022,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -64,7 +68,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 7289,
-            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogICAgICAvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=76618ff6-e851-433e-9704-9d2852a17b7a,ou=user,ou=am-config\",\"lastModifiedDate\":1703121248483,\"evaluatorVersion\":\"1.0\"}"
+            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogICAgICAvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733777900694,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -118,15 +122,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:08 GMT"
+              "value": "Mon, 09 Dec 2024 20:58:20 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-1c8fbd6d-9373-407f-897c-c6493e029c28"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -137,14 +145,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 747,
+          "headersSize": 767,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-21T01:14:08.427Z",
-        "time": 85,
+        "startedDateTime": "2024-12-09T20:58:20.634Z",
+        "time": 82,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -152,15 +160,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 85
+          "wait": 82
         }
       },
       {
-        "_id": "ec73e44ac5f9fd553857a9747dfe75fa",
+        "_id": "536d12e8c96acec04129a2b234dfdc60",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1585,
+          "bodySize": 1615,
           "cookies": [],
           "headers": [
             {
@@ -173,11 +181,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-1c8fbd6d-9373-407f-897c-c6493e029c28"
             },
             {
               "name": "accept-api-version",
@@ -189,20 +197,24 @@
             },
             {
               "name": "content-length",
-              "value": 1585
+              "value": "1615"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1662,
+          "headersSize": 2048,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp4\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true}}"
+            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp4\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true},\"redirectAfterFormPostURI\":\"\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp4"
@@ -274,15 +286,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:08 GMT"
+              "value": "Mon, 09 Dec 2024 20:58:20 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-1c8fbd6d-9373-407f-897c-c6493e029c28"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -293,14 +309,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 923,
+          "headersSize": 943,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp4",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-12-21T01:14:08.517Z",
-        "time": 188,
+        "startedDateTime": "2024-12-09T20:58:20.723Z",
+        "time": 175,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -308,7 +324,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 188
+          "wait": 175
         }
       }
     ],

--- a/src/test/mock-recordings/IdpOps_3439825948/importSocialIdentityProvider_3861667235/2-Import-social-provider-FrodoTestIdp4-no-deps_1263354232/recording.har
+++ b/src/test/mock-recordings/IdpOps_3439825948/importSocialIdentityProvider_3861667235/2-Import-social-provider-FrodoTestIdp4-no-deps_1263354232/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec73e44ac5f9fd553857a9747dfe75fa",
+        "_id": "536d12e8c96acec04129a2b234dfdc60",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1585,
+          "bodySize": 1615,
           "cookies": [],
           "headers": [
             {
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-55"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-f540673f-1f98-4658-9add-c36835388038"
             },
             {
               "name": "accept-api-version",
@@ -41,20 +41,24 @@
             },
             {
               "name": "content-length",
-              "value": 1585
+              "value": "1615"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1662,
+          "headersSize": 2048,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp4\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true}}"
+            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"FrodoTestIdp4\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true},\"redirectAfterFormPostURI\":\"\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp4"
@@ -109,6 +113,10 @@
               "value": "0"
             },
             {
+              "name": "location",
+              "value": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp4"
+            },
+            {
               "name": "pragma",
               "value": "no-cache"
             },
@@ -122,15 +130,19 @@
             },
             {
               "name": "date",
-              "value": "Thu, 21 Dec 2023 01:14:08 GMT"
+              "value": "Mon, 09 Dec 2024 20:58:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-c7fd8ff6-787b-4d74-a2f0-07cfdc3f4eee"
+              "value": "frodo-f540673f-1f98-4658-9add-c36835388038"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -141,14 +153,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 767,
+          "headersSize": 943,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
+          "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp4",
+          "status": 201,
+          "statusText": "Created"
         },
-        "startedDateTime": "2023-12-21T01:14:08.726Z",
-        "time": 76,
+        "startedDateTime": "2024-12-09T20:58:30.436Z",
+        "time": 169,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -156,7 +168,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 76
+          "wait": 169
         }
       }
     ],

--- a/src/test/mock-recordings/IdpOps_3439825948/updateSocialIdentityProvider_2825627011/1-Update-social-provider-FrodoTestIdp3_1534422775/recording.har
+++ b/src/test/mock-recordings/IdpOps_3439825948/updateSocialIdentityProvider_2825627011/1-Update-social-provider-FrodoTestIdp3_1534422775/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "4ce708137768fde03bcf66cd8ba4e418",
+        "_id": "98bbf027b071d7b32a60d8ea799b7e8d",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1246,
+          "bodySize": 1276,
           "cookies": [],
           "headers": [
             {
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.0.0-32"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-3d260758-3de5-4ae7-a31b-f2162d9818f5"
+              "value": "frodo-840a0555-5a43-4136-a30e-2fb7e9479010"
             },
             {
               "name": "accept-api-version",
@@ -41,20 +41,24 @@
             },
             {
               "name": "content-length",
-              "value": 1246
+              "value": "1276"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
             },
             {
               "name": "host",
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1662,
+          "headersSize": 2048,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"clientId\":\"0oa13r2cp29Rynmyw697\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://trial-1234567.okta.com/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://trial-1234567.okta.com/oauth2/v1/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://trial-1234567.okta.com\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"id\",\"uiConfig\":{\"buttonDisplayName\":\"Okta\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"6325cf19-a49b-471e-8d26-7e4df76df0e2\",\"userInfoEndpoint\":\"https://trial-1234567.okta.com/oauth2/v1/userinfo\",\"jwtSigningAlgorithm\":\"NONE\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://trial-1234567.okta.com/oauth2/v1/token\",\"_id\":\"FrodoTestIdp3\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true}}"
+            "text": "{\"clientId\":\"0oa13r2cp29Rynmyw697\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://trial-1234567.okta.com/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://trial-1234567.okta.com/oauth2/v1/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://trial-1234567.okta.com\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"id\",\"uiConfig\":{\"buttonDisplayName\":\"Okta\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"6325cf19-a49b-471e-8d26-7e4df76df0e2\",\"userInfoEndpoint\":\"https://trial-1234567.okta.com/oauth2/v1/userinfo\",\"jwtSigningAlgorithm\":\"NONE\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://trial-1234567.okta.com/oauth2/v1/token\",\"_id\":\"FrodoTestIdp3\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true},\"redirectAfterFormPostURI\":\"\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp3"
@@ -126,15 +130,19 @@
             },
             {
               "name": "date",
-              "value": "Sat, 30 Sep 2023 04:03:33 GMT"
+              "value": "Mon, 09 Dec 2024 20:58:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-3d260758-3de5-4ae7-a31b-f2162d9818f5"
+              "value": "frodo-840a0555-5a43-4136-a30e-2fb7e9479010"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
             },
             {
               "name": "via",
@@ -145,14 +153,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 923,
+          "headersSize": 943,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/FrodoTestIdp3",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2023-09-30T04:03:34.307Z",
-        "time": 188,
+        "startedDateTime": "2024-12-09T20:58:10.775Z",
+        "time": 174,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -160,7 +168,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 188
+          "wait": 174
         }
       }
     ],

--- a/src/test/mock-recordings/JourneyOps_2291468013/importJourney_541402267/2-Import-journey-FrodoTestJourney5-w_1119246922/dependencies_1379947466/recording.har
+++ b/src/test/mock-recordings/JourneyOps_2291468013/importJourney_541402267/2-Import-journey-FrodoTestJourney5-w_1119246922/dependencies_1379947466/recording.har
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
@@ -52,7 +52,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1980,
+          "headersSize": 2022,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -68,7 +68,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 1100,
-            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"name\":\"Check Username\",\"description\":\"Check if username has already been collected.\",\"script\":\"Ii8qIENoZWNrIFVzZXJuYW1lXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBDaGVjayBpZiB1c2VybmFtZSBoYXMgYWxyZWFkeSBiZWVuIGNvbGxlY3RlZC5cbiAqIFJldHVybiBcImtub3duXCIgaWYgeWVzLCBcInVua25vd25cIiBvdGhlcndpc2UuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0ga25vd25cbiAqIC0gdW5rbm93blxuICovXG4oZnVuY3Rpb24gKCkge1xuICAgIGlmIChudWxsICE9IHNoYXJlZFN0YXRlLmdldChcInVzZXJuYW1lXCIpKSB7XG4gICAgICAgIG91dGNvbWUgPSBcImtub3duXCI7XG4gICAgfVxuICAgIGVsc2Uge1xuICAgICAgICBvdXRjb21lID0gXCJ1bmtub3duXCI7XG4gICAgfVxufSgpKTsi\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1725915625427,\"evaluatorVersion\":\"1.0\"}"
+            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"name\":\"Check Username\",\"description\":\"Check if username has already been collected.\",\"script\":\"Ii8qIENoZWNrIFVzZXJuYW1lXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBDaGVjayBpZiB1c2VybmFtZSBoYXMgYWxyZWFkeSBiZWVuIGNvbGxlY3RlZC5cbiAqIFJldHVybiBcImtub3duXCIgaWYgeWVzLCBcInVua25vd25cIiBvdGhlcndpc2UuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0ga25vd25cbiAqIC0gdW5rbm93blxuICovXG4oZnVuY3Rpb24gKCkge1xuICAgIGlmIChudWxsICE9IHNoYXJlZFN0YXRlLmdldChcInVzZXJuYW1lXCIpKSB7XG4gICAgICAgIG91dGNvbWUgPSBcImtub3duXCI7XG4gICAgfVxuICAgIGVsc2Uge1xuICAgICAgICBvdXRjb21lID0gXCJ1bmtub3duXCI7XG4gICAgfVxufSgpKTsi\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733777590769,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -122,11 +122,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -151,8 +151,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.369Z",
-        "time": 90,
+        "startedDateTime": "2024-12-09T20:53:10.725Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -160,7 +160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 90
+          "wait": 64
         }
       },
       {
@@ -181,11 +181,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
@@ -208,7 +208,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1979,
+          "headersSize": 2021,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -224,7 +224,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 3162,
-            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"name\":\"Normalized Profile to Managed User\",\"description\":\"Converts a normalized social profile into a managed user\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5pbXBvcnQgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuXG5Kc29uVmFsdWUgbWFuYWdlZFVzZXIgPSBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcbiAgICAgICAgZmllbGQoXCJzblwiLCBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJtYWlsXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VyTmFtZVwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxuXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQWRkcmVzcy5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwicG9zdGFsQWRkcmVzc1wiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwiY2l0eVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwic3RhdGVQcm92aW5jZVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzUmVnaW9uKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbENvZGUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInBvc3RhbENvZGVcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcbmlmIChub3JtYWxpemVkUHJvZmlsZS5jb3VudHJ5LmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXCJjb3VudHJ5XCIsIG5vcm1hbGl6ZWRQcm9maWxlLmNvdW50cnkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInRlbGVwaG9uZU51bWJlclwiLCBub3JtYWxpemVkUHJvZmlsZS5waG9uZSlcblxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XG4vLyB0aGVuIGFkZCBhIGJvb2xlYW4gZmxhZyB0byB0aGUgc2hhcmVkIHN0YXRlIHRvIGluZGljYXRlIG5hbWVzIGFyZSBub3QgcHJlc2VudFxuLy8gdGhpcyBjb3VsZCBiZSB1c2VkIGVsc2V3aGVyZVxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcbi8vIHRoZSB1c2VyIG9iamVjdCB3aXRoIGJsYW5rIHZhbHVlcyB3aGVuIGdpdmVuTmFtZSAgYW5kIGZhbWlseU5hbWUgaXMgbm90IHByZXNlbnRcbmJvb2xlYW4gbm9HaXZlbk5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuaXNOdWxsKCkgfHwgKCFub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuYXNTdHJpbmcoKT8udHJpbSgpKVxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXG5zaGFyZWRTdGF0ZS5wdXQoXCJuYW1lRW1wdHlPck51bGxcIiwgbm9HaXZlbk5hbWUgJiYgbm9GYW1pbHlOYW1lKVxuXG5yZXR1cm4gbWFuYWdlZFVzZXJcbiI=\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1725915625513,\"evaluatorVersion\":\"1.0\"}"
+            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"name\":\"Normalized Profile to Managed User\",\"description\":\"Converts a normalized social profile into a managed user\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5pbXBvcnQgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuXG5Kc29uVmFsdWUgbWFuYWdlZFVzZXIgPSBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcbiAgICAgICAgZmllbGQoXCJzblwiLCBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJtYWlsXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VyTmFtZVwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxuXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQWRkcmVzcy5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwicG9zdGFsQWRkcmVzc1wiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwiY2l0eVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwic3RhdGVQcm92aW5jZVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzUmVnaW9uKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbENvZGUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInBvc3RhbENvZGVcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcbmlmIChub3JtYWxpemVkUHJvZmlsZS5jb3VudHJ5LmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXCJjb3VudHJ5XCIsIG5vcm1hbGl6ZWRQcm9maWxlLmNvdW50cnkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInRlbGVwaG9uZU51bWJlclwiLCBub3JtYWxpemVkUHJvZmlsZS5waG9uZSlcblxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XG4vLyB0aGVuIGFkZCBhIGJvb2xlYW4gZmxhZyB0byB0aGUgc2hhcmVkIHN0YXRlIHRvIGluZGljYXRlIG5hbWVzIGFyZSBub3QgcHJlc2VudFxuLy8gdGhpcyBjb3VsZCBiZSB1c2VkIGVsc2V3aGVyZVxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcbi8vIHRoZSB1c2VyIG9iamVjdCB3aXRoIGJsYW5rIHZhbHVlcyB3aGVuIGdpdmVuTmFtZSAgYW5kIGZhbWlseU5hbWUgaXMgbm90IHByZXNlbnRcbmJvb2xlYW4gbm9HaXZlbk5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuaXNOdWxsKCkgfHwgKCFub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuYXNTdHJpbmcoKT8udHJpbSgpKVxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXG5zaGFyZWRTdGF0ZS5wdXQoXCJuYW1lRW1wdHlPck51bGxcIiwgbm9HaXZlbk5hbWUgJiYgbm9GYW1pbHlOYW1lKVxuXG5yZXR1cm4gbWFuYWdlZFVzZXJcbiI=\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733777590844,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -278,11 +278,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -307,8 +307,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.464Z",
-        "time": 84,
+        "startedDateTime": "2024-12-09T20:53:10.797Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -316,7 +316,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 69
         }
       },
       {
@@ -337,11 +337,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
@@ -364,7 +364,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1980,
+          "headersSize": 2022,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -380,7 +380,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 1553,
-            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"name\":\"GitHub Profile Normalization (VS)\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIkdpdEh1YiByYXdQcm9maWxlOiBcIityYXdQcm9maWxlKVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5pZCksXG4gICAgICAgIGZpZWxkKFwiZGlzcGxheU5hbWVcIiwgcmF3UHJvZmlsZS5uYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5maXJzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJmYW1pbHlOYW1lXCIsIHJhd1Byb2ZpbGUubGFzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUuZGF0YS51cmwpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpKSki\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1725915625618,\"evaluatorVersion\":\"1.0\"}"
+            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"name\":\"GitHub Profile Normalization (VS)\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIkdpdEh1YiByYXdQcm9maWxlOiBcIityYXdQcm9maWxlKVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5pZCksXG4gICAgICAgIGZpZWxkKFwiZGlzcGxheU5hbWVcIiwgcmF3UHJvZmlsZS5uYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5maXJzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJmYW1pbHlOYW1lXCIsIHJhd1Byb2ZpbGUubGFzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUuZGF0YS51cmwpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpKSki\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733777590918,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -434,11 +434,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -463,8 +463,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.555Z",
-        "time": 94,
+        "startedDateTime": "2024-12-09T20:53:10.871Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -472,7 +472,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 94
+          "wait": 69
         }
       },
       {
@@ -493,11 +493,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
@@ -520,7 +520,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1980,
+          "headersSize": 2022,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -536,7 +536,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 7449,
-            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqL1xuXG4vKlxuICogVGhpcyBzY3JpcHQgcmV0dXJucyB0aGUgc29jaWFsIGlkZW50aXR5IHByb2ZpbGUgaW5mb3JtYXRpb24gZm9yIHRoZSBhdXRoZW50aWNhdGluZyB1c2VyXG4gKiBpbiBhIHN0YW5kYXJkIGZvcm0gZXhwZWN0ZWQgYnkgdGhlIFNvY2lhbCBQcm92aWRlciBIYW5kbGVyIE5vZGUuXG4gKlxuICogRGVmaW5lZCB2YXJpYWJsZXM6XG4gKiByYXdQcm9maWxlIC0gVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBwcm9maWxlIGluZm9ybWF0aW9uIGZvciB0aGUgYXV0aGVudGljYXRpbmcgdXNlci5cbiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLlxuICogbG9nZ2VyIC0gVGhlIGRlYnVnIGxvZ2dlciBpbnN0YW5jZTpcbiAqICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L3NjcmlwdGluZy1ndWlkZS9zY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuaHRtbCNzY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuXG4gKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS5cbiAqICAgICAgICAgVGhlIG5hbWUgb2YgdGhlIHJlYWxtIHRoZSB1c2VyIGlzIGF1dGhlbnRpY2F0aW5nIHRvLlxuICogcmVxdWVzdEhlYWRlcnMgLSBUcmVlTWFwICgyKS5cbiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OlxuICogICAgICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoZW50aWNhdGlvbi1ndWlkZS9zY3JpcHRpbmctYXBpLW5vZGUuaHRtbCNzY3JpcHRpbmctYXBpLW5vZGUtcmVxdWVzdEhlYWRlcnMuXG4gKiByZXF1ZXN0UGFyYW1ldGVycyAtIFRyZWVNYXAgKDIpLlxuICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy5cbiAqIHNlbGVjdGVkSWRwIC0gU3RyaW5nIChwcmltaXRpdmUpLlxuICogICAgICAgICAgICAgICBUaGUgc29jaWFsIGlkZW50aXR5IHByb3ZpZGVyIG5hbWUuIEZvciBleGFtcGxlOiBnb29nbGUuXG4gKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLlxuICogICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgaG9sZHMgdGhlIHN0YXRlIG9mIHRoZSBhdXRoZW50aWNhdGlvbiB0cmVlIGFuZCBhbGxvd3MgZGF0YSBleGNoYW5nZSBiZXR3ZWVuIHRoZSBzdGF0ZWxlc3Mgbm9kZXM6XG4gKiAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuXG4gKiAgICAgICAgICAgICAgICAgIFRoZSBvYmplY3QgZm9yIHN0b3Jpbmcgc2Vuc2l0aXZlIGluZm9ybWF0aW9uIHRoYXQgbXVzdCBub3QgbGVhdmUgdGhlIHNlcnZlciB1bmVuY3J5cHRlZCxcbiAqICAgICAgICAgICAgICAgICAgYW5kIHRoYXQgbWF5IG5vdCBuZWVkIHRvIHBlcnNpc3QgYmV0d2VlbiBhdXRoZW50aWNhdGlvbiByZXF1ZXN0cyBkdXJpbmcgdGhlIGF1dGhlbnRpY2F0aW9uIHNlc3Npb246XG4gKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqXG4gKiBSZXR1cm4gLSBhIEpzb25WYWx1ZSAoMSkuXG4gKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuXG4gKiAgICAgICAgICBDdXJyZW50bHksIHRoZSBJbW1lZGlhdGVseSBJbnZva2VkIEZ1bmN0aW9uIEV4cHJlc3Npb24gKGFsc28ga25vd24gYXMgU2VsZi1FeGVjdXRpbmcgQW5vbnltb3VzIEZ1bmN0aW9uKVxuICogICAgICAgICAgaXMgdGhlIGxhc3QgKGFuZCBvbmx5KSBzdGF0ZW1lbnQgaW4gdGhpcyBzY3JpcHQsIGFuZCBpdHMgcmV0dXJuIHZhbHVlIHdpbGwgYmVjb21lIHRoZSBzY3JpcHQgcmVzdWx0LlxuICogICAgICAgICAgRG8gbm90IHVzZSBcInJldHVybiB2YXJpYWJsZVwiIHN0YXRlbWVudCBvdXRzaWRlIG9mIGEgZnVuY3Rpb24gZGVmaW5pdGlvbi5cbiAqXG4gKiAgICAgICAgICBUaGlzIHNjcmlwdCdzIGxhc3Qgc3RhdGVtZW50IHNob3VsZCByZXN1bHQgaW4gYSBKc29uVmFsdWUgKDEpIHdpdGggdGhlIGZvbGxvd2luZyBrZXlzOlxuICogICAgICAgICAge1xuICogICAgICAgICAgICAgIHtcImRpc3BsYXlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZW1haWxcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJmYW1pbHlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZ2l2ZW5OYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiaWRcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJsb2NhbGVcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJwaG90b1VybFwiOiBcImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlXCJ9LFxuICogICAgICAgICAgICAgIHtcInVzZXJuYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn1cbiAqICAgICAgICAgIH1cbiAqXG4gKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC5cbiAqICAgICAgICAgIEZvciBleGFtcGxlLCB0aGUgc2NyaXB0IGFzc29jaWF0ZWQgd2l0aCB0aGUgU29jaWFsIFByb3ZpZGVyIEhhbmRsZXIgTm9kZSBhbmQsXG4gKiAgICAgICAgICB1bHRpbWF0ZWx5LCB0aGUgbWFuYWdlZCBvYmplY3QgY3JlYXRlZC91cGRhdGVkIHdpdGggdGhpcyBkYXRhXG4gKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLlxuICogICAgICAgICAgSW4gc29tZSBjb21tb24gZGVmYXVsdCBjb25maWd1cmF0aW9ucywgdGhlIGZvbGxvd2luZyBrZXlzIGFyZSByZXF1aXJlZCB0byBiZSBub3QgZW1wdHk6XG4gKiAgICAgICAgICB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cbiAqXG4gKiAgICAgICAgICBGcm9tIFJGQzQ1MTc6IEEgdmFsdWUgb2YgdGhlIERpcmVjdG9yeSBTdHJpbmcgc3ludGF4IGlzIGEgc3RyaW5nIG9mIG9uZSBvciBtb3JlXG4gKiAgICAgICAgICBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cbiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLlxuICpcbiAqICgxKSBKc29uVmFsdWUgLSBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hcGlkb2NzL29yZy9mb3JnZXJvY2svanNvbi9Kc29uVmFsdWUuaHRtbC5cbiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuXG4gKiAoMykgTGlua2VkSGFzaE1hcCAtIGh0dHBzOi8vZG9jcy5vcmFjbGUuY29tL2VuL2phdmEvamF2YXNlLzExL2RvY3MvYXBpL2phdmEuYmFzZS9qYXZhL3V0aWwvTGlua2VkSGFzaE1hcC5odG1sLlxuICovXG5cbihmdW5jdGlvbiAoKSB7XG4gICAgdmFyIGZySmF2YSA9IEphdmFJbXBvcnRlcihcbiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuICAgICk7XG5cbiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpO1xuICBcbiAgXHQvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTtcblxuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2lkJywgcmF3UHJvZmlsZS5nZXQoJ3N1YicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdlbWFpbCcsIHJhd1Byb2ZpbGUuZ2V0KCdtYWlsJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZ2l2ZW5OYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCd1c2VybmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCd1cG4nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdyb2xlcycsIHJhd1Byb2ZpbGUuZ2V0KCdyb2xlcycpLmFzU3RyaW5nKCkpO1xuICBcbiAgXHQvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gbm9ybWFsaXplZFByb2ZpbGVEYXRhOiAnK25vcm1hbGl6ZWRQcm9maWxlRGF0YSk7XG5cbiAgICByZXR1cm4gbm9ybWFsaXplZFByb2ZpbGVEYXRhO1xufSgpKTsi\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1725915625705,\"evaluatorVersion\":\"1.0\"}"
+            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqL1xuXG4vKlxuICogVGhpcyBzY3JpcHQgcmV0dXJucyB0aGUgc29jaWFsIGlkZW50aXR5IHByb2ZpbGUgaW5mb3JtYXRpb24gZm9yIHRoZSBhdXRoZW50aWNhdGluZyB1c2VyXG4gKiBpbiBhIHN0YW5kYXJkIGZvcm0gZXhwZWN0ZWQgYnkgdGhlIFNvY2lhbCBQcm92aWRlciBIYW5kbGVyIE5vZGUuXG4gKlxuICogRGVmaW5lZCB2YXJpYWJsZXM6XG4gKiByYXdQcm9maWxlIC0gVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBwcm9maWxlIGluZm9ybWF0aW9uIGZvciB0aGUgYXV0aGVudGljYXRpbmcgdXNlci5cbiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLlxuICogbG9nZ2VyIC0gVGhlIGRlYnVnIGxvZ2dlciBpbnN0YW5jZTpcbiAqICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L3NjcmlwdGluZy1ndWlkZS9zY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuaHRtbCNzY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuXG4gKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS5cbiAqICAgICAgICAgVGhlIG5hbWUgb2YgdGhlIHJlYWxtIHRoZSB1c2VyIGlzIGF1dGhlbnRpY2F0aW5nIHRvLlxuICogcmVxdWVzdEhlYWRlcnMgLSBUcmVlTWFwICgyKS5cbiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OlxuICogICAgICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoZW50aWNhdGlvbi1ndWlkZS9zY3JpcHRpbmctYXBpLW5vZGUuaHRtbCNzY3JpcHRpbmctYXBpLW5vZGUtcmVxdWVzdEhlYWRlcnMuXG4gKiByZXF1ZXN0UGFyYW1ldGVycyAtIFRyZWVNYXAgKDIpLlxuICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy5cbiAqIHNlbGVjdGVkSWRwIC0gU3RyaW5nIChwcmltaXRpdmUpLlxuICogICAgICAgICAgICAgICBUaGUgc29jaWFsIGlkZW50aXR5IHByb3ZpZGVyIG5hbWUuIEZvciBleGFtcGxlOiBnb29nbGUuXG4gKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLlxuICogICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgaG9sZHMgdGhlIHN0YXRlIG9mIHRoZSBhdXRoZW50aWNhdGlvbiB0cmVlIGFuZCBhbGxvd3MgZGF0YSBleGNoYW5nZSBiZXR3ZWVuIHRoZSBzdGF0ZWxlc3Mgbm9kZXM6XG4gKiAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuXG4gKiAgICAgICAgICAgICAgICAgIFRoZSBvYmplY3QgZm9yIHN0b3Jpbmcgc2Vuc2l0aXZlIGluZm9ybWF0aW9uIHRoYXQgbXVzdCBub3QgbGVhdmUgdGhlIHNlcnZlciB1bmVuY3J5cHRlZCxcbiAqICAgICAgICAgICAgICAgICAgYW5kIHRoYXQgbWF5IG5vdCBuZWVkIHRvIHBlcnNpc3QgYmV0d2VlbiBhdXRoZW50aWNhdGlvbiByZXF1ZXN0cyBkdXJpbmcgdGhlIGF1dGhlbnRpY2F0aW9uIHNlc3Npb246XG4gKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqXG4gKiBSZXR1cm4gLSBhIEpzb25WYWx1ZSAoMSkuXG4gKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuXG4gKiAgICAgICAgICBDdXJyZW50bHksIHRoZSBJbW1lZGlhdGVseSBJbnZva2VkIEZ1bmN0aW9uIEV4cHJlc3Npb24gKGFsc28ga25vd24gYXMgU2VsZi1FeGVjdXRpbmcgQW5vbnltb3VzIEZ1bmN0aW9uKVxuICogICAgICAgICAgaXMgdGhlIGxhc3QgKGFuZCBvbmx5KSBzdGF0ZW1lbnQgaW4gdGhpcyBzY3JpcHQsIGFuZCBpdHMgcmV0dXJuIHZhbHVlIHdpbGwgYmVjb21lIHRoZSBzY3JpcHQgcmVzdWx0LlxuICogICAgICAgICAgRG8gbm90IHVzZSBcInJldHVybiB2YXJpYWJsZVwiIHN0YXRlbWVudCBvdXRzaWRlIG9mIGEgZnVuY3Rpb24gZGVmaW5pdGlvbi5cbiAqXG4gKiAgICAgICAgICBUaGlzIHNjcmlwdCdzIGxhc3Qgc3RhdGVtZW50IHNob3VsZCByZXN1bHQgaW4gYSBKc29uVmFsdWUgKDEpIHdpdGggdGhlIGZvbGxvd2luZyBrZXlzOlxuICogICAgICAgICAge1xuICogICAgICAgICAgICAgIHtcImRpc3BsYXlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZW1haWxcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJmYW1pbHlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZ2l2ZW5OYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiaWRcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJsb2NhbGVcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJwaG90b1VybFwiOiBcImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlXCJ9LFxuICogICAgICAgICAgICAgIHtcInVzZXJuYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn1cbiAqICAgICAgICAgIH1cbiAqXG4gKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC5cbiAqICAgICAgICAgIEZvciBleGFtcGxlLCB0aGUgc2NyaXB0IGFzc29jaWF0ZWQgd2l0aCB0aGUgU29jaWFsIFByb3ZpZGVyIEhhbmRsZXIgTm9kZSBhbmQsXG4gKiAgICAgICAgICB1bHRpbWF0ZWx5LCB0aGUgbWFuYWdlZCBvYmplY3QgY3JlYXRlZC91cGRhdGVkIHdpdGggdGhpcyBkYXRhXG4gKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLlxuICogICAgICAgICAgSW4gc29tZSBjb21tb24gZGVmYXVsdCBjb25maWd1cmF0aW9ucywgdGhlIGZvbGxvd2luZyBrZXlzIGFyZSByZXF1aXJlZCB0byBiZSBub3QgZW1wdHk6XG4gKiAgICAgICAgICB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cbiAqXG4gKiAgICAgICAgICBGcm9tIFJGQzQ1MTc6IEEgdmFsdWUgb2YgdGhlIERpcmVjdG9yeSBTdHJpbmcgc3ludGF4IGlzIGEgc3RyaW5nIG9mIG9uZSBvciBtb3JlXG4gKiAgICAgICAgICBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cbiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLlxuICpcbiAqICgxKSBKc29uVmFsdWUgLSBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hcGlkb2NzL29yZy9mb3JnZXJvY2svanNvbi9Kc29uVmFsdWUuaHRtbC5cbiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuXG4gKiAoMykgTGlua2VkSGFzaE1hcCAtIGh0dHBzOi8vZG9jcy5vcmFjbGUuY29tL2VuL2phdmEvamF2YXNlLzExL2RvY3MvYXBpL2phdmEuYmFzZS9qYXZhL3V0aWwvTGlua2VkSGFzaE1hcC5odG1sLlxuICovXG5cbihmdW5jdGlvbiAoKSB7XG4gICAgdmFyIGZySmF2YSA9IEphdmFJbXBvcnRlcihcbiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuICAgICk7XG5cbiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpO1xuICBcbiAgXHQvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTtcblxuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2lkJywgcmF3UHJvZmlsZS5nZXQoJ3N1YicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdlbWFpbCcsIHJhd1Byb2ZpbGUuZ2V0KCdtYWlsJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZ2l2ZW5OYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCd1c2VybmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCd1cG4nKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdyb2xlcycsIHJhd1Byb2ZpbGUuZ2V0KCdyb2xlcycpLmFzU3RyaW5nKCkpO1xuICBcbiAgXHQvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gbm9ybWFsaXplZFByb2ZpbGVEYXRhOiAnK25vcm1hbGl6ZWRQcm9maWxlRGF0YSk7XG5cbiAgICByZXR1cm4gbm9ybWFsaXplZFByb2ZpbGVEYXRhO1xufSgpKTsi\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733777590993,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -590,11 +590,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -619,8 +619,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.660Z",
-        "time": 76,
+        "startedDateTime": "2024-12-09T20:53:10.947Z",
+        "time": 67,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -628,7 +628,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 76
+          "wait": 67
         }
       },
       {
@@ -649,11 +649,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "authorization",
@@ -672,7 +672,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1891,
+          "headersSize": 1933,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -698,7 +698,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:11 GMT"
             },
             {
               "name": "cache-control",
@@ -742,7 +742,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -767,8 +767,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.743Z",
-        "time": 61,
+        "startedDateTime": "2024-12-09T20:53:11.019Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -776,15 +776,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 61
+          "wait": 73
         }
       },
       {
-        "_id": "5cf1fd4aac405e33eb63ec176a771fb5",
+        "_id": "b6f5950c32a37357d404097bb8f4318a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1202,
+          "bodySize": 1232,
           "cookies": [],
           "headers": [
             {
@@ -797,11 +797,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
@@ -813,7 +813,7 @@
             },
             {
               "name": "content-length",
-              "value": "1202"
+              "value": "1232"
             },
             {
               "name": "accept-encoding",
@@ -824,13 +824,13 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2001,
+          "headersSize": 2043,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"clientId\":\"bdae6d141d4dcf95a630\",\"pkceMethod\":\"S256\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://github.com/login/oauth/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"clientSecret\":null,\"scopeDelimiter\":\" \",\"scopes\":[\"user\"],\"enabled\":true,\"authenticationIdKey\":\"id\",\"uiConfig\":{\"buttonCustomStyle\":\"background-color: #fff; color: #757575; border-color: #ddd;\",\"buttonCustomStyleHover\":\"color: #6d6d6d; background-color: #eee; border-color: #ccc;\",\"buttonDisplayName\":\"GitHub\",\"buttonImage\":\"https://cdn-icons-png.flaticon.com/512/25/25231.png\",\"iconBackground\":\"#4184f3\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"transform\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"userInfoEndpoint\":\"https://ig.mytestrun.com/user\",\"jwtSigningAlgorithm\":\"NONE\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://ig.mytestrun.com/login/oauth/access_token\",\"_id\":\"github\",\"_type\":{\"_id\":\"oauth2Config\",\"name\":\"Client configuration for providers that implement the OAuth2 specification.\",\"collection\":true}}"
+            "text": "{\"clientId\":\"bdae6d141d4dcf95a630\",\"pkceMethod\":\"S256\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://github.com/login/oauth/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"clientSecret\":null,\"scopeDelimiter\":\" \",\"scopes\":[\"user\"],\"enabled\":true,\"authenticationIdKey\":\"id\",\"uiConfig\":{\"buttonCustomStyle\":\"background-color: #fff; color: #757575; border-color: #ddd;\",\"buttonCustomStyleHover\":\"color: #6d6d6d; background-color: #eee; border-color: #ccc;\",\"buttonDisplayName\":\"GitHub\",\"buttonImage\":\"https://cdn-icons-png.flaticon.com/512/25/25231.png\",\"iconBackground\":\"#4184f3\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"transform\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"userInfoEndpoint\":\"https://ig.mytestrun.com/user\",\"jwtSigningAlgorithm\":\"NONE\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://ig.mytestrun.com/login/oauth/access_token\",\"_id\":\"github\",\"_type\":{\"_id\":\"oauth2Config\",\"name\":\"Client configuration for providers that implement the OAuth2 specification.\",\"collection\":true},\"redirectAfterFormPostURI\":\"\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oauth2Config/github"
@@ -898,11 +898,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -927,8 +927,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.809Z",
-        "time": 75,
+        "startedDateTime": "2024-12-09T20:53:11.098Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -936,15 +936,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 75
+          "wait": 70
         }
       },
       {
-        "_id": "52f89e5f469478b099bb03469118d2b3",
+        "_id": "eb186ed3c0e5ac3d76933fb736b691ee",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1596,
+          "bodySize": 1626,
           "cookies": [],
           "headers": [
             {
@@ -957,11 +957,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
@@ -973,7 +973,7 @@
             },
             {
               "name": "content-length",
-              "value": "1596"
+              "value": "1626"
             },
             {
               "name": "accept-encoding",
@@ -984,13 +984,13 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1997,
+          "headersSize": 2039,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"clientSecret\":null,\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"adfs\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true}}"
+            "text": "{\"clientId\":\"aa9a179e-cdba-4db8-8477-3d1069d5ec04\",\"pkceMethod\":\"S256\",\"wellKnownEndpoint\":\"https://adfs.mytestrun.com/adfs/.well-known/openid-configuration\",\"jwtEncryptionMethod\":\"NONE\",\"authorizationEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/authorize\",\"jwtEncryptionAlgorithm\":\"NONE\",\"issuerComparisonCheckType\":\"EXACT\",\"clientSecret\":null,\"encryptJwtRequestParameter\":false,\"scopeDelimiter\":\" \",\"scopes\":[\"openid\",\"profile\",\"email\"],\"issuer\":\"https://adfs.mytestrun.com/adfs\",\"userInfoResponseType\":\"JSON\",\"acrValues\":[],\"jwksUriEndpoint\":\"https://adfs.mytestrun.com/adfs/discovery/keys\",\"encryptedIdTokens\":false,\"enabled\":true,\"jwtRequestParameterOption\":\"NONE\",\"authenticationIdKey\":\"sub\",\"uiConfig\":{\"buttonClass\":\"\",\"buttonCustomStyle\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonCustomStyleHover\":\"background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;\",\"buttonDisplayName\":\"Microsoft ADFS\",\"buttonImage\":\"/login/images/microsoft-logo.png\",\"iconBackground\":\"#0078d7\",\"iconClass\":\"fa-windows\",\"iconFontColor\":\"white\"},\"privateKeyJwtExpTime\":600,\"revocationCheckOptions\":[],\"enableNativeNonce\":true,\"transform\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"jwtSigningAlgorithm\":\"RS256\",\"redirectURI\":\"https://idc.scheuber.io/login\",\"clientAuthenticationMethod\":\"CLIENT_SECRET_POST\",\"responseMode\":\"DEFAULT\",\"useCustomTrustStore\":false,\"tokenEndpoint\":\"https://adfs.mytestrun.com/adfs/oauth2/token\",\"_id\":\"adfs\",\"_type\":{\"_id\":\"oidcConfig\",\"name\":\"Client configuration for providers that implement the OpenID Connect specification.\",\"collection\":true},\"redirectAfterFormPostURI\":\"\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/services/SocialIdentityProviders/oidcConfig/adfs"
@@ -1058,11 +1058,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -1087,8 +1087,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.891Z",
-        "time": 80,
+        "startedDateTime": "2024-12-09T20:53:11.175Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1096,7 +1096,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 80
+          "wait": 68
         }
       },
       {
@@ -1117,11 +1117,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
@@ -1140,7 +1140,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1993,
+          "headersSize": 2035,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1214,11 +1214,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:25 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -1243,8 +1243,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:25.980Z",
-        "time": 59,
+        "startedDateTime": "2024-12-09T20:53:11.253Z",
+        "time": 62,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1252,7 +1252,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 59
+          "wait": 62
         }
       },
       {
@@ -1273,11 +1273,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
@@ -1300,7 +1300,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1973,
+          "headersSize": 2015,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -1312,11 +1312,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/saml2/hosted/aVNQQXp1cmU"
         },
         "response": {
-          "bodySize": 3964,
+          "bodySize": 3991,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 3964,
-            "text": "{\"_id\":\"aVNQQXp1cmU\",\"_rev\":\"1379466460\",\"entityId\":\"iSPAzure\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName\"]},\"authenticationContext\":{\"authenticationContextMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAuthnContextMapper\",\"authContextItems\":[{\"contextReference\":\"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport\",\"level\":0,\"defaultItem\":true}],\"authenticationComparisonType\":\"Exact\",\"includeRequestedAuthenticationContext\":true},\"assertionTimeSkew\":300,\"basicAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAttributeMapper\",\"attributeMap\":[{\"key\":\"http://schemas.microsoft.com/identity/claims/displayname\",\"value\":\"cn\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\",\"value\":\"givenName\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\",\"value\":\"sn\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\",\"value\":\"mail\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\",\"value\":\"uid\"}]},\"autoFederation\":{\"autoFedEnabled\":false},\"accountMapping\":{\"spAccountMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAccountMapper\",\"useNameIDAsSPUserID\":true},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"},\"url\":{},\"adapter\":{}},\"services\":{\"metaAlias\":\"/alpha/iSPAzure\",\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\",\"location\":\"https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\",\"location\":\"https://idc.scheuber.io/am/SPSloSoap/metaAlias/alpha/iSPAzure\"}],\"nameIdService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\",\"location\":\"https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\",\"location\":\"https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact\",\"location\":\"https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://idc.scheuber.io/am/Consumer/ECP/metaAlias/alpha/iSPAzure\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{\"spUrl\":\"https://idc.scheuber.io/am/spsaehandler/metaAlias/alpha/iSPAzure\"},\"ecpConfiguration\":{\"ecpRequestIdpListFinderImpl\":\"com.sun.identity.saml2.plugins.ECPIDPFinder\"},\"idpProxy\":{},\"relayStateUrlList\":{}}}}"
+            "size": 3991,
+            "text": "{\"_id\":\"aVNQQXp1cmU\",\"_rev\":\"-1533212691\",\"entityId\":\"iSPAzure\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName\"]},\"authenticationContext\":{\"authenticationContextMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAuthnContextMapper\",\"authContextItems\":[{\"contextReference\":\"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport\",\"level\":0,\"defaultItem\":true}],\"authenticationComparisonType\":\"Exact\",\"includeRequestedAuthenticationContext\":true},\"assertionTimeSkew\":300,\"basicAuthentication\":{},\"clientAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAttributeMapper\",\"attributeMap\":[{\"key\":\"http://schemas.microsoft.com/identity/claims/displayname\",\"value\":\"cn\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname\",\"value\":\"givenName\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname\",\"value\":\"sn\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\",\"value\":\"mail\"},{\"key\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\",\"value\":\"uid\"}]},\"autoFederation\":{\"autoFedEnabled\":false},\"accountMapping\":{\"spAccountMapper\":\"com.sun.identity.saml2.plugins.DefaultSPAccountMapper\",\"useNameIDAsSPUserID\":true},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"},\"url\":{},\"adapter\":{}},\"services\":{\"metaAlias\":\"/alpha/iSPAzure\",\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\",\"location\":\"https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\",\"location\":\"https://idc.scheuber.io/am/SPSloSoap/metaAlias/alpha/iSPAzure\"}],\"nameIdService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\",\"location\":\"https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure\"},{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\",\"location\":\"https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure\",\"responseLocation\":\"https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact\",\"location\":\"https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://idc.scheuber.io/am/Consumer/ECP/metaAlias/alpha/iSPAzure\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{\"spUrl\":\"https://idc.scheuber.io/am/spsaehandler/metaAlias/alpha/iSPAzure\"},\"ecpConfiguration\":{\"ecpRequestIdpListFinderImpl\":\"com.sun.identity.saml2.plugins.ECPIDPFinder\"},\"idpProxy\":{},\"relayStateUrlList\":{}}}}"
           },
           "cookies": [],
           "headers": [
@@ -1354,7 +1354,7 @@
             },
             {
               "name": "etag",
-              "value": "\"1379466460\""
+              "value": "\"-1533212691\""
             },
             {
               "name": "expires",
@@ -1370,15 +1370,15 @@
             },
             {
               "name": "content-length",
-              "value": "3964"
+              "value": "3991"
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -1397,14 +1397,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 787,
+          "headersSize": 788,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:26.045Z",
-        "time": 94,
+        "startedDateTime": "2024-12-09T20:53:11.320Z",
+        "time": 97,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1412,7 +1412,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 94
+          "wait": 97
         }
       },
       {
@@ -1433,11 +1433,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
@@ -1456,7 +1456,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2019,
+          "headersSize": 2061,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -1530,11 +1530,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -1559,8 +1559,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:26.143Z",
-        "time": 66,
+        "startedDateTime": "2024-12-09T20:53:11.422Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1568,7 +1568,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 68
         }
       },
       {
@@ -1589,11 +1589,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
@@ -1616,7 +1616,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2002,
+          "headersSize": 2044,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -1628,11 +1628,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/saml2/remote/dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l"
         },
         "response": {
-          "bodySize": 1562,
+          "bodySize": 1604,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1562,
-            "text": "{\"_id\":\"dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l\",\"_rev\":\"2050716030\",\"entityId\":\"urn:federation:MicrosoftOnline\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{\"assertion\":true},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:mace:shibboleth:1.0:nameIdentifier\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\"]},\"secrets\":{},\"basicAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMap\":[{\"samlAttribute\":\"IDPEmail\",\"localAttribute\":\"mail\",\"binary\":false},{\"samlAttribute\":\"UOPClassID\",\"localAttribute\":\"UOPClassID\",\"binary\":false}]},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"}},\"services\":{\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{},\"idpProxy\":{}}}}"
+            "size": 1604,
+            "text": "{\"_id\":\"dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l\",\"_rev\":\"-901720656\",\"entityId\":\"urn:federation:MicrosoftOnline\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{\"assertion\":true},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:mace:shibboleth:1.0:nameIdentifier\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\"]},\"secrets\":{},\"basicAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMap\":[{\"samlAttribute\":\"IDPEmail\",\"localAttribute\":\"mail\",\"binary\":false},{\"samlAttribute\":\"UOPClassID\",\"localAttribute\":\"UOPClassID\",\"binary\":false}]},\"accountMapper\":{},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"}},\"services\":{\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{},\"idpProxy\":{},\"treeConfiguration\":{}}}}"
           },
           "cookies": [],
           "headers": [
@@ -1670,7 +1670,7 @@
             },
             {
               "name": "etag",
-              "value": "\"2050716030\""
+              "value": "\"-901720656\""
             },
             {
               "name": "expires",
@@ -1686,15 +1686,15 @@
             },
             {
               "name": "content-length",
-              "value": "1562"
+              "value": "1604"
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -1719,8 +1719,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:26.213Z",
-        "time": 113,
+        "startedDateTime": "2024-12-09T20:53:11.496Z",
+        "time": 103,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1728,7 +1728,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 113
+          "wait": 103
         }
       },
       {
@@ -1749,15 +1749,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1776,7 +1776,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1990,
+          "headersSize": 2032,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1819,7 +1819,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1851,11 +1851,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -1880,8 +1880,8 @@
           "status": 409,
           "statusText": "Conflict"
         },
-        "startedDateTime": "2024-09-09T21:00:26.331Z",
-        "time": 68,
+        "startedDateTime": "2024-12-09T20:53:11.604Z",
+        "time": 62,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1889,7 +1889,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 62
         }
       },
       {
@@ -1910,15 +1910,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1937,7 +1937,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 1982,
+          "headersSize": 2024,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -1975,7 +1975,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2011,11 +2011,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -2040,8 +2040,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-09-09T21:00:26.404Z",
-        "time": 77,
+        "startedDateTime": "2024-12-09T20:53:11.673Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2049,7 +2049,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 77
+          "wait": 76
         }
       },
       {
@@ -2070,15 +2070,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2097,7 +2097,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2047,
+          "headersSize": 2089,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2135,7 +2135,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2175,11 +2175,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -2204,8 +2204,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:26.487Z",
-        "time": 172,
+        "startedDateTime": "2024-12-09T20:53:11.755Z",
+        "time": 181,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2213,7 +2213,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 172
+          "wait": 181
         }
       },
       {
@@ -2234,15 +2234,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2261,7 +2261,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2039,
+          "headersSize": 2081,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2299,7 +2299,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2339,11 +2339,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -2368,8 +2368,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:26.666Z",
-        "time": 172,
+        "startedDateTime": "2024-12-09T20:53:11.941Z",
+        "time": 165,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2377,7 +2377,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 172
+          "wait": 165
         }
       },
       {
@@ -2398,15 +2398,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2425,7 +2425,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2047,
+          "headersSize": 2089,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2463,7 +2463,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2503,11 +2503,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:26 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -2532,8 +2532,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:26.843Z",
-        "time": 181,
+        "startedDateTime": "2024-12-09T20:53:12.112Z",
+        "time": 177,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2541,7 +2541,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 181
+          "wait": 177
         }
       },
       {
@@ -2562,15 +2562,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2589,7 +2589,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2047,
+          "headersSize": 2089,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2627,7 +2627,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2667,11 +2667,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -2696,8 +2696,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.031Z",
-        "time": 174,
+        "startedDateTime": "2024-12-09T20:53:12.296Z",
+        "time": 175,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2705,7 +2705,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 174
+          "wait": 175
         }
       },
       {
@@ -2726,15 +2726,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2753,7 +2753,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2039,
+          "headersSize": 2081,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2791,7 +2791,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2831,11 +2831,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -2860,8 +2860,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.210Z",
-        "time": 171,
+        "startedDateTime": "2024-12-09T20:53:12.476Z",
+        "time": 164,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2869,7 +2869,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 171
+          "wait": 164
         }
       },
       {
@@ -2890,15 +2890,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2917,7 +2917,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2034,
+          "headersSize": 2076,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -2955,7 +2955,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2995,11 +2995,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -3024,8 +3024,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.387Z",
-        "time": 172,
+        "startedDateTime": "2024-12-09T20:53:12.646Z",
+        "time": 184,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3033,7 +3033,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 172
+          "wait": 184
         }
       },
       {
@@ -3054,15 +3054,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3081,7 +3081,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2043,
+          "headersSize": 2085,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3119,7 +3119,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3159,11 +3159,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -3188,8 +3188,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.563Z",
-        "time": 172,
+        "startedDateTime": "2024-12-09T20:53:12.836Z",
+        "time": 175,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3197,7 +3197,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 172
+          "wait": 175
         }
       },
       {
@@ -3218,15 +3218,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3245,7 +3245,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2043,
+          "headersSize": 2085,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3283,7 +3283,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3323,11 +3323,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -3352,8 +3352,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.739Z",
-        "time": 176,
+        "startedDateTime": "2024-12-09T20:53:13.015Z",
+        "time": 174,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3361,7 +3361,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 176
+          "wait": 174
         }
       },
       {
@@ -3382,15 +3382,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3409,7 +3409,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2048,
+          "headersSize": 2090,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3447,7 +3447,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3487,11 +3487,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:27 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -3516,8 +3516,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:27.920Z",
-        "time": 196,
+        "startedDateTime": "2024-12-09T20:53:13.195Z",
+        "time": 191,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3525,7 +3525,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 196
+          "wait": 191
         }
       },
       {
@@ -3546,15 +3546,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3573,7 +3573,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2046,
+          "headersSize": 2088,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3611,7 +3611,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3651,11 +3651,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:28 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -3680,8 +3680,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:28.121Z",
-        "time": 191,
+        "startedDateTime": "2024-12-09T20:53:13.390Z",
+        "time": 180,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3689,7 +3689,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 191
+          "wait": 180
         }
       },
       {
@@ -3710,15 +3710,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3737,7 +3737,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2051,
+          "headersSize": 2093,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3775,7 +3775,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3815,11 +3815,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:28 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -3844,8 +3844,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:28.315Z",
-        "time": 175,
+        "startedDateTime": "2024-12-09T20:53:13.576Z",
+        "time": 180,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3853,7 +3853,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 175
+          "wait": 180
         }
       },
       {
@@ -3874,15 +3874,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -3901,7 +3901,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2034,
+          "headersSize": 2076,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -3939,7 +3939,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -3979,11 +3979,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:28 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -4008,8 +4008,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:28.495Z",
-        "time": 202,
+        "startedDateTime": "2024-12-09T20:53:13.760Z",
+        "time": 177,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4017,7 +4017,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 202
+          "wait": 177
         }
       },
       {
@@ -4038,15 +4038,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4065,7 +4065,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2051,
+          "headersSize": 2093,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -4103,7 +4103,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -4143,11 +4143,11 @@
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:28 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:14 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -4172,8 +4172,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:28.702Z",
-        "time": 177,
+        "startedDateTime": "2024-12-09T20:53:13.942Z",
+        "time": 173,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4181,7 +4181,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 177
+          "wait": 173
         }
       },
       {
@@ -4202,15 +4202,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4229,7 +4229,7 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2007,
+          "headersSize": 2049,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
@@ -4241,11 +4241,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/FrodoTestJourney5"
         },
         "response": {
-          "bodySize": 2662,
+          "bodySize": 2677,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 2662,
-            "text": "{\"_id\":\"FrodoTestJourney5\",\"_rev\":\"-2052317947\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Frodo\\\",\\\"Prototype\\\"]\"},\"entryNodeId\":\"94299dce-b606-409f-8be0-66d23061692f\",\"innerTreeOnly\":false,\"nodes\":{\"ef8f26a5-a85f-4929-acf6-842e24d89493\":{\"x\":440,\"y\":424,\"connections\":{\"localAuthentication\":\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\",\"socialAuthentication\":\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\"},\"nodeType\":\"PageNode\",\"displayName\":\"Login Page\"},\"c89fb4c7-0122-42c0-817a-a0451b67bcdc\":{\"x\":915,\"y\":309.3333333333333,\"connections\":{\"EMAIL_NOT_SENT\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EMAIL_SENT\":\"58f762af-8e19-4d96-aae0-73b48e8f95d4\"},\"nodeType\":\"EmailTemplateNode\",\"displayName\":\"Email Template Node\"},\"58f762af-8e19-4d96-aae0-73b48e8f95d4\":{\"x\":1163,\"y\":305.5,\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"nodeType\":\"product-Saml2Node\",\"displayName\":\"SAML2 Authentication\"},\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\":{\"x\":915,\"y\":168.66666666666669,\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"nodeType\":\"InnerTreeEvaluatorNode\",\"displayName\":\"Login\"},\"94299dce-b606-409f-8be0-66d23061692f\":{\"x\":210,\"y\":305.5,\"connections\":{\"unknown\":\"da49467f-a848-4e41-a175-5a0502c5d2af\",\"known\":\"ef8f26a5-a85f-4929-acf6-842e24d89493\"},\"nodeType\":\"ScriptedDecisionNode\",\"displayName\":\"Check Username\"},\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\":{\"x\":685,\"y\":143.66666666666666,\"connections\":{\"CANCELLED\":\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\",\"EXPIRED\":\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"nodeType\":\"IdentityStoreDecisionNode\",\"displayName\":\"Validate Creds\"},\"da49467f-a848-4e41-a175-5a0502c5d2af\":{\"x\":440,\"y\":80,\"connections\":{\"localAuthentication\":\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\",\"socialAuthentication\":\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\"},\"nodeType\":\"PageNode\",\"displayName\":\"Login Page\"},\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\":{\"x\":685,\"y\":371.8333333333333,\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"c89fb4c7-0122-42c0-817a-a0451b67bcdc\"},\"nodeType\":\"SocialProviderHandlerNode\",\"displayName\":\"Social Login\"}},\"staticNodes\":{\"startNode\":{\"x\":70,\"y\":323},\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1417,\"y\":192},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1417,\"y\":286}},\"description\":\"Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.\",\"enabled\":true}"
+            "size": 2677,
+            "text": "{\"_id\":\"FrodoTestJourney5\",\"_rev\":\"-639311844\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Frodo\\\",\\\"Prototype\\\"]\"},\"entryNodeId\":\"94299dce-b606-409f-8be0-66d23061692f\",\"innerTreeOnly\":false,\"nodes\":{\"ef8f26a5-a85f-4929-acf6-842e24d89493\":{\"x\":440,\"y\":424,\"connections\":{\"localAuthentication\":\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\",\"socialAuthentication\":\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\"},\"nodeType\":\"PageNode\",\"displayName\":\"Login Page\"},\"c89fb4c7-0122-42c0-817a-a0451b67bcdc\":{\"x\":915,\"y\":309.3333333333333,\"connections\":{\"EMAIL_NOT_SENT\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EMAIL_SENT\":\"58f762af-8e19-4d96-aae0-73b48e8f95d4\"},\"nodeType\":\"EmailTemplateNode\",\"displayName\":\"Email Template Node\"},\"58f762af-8e19-4d96-aae0-73b48e8f95d4\":{\"x\":1163,\"y\":305.5,\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"nodeType\":\"product-Saml2Node\",\"displayName\":\"SAML2 Authentication\"},\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\":{\"x\":915,\"y\":168.66666666666669,\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"nodeType\":\"InnerTreeEvaluatorNode\",\"displayName\":\"Login\"},\"94299dce-b606-409f-8be0-66d23061692f\":{\"x\":210,\"y\":305.5,\"connections\":{\"unknown\":\"da49467f-a848-4e41-a175-5a0502c5d2af\",\"known\":\"ef8f26a5-a85f-4929-acf6-842e24d89493\"},\"nodeType\":\"ScriptedDecisionNode\",\"displayName\":\"Check Username\"},\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\":{\"x\":685,\"y\":143.66666666666666,\"connections\":{\"CANCELLED\":\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\",\"EXPIRED\":\"ff179a8f-b67b-46e8-bb8d-edc78c80341b\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"nodeType\":\"IdentityStoreDecisionNode\",\"displayName\":\"Validate Creds\"},\"da49467f-a848-4e41-a175-5a0502c5d2af\":{\"x\":440,\"y\":80,\"connections\":{\"localAuthentication\":\"a036a5e1-cee2-4c23-b7ae-8f39a7087444\",\"socialAuthentication\":\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\"},\"nodeType\":\"PageNode\",\"displayName\":\"Login Page\"},\"f4e81b8b-8465-409f-b71c-b5c58ab688ef\":{\"x\":685,\"y\":371.8333333333333,\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"c89fb4c7-0122-42c0-817a-a0451b67bcdc\"},\"nodeType\":\"SocialProviderHandlerNode\",\"displayName\":\"Social Login\"}},\"staticNodes\":{\"startNode\":{\"x\":70,\"y\":323},\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1417,\"y\":192},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1417,\"y\":286}},\"description\":\"Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.\",\"mustRun\":false,\"enabled\":true}"
           },
           "cookies": [],
           "headers": [
@@ -4267,7 +4267,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -4283,7 +4283,7 @@
             },
             {
               "name": "etag",
-              "value": "\"-2052317947\""
+              "value": "\"-639311844\""
             },
             {
               "name": "expires",
@@ -4303,15 +4303,15 @@
             },
             {
               "name": "content-length",
-              "value": "2662"
+              "value": "2677"
             },
             {
               "name": "date",
-              "value": "Mon, 09 Sep 2024 21:00:28 GMT"
+              "value": "Mon, 09 Dec 2024 20:53:14 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-d606f809-884a-41b2-82e3-811636c4df50"
+              "value": "frodo-dd95588e-92de-4127-bec2-9139caa9fdf9"
             },
             {
               "name": "strict-transport-security",
@@ -4330,14 +4330,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 945,
+          "headersSize": 944,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/FrodoTestJourney5",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-09-09T21:00:28.884Z",
-        "time": 76,
+        "startedDateTime": "2024-12-09T20:53:14.122Z",
+        "time": 63,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4345,7 +4345,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 76
+          "wait": 63
         }
       }
     ],


### PR DESCRIPTION
This PR fixes a bug with IdP imports where not including the redirectAfterFormPostURI attribute in the import (at least on updates) would cause it to throw an HTTP 500 error.

Tests in the CLI needed to be updated as well to pass, so there is a [PR](https://github.com/rockcarver/frodo-cli/pull/463) in the CLI with those updates.

Merge in this [PR](https://github.com/rockcarver/frodo-lib/pull/478) first so that the pipeline can pass.