### PR TITLE
Remove duplicate IDPs from full export

### DIFF
--- a/src/ops/ConfigOps.ts
+++ b/src/ops/ConfigOps.ts
@@ -454,7 +454,7 @@ export async function exportFullConfiguration({
     ...config.global,
   };
 
-  //Clean up duplicates
+  //Clean up global duplicates
   if (globalConfig.idm) {
     Object.keys(globalConfig.idm)
       .filter(
@@ -613,6 +613,14 @@ export async function exportFullConfiguration({
       )?.trustedJwtIssuer,
       ...config.realm[realm],
     };
+    //Clean up realm duplicates
+    if (
+      realmConfig[realm].service &&
+      realmConfig[realm].service['SocialIdentityProviders']
+    ) {
+      delete realmConfig[realm].service['SocialIdentityProviders']
+        .nextDescendents;
+    }
   }
   state.setRealm(currentRealm);
 

--- a/src/ops/ServiceOps.ts
+++ b/src/ops/ServiceOps.ts
@@ -405,7 +405,7 @@ export async function putFullService({
     });
 
     // return fast if no next descendents supplied
-    if (nextDescendents.length === 0) {
+    if (!nextDescendents || nextDescendents.length === 0) {
       debugMessage({
         message: `ServiceOps.putFullService: end (w/o descendents)`,
         state,


### PR DESCRIPTION
This PR removes duplicate IdP config exported as part of the SocialIdentityProviders service in the full config export since they are already exported separately. The service is still exported, but the nextDescendents field is simply deleted before returning the full export.

Tests in the CLI needed to be updated as well, so a [PR](https://github.com/rockcarver/frodo-cli/pull/466) was made there to update them.

Merge in this [PR](https://github.com/rockcarver/frodo-lib/pull/478) first so that the pipeline can pass.