### PR TITLE
Fix Adding Connection Profiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rockcarver/frodo-lib",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rockcarver/frodo-lib",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^29.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rockcarver/frodo-lib",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "commonjs",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/ops/AuthenticateOps.ts
+++ b/src/ops/AuthenticateOps.ts
@@ -119,12 +119,10 @@ const CLOUD_ADMIN_DEFAULT_SCOPES: string[] = [
   s.ESVFullScope,
   s.FederationEnforcementFullScope,
   s.IdmFullScope,
-  s.IGAFullScope,
   s.OpenIdScope,
   s.PromotionScope,
   s.ReleaseFullScope,
   s.SSOCookieFullScope,
-  s.WafFullScope,
 ];
 const FORGEOPS_ADMIN_DEFAULT_SCOPES: string[] = [s.IdmFullScope, s.OpenIdScope];
 

--- a/src/ops/cloud/ServiceAccountOps.ts
+++ b/src/ops/cloud/ServiceAccountOps.ts
@@ -104,13 +104,9 @@ export const SERVICE_ACCOUNT_ALLOWED_SCOPES: string[] = [
   s.ESVRestartScope,
   s.ESVUpdateScope,
   s.IdmFullScope,
-  s.IGAFullScope,
   s.PromotionScope,
   s.ReleaseFullScope,
   s.SSOCookieFullScope,
-  s.WafFullScope,
-  s.WafReadScope,
-  s.WafWriteScope,
   s.CookieDomainsFullScope,
 ];
 
@@ -124,11 +120,9 @@ export const SERVICE_ACCOUNT_DEFAULT_SCOPES: string[] = [
   s.CustomDomainFullScope,
   s.ESVFullScope,
   s.IdmFullScope,
-  s.IGAFullScope,
   s.PromotionScope,
   s.ReleaseFullScope,
   s.SSOCookieFullScope,
-  s.WafFullScope,
 ];
 
 export type ServiceAccountType = IdObjectSkeletonInterface & {

--- a/src/shared/Constants.ts
+++ b/src/shared/Constants.ts
@@ -39,7 +39,6 @@ const AVAILABLE_SCOPES = {
   AmFullScope: 'fr:am:*',
   IdmFullScope: 'fr:idm:*',
   AutoAccessFullScope: 'fr:autoaccess:*',
-  IGAFullScope: 'fr:iga:*',
   AnalyticsFullScope: 'fr:idc:analytics:*',
 
   // AMIntrospectRealmTokenScope lets you introspect scopes _from the same realm_, there is a separate scope to introspect tokens from _all_ realms
@@ -77,11 +76,6 @@ const AVAILABLE_SCOPES = {
 
   // Promotion scopes
   PromotionScope: 'fr:idc:promotion:*',
-
-  // WAF scopes
-  WafFullScope: 'fr:idc:proxy-connect:*',
-  WafReadScope: 'fr:idc:proxy-connect:read',
-  WafWriteScope: 'fr:idc:proxy-connect:write',
 
   // Cookie Domains scopes
   CookieDomainsFullScope: 'fr:idc:cookie-domain:*',


### PR DESCRIPTION
This PR removes the `fr:iga:*` and `fr:idc:proxy-connect:*` scopes from being used to create service accounts since the newer version of cloud, 16747.0, doesn't have them anymore. This was causing an issue where connection profiles couldn't be added without specifying an already existing service account (see [this](https://github.com/rockcarver/frodo-cli/issues/479) issue).

I verified after making the change that the tests still pass in frodo-cli as well as frodo-lib. I also tested adding connections in both a tenant in version 16747.0, and in a tenant using an older version 16368.14, and it works in both versions now.