### PR TITLE
Add ability to determine if a tenant is an IGA tenant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2117,7 +2116,6 @@
       "integrity": "sha512-1ZZcmojW8iSFmvHGeLlvuudM3WiDV842FsVvtPAo3HoAYE6jCNveLHJ+X4qvonL4enj1SyTF3hXA107UkQFQrA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@pollyjs/utils": "^6.0.6",
         "@sindresorhus/fnv1a": "^2.0.1",
@@ -2980,7 +2978,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3501,7 +3498,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3873,7 +3869,6 @@
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4217,7 +4212,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5375,7 +5369,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5470,7 +5463,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5527,7 +5519,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7806,7 +7797,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8952,9 +8942,9 @@
       "license": "MIT"
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10038,7 +10028,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11534,7 +11523,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11935,7 +11923,6 @@
       "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -11970,7 +11957,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12557,7 +12543,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/api/cloud/EnvServiceAccountScopesApi.ts
+++ b/src/api/cloud/EnvServiceAccountScopesApi.ts
@@ -37,11 +37,13 @@ export async function getServiceAccountScopes({
   );
   const { data } = await generateEnvApi({
     resource: getApiConfig(),
-    requestOverride: {
-      headers: {
-        Cookie: `${state.getCookieName()}=${state.getCookieValue()}`,
-      },
-    },
+    requestOverride: state.getCookieValue()
+      ? {
+          headers: {
+            Cookie: `${state.getCookieName()}=${state.getCookieValue()}`,
+          },
+        }
+      : undefined,
     state,
   }).get(urlString, {
     withCredentials: true,

--- a/src/ops/ConnectionProfileOps.test.ts
+++ b/src/ops/ConnectionProfileOps.test.ts
@@ -63,6 +63,8 @@ describe('ConnectionProfileOps', () => {
 
       state.setHost(host);
       state.setDeploymentType(Constants.FORGEOPS_DEPLOYMENT_TYPE_KEY);
+      // Even though IGA is not part of forgeops deployments, we want to check it is not set to the connection profile
+      state.setIsIGA(true);
       state.setUsername(user);
       state.setPassword(password);
       state.setConnectionProfilesPath(connectionProfilePath1);
@@ -76,6 +78,7 @@ describe('ConnectionProfileOps', () => {
       expect(connections[host].deploymentType).toEqual(
         Constants.FORGEOPS_DEPLOYMENT_TYPE_KEY
       );
+      expect(connections[host].isIGA).toBeUndefined();
       expect(connections[host].username).toEqual(user);
       expect(connections[host].encodedPassword).toBeTruthy();
     });
@@ -90,6 +93,7 @@ describe('ConnectionProfileOps', () => {
 
       state.setHost(host);
       state.setDeploymentType(Constants.CLOUD_DEPLOYMENT_TYPE_KEY);
+      state.setIsIGA(true);
       state.setUsername(user);
       state.setPassword(password);
       state.setConnectionProfilesPath('');
@@ -105,6 +109,7 @@ describe('ConnectionProfileOps', () => {
       expect(connections[host].deploymentType).toEqual(
         Constants.CLOUD_DEPLOYMENT_TYPE_KEY
       );
+      expect(connections[host].isIGA).toEqual(true);
       expect(connections[host].username).toEqual(user);
       expect(connections[host].encodedPassword).toBeTruthy();
     });
@@ -119,6 +124,8 @@ describe('ConnectionProfileOps', () => {
 
       state.setHost(host);
       state.setDeploymentType(Constants.CLASSIC_DEPLOYMENT_TYPE_KEY);
+      // Even though IGA is not part of classic deployments, we want to check it is not set to the connection profile
+      state.setIsIGA(false);
       state.setUsername(user);
       state.setPassword(password);
       state.setConnectionProfilesPath(connectionProfilePath3);
@@ -132,6 +139,7 @@ describe('ConnectionProfileOps', () => {
       expect(connections[host].deploymentType).toEqual(
         Constants.CLASSIC_DEPLOYMENT_TYPE_KEY
       );
+      expect(connections[host].isIGA).toBeUndefined();
       expect(connections[host].username).toEqual(user);
       expect(connections[host].encodedPassword).toBeTruthy();
     });

--- a/src/ops/ConnectionProfileOps.ts
+++ b/src/ops/ConnectionProfileOps.ts
@@ -133,6 +133,7 @@ export interface SecureConnectionProfileInterface {
   idmHost?: string;
   allowInsecureConnection?: boolean;
   deploymentType?: string;
+  isIGA?: boolean;
   username?: string | null;
   encodedPassword?: string | null;
   logApiKey?: string | null;
@@ -153,6 +154,7 @@ export interface ConnectionProfileInterface {
   idmHost?: string;
   allowInsecureConnection?: boolean;
   deploymentType?: string;
+  isIGA?: boolean;
   username?: string | null;
   password?: string | null;
   logApiKey?: string | null;
@@ -396,6 +398,7 @@ export async function getConnectionProfileByHost({
       idmHost: profiles[0].idmHost ? profiles[0].idmHost : null,
       allowInsecureConnection: profiles[0].allowInsecureConnection,
       deploymentType: profiles[0].deploymentType,
+      isIGA: profiles[0].isIGA,
       username: profiles[0].username ? profiles[0].username : null,
       password: profiles[0].encodedPassword
         ? await dataProtection.decrypt(profiles[0].encodedPassword)
@@ -465,6 +468,9 @@ export async function loadConnectionProfileByHost({
   state.setIdmHost(state.getIdmHost() || conn.idmHost);
   state.setAllowInsecureConnection(conn.allowInsecureConnection);
   state.setDeploymentType(state.getDeploymentType() || conn.deploymentType);
+  state.setIsIGA(
+    state.getIsIGA() === undefined ? conn.isIGA : state.getIsIGA()
+  );
   state.setAdminClientId(state.getAdminClientId() || conn.adminClientId);
   state.setAdminClientRedirectUri(
     state.getAdminClientRedirectUri() || conn.adminClientRedirectUri
@@ -579,6 +585,10 @@ export async function saveConnectionProfile({
     // deployment type
     if (state.getDeploymentType())
       profile.deploymentType = state.getDeploymentType();
+
+    // is IGA
+    if (state.getDeploymentType() === Constants.CLOUD_DEPLOYMENT_TYPE_KEY)
+      profile.isIGA = !!state.getIsIGA();
 
     // admin client id
     if (state.getAdminClientId())

--- a/src/shared/State.test.ts
+++ b/src/shared/State.test.ts
@@ -19,6 +19,10 @@ describe('State', () => {
   const host = 'https://openam-frodo-dev.forgeblocks.com/am';
   const hostEnv = 'https://openam-host-env.forgeblocks.com/am';
 
+  beforeEach(() => {
+    state.setDeploymentType(undefined);
+  });
+
   describe('getHost()/setHost()/getTenant()/setTenant()', () => {
     test('0: Method getHost is implemented', () => {
       expect(state.getHost).toBeDefined();
@@ -138,6 +142,44 @@ describe('State', () => {
 
   // setDeploymentType,
   // getDeploymentType,
+
+  describe('getIsIGA()/setIsIGA()', () => {
+    test('0: Method getIsIGA is implemented', () => {
+      expect(state.getIsIGA).toBeDefined();
+    });
+
+    test('1: Method setIsIGA is implemented', () => {
+      expect(state.setIsIGA).toBeDefined();
+    });
+
+    test("2: isIGA value should be undefined if it hasn't been set before or defined if set explicitly", () => {
+      expect(state.getIsIGA()).toBe(false);
+      state.setDeploymentType(Constants.FORGEOPS_DEPLOYMENT_TYPE_KEY);
+      expect(state.getIsIGA()).toBe(false);
+      state.setDeploymentType(Constants.CLASSIC_DEPLOYMENT_TYPE_KEY);
+      expect(state.getIsIGA()).toBe(false);
+      state.setDeploymentType(Constants.CLOUD_DEPLOYMENT_TYPE_KEY);
+      expect(state.getIsIGA()).toBeUndefined();
+      process.env.FRODO_IGA = "hello";
+      expect(state.getIsIGA()).toBeUndefined();
+      process.env.FRODO_IGA = "true";
+      expect(state.getIsIGA()).toBe(true);
+      process.env.FRODO_IGA = "false";
+      expect(state.getIsIGA()).toBe(false);
+      state.setIsIGA(true);
+      expect(state.getIsIGA()).toBe(false);
+      delete process.env.FRODO_IGA;
+      expect(state.getIsIGA()).toBe(true);
+      state.setIsIGA(false);
+      expect(state.getIsIGA()).toBe(false);
+      state.setIsIGA(true);
+      expect(state.getIsIGA()).toBe(true);
+      state.setDeploymentType(Constants.FORGEOPS_DEPLOYMENT_TYPE_KEY);
+      expect(state.getIsIGA()).toBe(false);
+      state.setDeploymentType(Constants.CLASSIC_DEPLOYMENT_TYPE_KEY);
+      expect(state.getIsIGA()).toBe(false);
+    });
+  });
 
   // setAllowInsecureConnection,
   // getAllowInsecureConnection,

--- a/src/shared/State.ts
+++ b/src/shared/State.ts
@@ -59,6 +59,8 @@ export type State = {
   getUseRealmPrefixOnManagedObjects(): boolean;
   setDeploymentType(type: string): void;
   getDeploymentType(): string;
+  setIsIGA(isIGA: boolean): void;
+  getIsIGA(): boolean | undefined;
   setAdminClientId(type: string): void;
   getAdminClientId(): string;
   setAdminClientRedirectUri(type: string): void;
@@ -238,6 +240,19 @@ export default (initialState: StateInterface): State => {
     },
     getDeploymentType() {
       return state.deploymentType;
+    },
+
+    setIsIGA(isIGA: boolean) {
+      state.isIGA = isIGA;
+    },
+    getIsIGA(): boolean | undefined {
+      if (this.getDeploymentType() !== Constants.CLOUD_DEPLOYMENT_TYPE_KEY)
+        return false;
+      return process.env.FRODO_IGA === 'true'
+        ? true
+        : process.env.FRODO_IGA === 'false'
+          ? false
+          : state.isIGA;
     },
 
     setAdminClientId(clientId: string) {
@@ -592,6 +607,7 @@ export interface StateInterface {
   realm?: string;
   useRealmPrefixOnManagedObjects?: boolean;
   deploymentType?: string;
+  isIGA?: boolean;
   adminClientId?: string;
   adminClientRedirectUri?: string;
   allowInsecureConnection?: boolean;


### PR DESCRIPTION
This PR adds the ability to determine automatically or by an environment variable whether or not IGA endpoints can be accessed for an AIC tenant. 

The reason for adding this is so that we can add IGA configuration to Frodo in the future. I've already finished adding glossary schema, request types/forms, events, and certification templates to the library in other branches, and I'm almost finished with workflows. Once I finish workflows I'll begin creating those PRs for those changes, but this is a pre-requisite to those.

There wasn't a super straightforward way to determine if a tenant has the IGA add-on that I could find (for example, the `/server-info` endpoint doesn't have that information). The best way I could come up with doing it without attempting to hit an existing IGA endpoint would be to use the `/environment/scopes/service-accounts`. This endpoint is accessible from any tenant, and it returns the `fr:iga:*` scope as a possible scope only when the tenant has the IGA add-on, and since we already have the functions to use this endpoint in Frodo that's what I decided to go with, although there may be a better way to determine this. 

The result also gets stored on the connection profile so we don't have to do the check everytime the user connects. One note is that I do allow the `isIGA` flag to be set as undefined in addition to a boolean value. The reason for this is so that we know whether or not we need to determine still if the tenant is IGA. To be more specific:
- `isIGA=undefined` means that it hasn't been determined that the tenant is an IGA tenant (or that the deployment type is not cloud)
- `isIGA=false` implies that the deployment type is cloud, but doesn't have the IGA add-on
- `isIGA=true` implies that the deployment type is cloud and also has the IGA add-on

The CLI changes can be found in [this PR](https://github.com/rockcarver/frodo-cli/pull/541)