### PR TITLE
bugfix: Fix root realm managed object prefixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2117,7 +2116,6 @@
       "integrity": "sha512-1ZZcmojW8iSFmvHGeLlvuudM3WiDV842FsVvtPAo3HoAYE6jCNveLHJ+X4qvonL4enj1SyTF3hXA107UkQFQrA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@pollyjs/utils": "^6.0.6",
         "@sindresorhus/fnv1a": "^2.0.1",
@@ -2980,7 +2978,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3501,7 +3498,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3868,15 +3864,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
-      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -4217,7 +4212,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5375,7 +5369,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5470,7 +5463,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5527,7 +5519,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7806,7 +7797,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -10038,7 +10028,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10223,9 +10212,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -11534,7 +11523,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11935,7 +11923,6 @@
       "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -11970,7 +11957,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12557,7 +12543,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/ops/ApplicationOps.ts
+++ b/src/ops/ApplicationOps.ts
@@ -438,7 +438,8 @@ export function getRealmManagedApplication({ state }: { state: State }) {
   let realmManagedApp = 'application';
   if (
     state.getDeploymentType() === constants.CLOUD_DEPLOYMENT_TYPE_KEY ||
-    state.getUseRealmPrefixOnManagedObjects() === true
+    (state.getUseRealmPrefixOnManagedObjects() === true &&
+      getCurrentRealmName(state) !== '/')
   ) {
     realmManagedApp = `${getCurrentRealmName(state)}_application`;
     debugMessage({

--- a/src/ops/OrganizationOps.ts
+++ b/src/ops/OrganizationOps.ts
@@ -3,6 +3,7 @@ import { queryAllManagedObjectsByType } from '../api/ManagedObjectApi';
 import Constants from '../shared/Constants';
 import { State } from '../shared/State';
 import { debugMessage } from '../utils/Console';
+import { getCurrentRealmName } from '../utils/ForgeRockUtils';
 import { FrodoError } from './FrodoError';
 
 export type Organization = {
@@ -56,9 +57,10 @@ export function getRealmManagedOrganization({ state }: { state: State }) {
   let realmManagedOrg = 'organization';
   if (
     state.getDeploymentType() === Constants.CLOUD_DEPLOYMENT_TYPE_KEY ||
-    state.getUseRealmPrefixOnManagedObjects() === true
+    (state.getUseRealmPrefixOnManagedObjects() === true &&
+      getCurrentRealmName(state) !== '/')
   ) {
-    realmManagedOrg = `${state.getRealm()}_organization`;
+    realmManagedOrg = `${getCurrentRealmName(state)}_organization`;
     debugMessage({
       message: `DeploymentType === cloud or UseRealmPrefixOnManagedObjects is true, returning '${realmManagedOrg}'`,
       state: state,

--- a/src/utils/ForgeRockUtils.ts
+++ b/src/utils/ForgeRockUtils.ts
@@ -214,7 +214,8 @@ export function getCurrentRealmManagedUser({
   let realmManagedUser = 'user';
   if (
     state.getDeploymentType() === Constants.CLOUD_DEPLOYMENT_TYPE_KEY ||
-    state.getUseRealmPrefixOnManagedObjects() === true
+    (state.getUseRealmPrefixOnManagedObjects() === true &&
+      getCurrentRealmName(state) !== '/')
   ) {
     realmManagedUser = `${getCurrentRealmName(state)}_user`;
     debugMessage({


### PR DESCRIPTION
This PR is a bugfix for a bug I found while making and running tests for [this PR](https://github.com/rockcarver/frodo-cli/pull/464).

Since root realms have the name '/', it would try looking for a managed object named '_application', which doesn't make sense. It rather should be just 'application' since that is the default managed object used for applications in forgeops just as the root realm is the default realm in forgeops.

I created a new [CLI PR](https://github.com/rockcarver/frodo-cli/pull/539) here for the CLI changes.