### PR TITLE
Feature/more flexibility for managed object names

### DIFF
--- a/src/ops/ApplicationOps.ts
+++ b/src/ops/ApplicationOps.ts
@@ -435,11 +435,18 @@ export function createApplicationExportTemplate({
 }
 
 export function getRealmManagedApplication({ state }: { state: State }) {
-  let realmManagedOrg = 'application';
-  if (state.getDeploymentType() === constants.CLOUD_DEPLOYMENT_TYPE_KEY) {
-    realmManagedOrg = `${getCurrentRealmName(state)}_application`;
+  let realmManagedApp = 'application';
+  if (
+    state.getDeploymentType() === constants.CLOUD_DEPLOYMENT_TYPE_KEY ||
+    state.getUseRealmPrefixOnManagedObjects() === true
+  ) {
+    realmManagedApp = `${getCurrentRealmName(state)}_application`;
+    debugMessage({
+      message: `DeploymentType === cloud or UseRealmPrefixOnManagedObjects is true, returning '${realmManagedApp}'`,
+      state: state,
+    });
   }
-  return realmManagedOrg;
+  return realmManagedApp;
 }
 
 export async function createApplication({

--- a/src/ops/OrganizationOps.ts
+++ b/src/ops/OrganizationOps.ts
@@ -2,6 +2,7 @@ import { IdObjectSkeletonInterface } from '../api/ApiTypes';
 import { queryAllManagedObjectsByType } from '../api/ManagedObjectApi';
 import Constants from '../shared/Constants';
 import { State } from '../shared/State';
+import { debugMessage } from '../utils/Console';
 import { FrodoError } from './FrodoError';
 
 export type Organization = {
@@ -53,8 +54,15 @@ export default (state: State): Organization => {
  */
 export function getRealmManagedOrganization({ state }: { state: State }) {
   let realmManagedOrg = 'organization';
-  if (state.getDeploymentType() === Constants.CLOUD_DEPLOYMENT_TYPE_KEY) {
+  if (
+    state.getDeploymentType() === Constants.CLOUD_DEPLOYMENT_TYPE_KEY ||
+    state.getUseRealmPrefixOnManagedObjects() === true
+  ) {
     realmManagedOrg = `${state.getRealm()}_organization`;
+    debugMessage({
+      message: `DeploymentType === cloud or UseRealmPrefixOnManagedObjects is true, returning '${realmManagedOrg}'`,
+      state: state,
+    });
   }
   return realmManagedOrg;
 }

--- a/src/shared/State.ts
+++ b/src/shared/State.ts
@@ -441,12 +441,6 @@ export default (initialState: StateInterface): State => {
     getStopProgressHandler() {
       return state.stopProgressHandler;
     },
-    // setUseRealmPrefixOnManagedObjects(useRealmPrefixOnManagedObjects: boolean) {
-    //   state.useRealmPrefixOnManagedObjects = useRealmPrefixOnManagedObjects;
-    // },
-    // getUseRealmPrefixOnManagedObjects() {
-    //   return state.useRealmPrefixOnManagedObjects;
-    // },
 
     // global state
 

--- a/src/shared/State.ts
+++ b/src/shared/State.ts
@@ -45,6 +45,8 @@ export type State = {
   getPassword(): string;
   setRealm(realm: string): void;
   getRealm(): string;
+  setUseRealmPrefixOnManagedObjects(useRealmPrefixOnManagedObjects: boolean): void;
+  getUseRealmPrefixOnManagedObjects(): boolean;
   setDeploymentType(type: string): void;
   getDeploymentType(): string;
   setAdminClientId(type: string): void;
@@ -209,6 +211,13 @@ export default (initialState: StateInterface): State => {
     },
     getRealm() {
       return state.realm || process.env.FRODO_REALM;
+    },
+
+    setUseRealmPrefixOnManagedObjects(useRealmPrefixOnManagedObjects: boolean) {
+      state.useRealmPrefixOnManagedObjects = useRealmPrefixOnManagedObjects;
+    },
+    getUseRealmPrefixOnManagedObjects() {
+      return state.useRealmPrefixOnManagedObjects || false;
     },
 
     setDeploymentType(type: string) {
@@ -432,6 +441,12 @@ export default (initialState: StateInterface): State => {
     getStopProgressHandler() {
       return state.stopProgressHandler;
     },
+    // setUseRealmPrefixOnManagedObjects(useRealmPrefixOnManagedObjects: boolean) {
+    //   state.useRealmPrefixOnManagedObjects = useRealmPrefixOnManagedObjects;
+    // },
+    // getUseRealmPrefixOnManagedObjects() {
+    //   return state.useRealmPrefixOnManagedObjects;
+    // },
 
     // global state
 
@@ -510,6 +525,7 @@ export interface StateInterface {
   username?: string;
   password?: string;
   realm?: string;
+  useRealmPrefixOnManagedObjects?: boolean;
   deploymentType?: string;
   adminClientId?: string;
   adminClientRedirectUri?: string;

--- a/src/utils/ForgeRockUtils.ts
+++ b/src/utils/ForgeRockUtils.ts
@@ -1,6 +1,7 @@
 import { getRealms } from '../ops/RealmOps';
 import Constants from '../shared/Constants';
 import { State } from '../shared/State';
+import { debugMessage } from '../utils/Console';
 
 export type FRUtils = {
   applyNameCollisionPolicy(name: string): string;
@@ -211,8 +212,15 @@ export function getCurrentRealmManagedUser({
   state: State;
 }): string {
   let realmManagedUser = 'user';
-  if (state.getDeploymentType() === Constants.CLOUD_DEPLOYMENT_TYPE_KEY) {
+  if (
+    state.getDeploymentType() === Constants.CLOUD_DEPLOYMENT_TYPE_KEY ||
+    state.getUseRealmPrefixOnManagedObjects() === true
+  ) {
     realmManagedUser = `${getCurrentRealmName(state)}_user`;
+    debugMessage({
+      message: `DeploymentType === cloud or UseRealmPrefixOnManagedObjects is true, returning '${realmManagedUser}'`,
+      state: state,
+    });
   }
   return realmManagedUser;
 }


### PR DESCRIPTION
Our use case for frodo is not executing correctly due to the logic in place to decide what the managed object name should be.

In a cloud deployment, the managed objects (user, application and organization) get the realm prefix, but in other types that is omitted, e.g.

- cloud: `managed/alpha_user`
- forgeops: `managed/organization`

We are working on replicating the alpha & bravo realm in a local deployment, so having some flexibility on this is needed.

Do you think this can be retrofitted into the 2.X codebase and released?  Currently we are relying on a fork for our needs.

If this is accepted, once we can migrate to 3.X I am happy to apply this to v3 too.

Also added cli option in this PR: [frodo-cli#464](https://github.com/rockcarver/frodo-cli/pull/464)

Thanks!