### PR TITLE
Add ability to customise auto-retries #494

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
       "email": "maas.marcel@gmail.com"
     },
     {
+      "name": "Conor Barford",
+      "email": "conor.barford@pingidentity.com"
+    },
+    {
       "name": "Joshua Sayers",
       "email": "joshua.sayers@forgerock.com"
     },

--- a/src/shared/State.test.ts
+++ b/src/shared/State.test.ts
@@ -110,6 +110,26 @@ describe('State', () => {
     });
   });
 
+  describe('getAxiosRetryConfig()/setAxiosRetryConfig()', () => {
+    test('0: Method getAxiosRetryConfig is implemented', () => {
+      expect(state.getAxiosRetryConfig).toBeDefined();
+    });
+
+    test('1: Method setAxiosRetryConfig is implemented', () => {
+      expect(state.setAxiosRetryConfig).toBeDefined();
+    });
+
+    test("2: axiosRetryConfig value should be undefined if it hasn't been set before or defined if set explicitly", () => {
+      const retryConfig = {
+        retries: 3
+      };
+
+      expect(state.getAxiosRetryConfig()).toBeUndefined();
+      state.setAxiosRetryConfig(retryConfig);
+      expect(state.getAxiosRetryConfig()).toEqual(retryConfig);
+    });
+  });
+
   // setDeploymentType,
   // getDeploymentType,
 

--- a/src/shared/State.ts
+++ b/src/shared/State.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+import { IAxiosRetryConfig } from 'axios-retry';
+
 import { FeatureInterface } from '../api/cloud/FeatureApi';
 import { UserSessionMetaType } from '../ops/AuthenticateOps';
 import { FrodoError } from '../ops/FrodoError';
@@ -149,6 +151,8 @@ export type State = {
   getDebugHandler(): (message: string | object) => void;
   setDebug(debug: boolean): void;
   getDebug(): boolean;
+  getAxiosRetryConfig(): IAxiosRetryConfig;
+  setAxiosRetryConfig(axiosRetryConfig: IAxiosRetryConfig): void;
   /**
    * Reset the state to default values
    */
@@ -476,6 +480,12 @@ export default (initialState: StateInterface): State => {
     getDebug(): boolean {
       return globalState.debug || process.env.FRODO_DEBUG !== undefined;
     },
+    getAxiosRetryConfig(): IAxiosRetryConfig {
+      return globalState.axiosRetryConfig;
+    },
+    setAxiosRetryConfig(axiosRetryConfig: IAxiosRetryConfig) {
+      globalState.axiosRetryConfig = axiosRetryConfig;
+    },
     reset(): void {
       for (const key of Object.keys(state)) {
         state[key] = globalState[key];
@@ -553,6 +563,7 @@ export interface StateInterface {
   ) => string;
   updateProgressHandler?: (id: string, message: string) => void;
   stopProgressHandler?: (id: string, message: string, status?: string) => void;
+  axiosRetryConfig?: IAxiosRetryConfig;
 }
 
 const globalState: StateInterface = {


### PR DESCRIPTION
- Adds methods to State to allow setting global retry config.

- In BaseApi apply retry config if present in the global state or in the passed in request overrides with the latter taking precedent.

- Default is to have no retry config to maintain current behaviour (removed the call in the top level of BaseAPI as I don't think it was actually taking effect in any calls).