### PR TITLE
Minor Bugfixes for ESV secretstore export/import 

### DIFF
--- a/src/api/SecretStoreApi.ts
+++ b/src/api/SecretStoreApi.ts
@@ -372,6 +372,7 @@ export async function putSecretStoreMapping({
     secretTypesThatIgnoreId.includes(secretStoreTypeId) ? '' : secretStoreId,
     secretStoreMappingData.secretId
   );
+  delete secretStoreMappingData._rev;
   const { data } = await generateAmApi({
     resource: getApiConfig(globalConfig),
     state,

--- a/src/ops/SecretStoreOps.test.ts
+++ b/src/ops/SecretStoreOps.test.ts
@@ -167,7 +167,8 @@ describe('SecretStoreOps', () => {
         });
     
         test('2: Read global SecretStores', async () => {
-          await expect(SecretStoreOps.readSecretStores({ globalConfig: true, state })).rejects.toThrow('Error reading alpha realm secret stores');
+          const response = await SecretStoreOps.readSecretStores({ globalConfig: true, state });
+          expect(response).toMatchSnapshot();
         });
       });
 
@@ -243,7 +244,10 @@ describe('SecretStoreOps', () => {
         });
     
         test('2: Export global SecretStores', async () => {
-          await expect(SecretStoreOps.exportSecretStores({ globalConfig: true, state })).rejects.toThrow('Error reading alpha realm secret stores');
+          const response = await SecretStoreOps.exportSecretStores({ globalConfig: true, resultCallback: snapshotResultCallback, state });
+          expect(response).toMatchSnapshot({
+            meta: expect.any(Object),
+          });
         });
       });
     

--- a/src/ops/SecretStoreOps.ts
+++ b/src/ops/SecretStoreOps.ts
@@ -579,16 +579,30 @@ export async function readSecretStores({
     });
     const isCloudDeployment =
       state.getDeploymentType() === Constants.CLOUD_DEPLOYMENT_TYPE_KEY;
-    const result = isCloudDeployment
-      ? [
+    let result = [];
+    if (isCloudDeployment) {
+      try {
+        result.push(
           await getSecretStore({
             secretStoreId: 'ESV',
             secretStoreTypeId: 'GoogleSecretManagerSecretStoreProvider',
             globalConfig,
             state,
-          }),
-        ]
-      : (await getSecretStores({ globalConfig, state })).result;
+          })
+        );
+      } catch (e) {
+        if (
+          e.response?.status === 403 &&
+          e.response?.data?.message ===
+            'This operation is not available in PingOne Advanced Identity Cloud.'
+        ) {
+          return result;
+        }
+        throw e;
+      }
+    } else {
+      result = (await getSecretStores({ globalConfig, state })).result;
+    }
     debugMessage({ message: `SecretStoreOps.readSecretStores: end`, state });
     return result;
   } catch (error) {

--- a/src/test/mock-recordings/SecretStoreOps_2115179242/Classic-Tests_743483830/deleteSecretStores_1727803707/0-Delete-global-secret-stores_1401080051/recording.har
+++ b/src/test/mock-recordings/SecretStoreOps_2115179242/Classic-Tests_743483830/deleteSecretStores_1727803707/0-Delete-global-secret-stores_1401080051/recording.har
@@ -825,11 +825,11 @@
         }
       },
       {
-        "_id": "07a03827f34d75e4636d85b5d10f720d",
+        "_id": "17e2d12fe72bc1d6f28ee6a720873402",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 249,
+          "bodySize": 229,
           "cookies": [],
           "headers": [
             {
@@ -842,11 +842,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/3.3.0"
+              "value": "@rockcarver/frodo-lib/4.0.0-10"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7ddf942c-ab50-4c1f-8be5-654d2e6ff40a"
+              "value": "frodo-556479c0-6d39-4ff7-9961-7e653515d28d"
             },
             {
               "name": "accept-api-version",
@@ -858,7 +858,7 @@
             },
             {
               "name": "content-length",
-              "value": "249"
+              "value": "229"
             },
             {
               "name": "accept-encoding",
@@ -869,23 +869,23 @@
               "value": "openam-frodo-dev.classic.com:8080"
             }
           ],
-          "headersSize": 679,
+          "headersSize": 682,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"am.applications.agents.remote.consent.request.signing.ES256\",\"_rev\":\"1192664276\",\"secretId\":\"am.applications.agents.remote.consent.request.signing.ES256\",\"aliases\":[\"es256test\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
+            "text": "{\"_id\":\"am.applications.agents.remote.consent.request.signing.ES256\",\"secretId\":\"am.applications.agents.remote.consent.request.signing.ES256\",\"aliases\":[\"es256test\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
           },
           "queryString": [],
           "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/secrets/stores/KeyStoreSecretStore/test-keystore/mappings/am.applications.agents.remote.consent.request.signing.ES256"
         },
         "response": {
-          "bodySize": 128,
+          "bodySize": 249,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 128,
-            "text": "{\"code\":400,\"reason\":\"Bad Request\",\"message\":\"Invalid attribute specified.\",\"detail\":{\"validAttributes\":[\"aliases\",\"secretId\"]}}"
+            "size": 249,
+            "text": "{\"_id\":\"am.applications.agents.remote.consent.request.signing.ES256\",\"_rev\":\"1192664276\",\"secretId\":\"am.applications.agents.remote.consent.request.signing.ES256\",\"aliases\":[\"es256test\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
           },
           "cookies": [],
           "headers": [
@@ -918,8 +918,16 @@
               "value": "same-origin"
             },
             {
+              "name": "etag",
+              "value": "\"1192664276\""
+            },
+            {
               "name": "expires",
               "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/secrets/stores/KeyStoreSecretStore/test-keystore/mappings/am.applications.agents.remote.consent.request.signing.ES256"
             },
             {
               "name": "pragma",
@@ -931,25 +939,29 @@
             },
             {
               "name": "content-length",
-              "value": "128"
+              "value": "249"
             },
             {
               "name": "date",
-              "value": "Mon, 22 Sep 2025 18:32:31 GMT"
+              "value": "Mon, 23 Feb 2026 22:16:52 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
             },
             {
               "name": "connection",
-              "value": "close"
+              "value": "keep-alive"
             }
           ],
-          "headersSize": 436,
+          "headersSize": 677,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 400,
-          "statusText": "Bad Request"
+          "redirectURL": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/secrets/stores/KeyStoreSecretStore/test-keystore/mappings/am.applications.agents.remote.consent.request.signing.ES256",
+          "status": 201,
+          "statusText": "Created"
         },
-        "startedDateTime": "2025-09-22T18:32:31.092Z",
-        "time": 3,
+        "startedDateTime": "2026-02-23T22:16:52.383Z",
+        "time": 142,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -957,7 +969,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 3
+          "wait": 142
         }
       },
       {

--- a/src/test/mock-recordings/SecretStoreOps_2115179242/Cloud-Tests_2178067211/importSecretStores_732967729/1-Import-ESV-secret-store_2132776162/recording.har
+++ b/src/test/mock-recordings/SecretStoreOps_2115179242/Cloud-Tests_2178067211/importSecretStores_732967729/1-Import-ESV-secret-store_2132776162/recording.har
@@ -303,11 +303,11 @@
         }
       },
       {
-        "_id": "9fa3ac969a4d66392ba2804423a401fe",
+        "_id": "b375b14accc9d355790acea77bea611c",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 204,
+          "bodySize": 184,
           "cookies": [],
           "headers": [
             {
@@ -320,11 +320,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/3.3.0"
+              "value": "@rockcarver/frodo-lib/4.0.0-10"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-3075180a-4f39-4834-a77c-f06880733811"
+              "value": "frodo-00413fa5-5793-4c65-8407-b97b1c9ee14b"
             },
             {
               "name": "accept-api-version",
@@ -336,7 +336,7 @@
             },
             {
               "name": "content-length",
-              "value": "204"
+              "value": "184"
             },
             {
               "name": "accept-encoding",
@@ -347,23 +347,23 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2071,
+          "headersSize": 2074,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"am.services.oauth2.oidc.signing.EDDSA\",\"_rev\":\"1919880477\",\"secretId\":\"am.services.oauth2.oidc.signing.EDDSA\",\"aliases\":[\"esv-test\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
+            "text": "{\"_id\":\"am.services.oauth2.oidc.signing.EDDSA\",\"secretId\":\"am.services.oauth2.oidc.signing.EDDSA\",\"aliases\":[\"esv-test\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings/am.services.oauth2.oidc.signing.EDDSA"
         },
         "response": {
-          "bodySize": 128,
+          "bodySize": 204,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 128,
-            "text": "{\"code\":400,\"reason\":\"Bad Request\",\"message\":\"Invalid attribute specified.\",\"detail\":{\"validAttributes\":[\"aliases\",\"secretId\"]}}"
+            "size": 204,
+            "text": "{\"_id\":\"am.services.oauth2.oidc.signing.EDDSA\",\"_rev\":\"1919880477\",\"secretId\":\"am.services.oauth2.oidc.signing.EDDSA\",\"aliases\":[\"esv-test\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
           },
           "cookies": [],
           "headers": [
@@ -396,6 +396,10 @@
               "value": "same-origin"
             },
             {
+              "name": "etag",
+              "value": "\"1919880477\""
+            },
+            {
               "name": "expires",
               "value": "0"
             },
@@ -409,15 +413,15 @@
             },
             {
               "name": "content-length",
-              "value": "128"
+              "value": "204"
             },
             {
               "name": "date",
-              "value": "Fri, 03 Oct 2025 22:34:08 GMT"
+              "value": "Mon, 23 Feb 2026 21:48:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-3075180a-4f39-4834-a77c-f06880733811"
+              "value": "frodo-00413fa5-5793-4c65-8407-b97b1c9ee14b"
             },
             {
               "name": "strict-transport-security",
@@ -436,14 +440,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 731,
+          "headersSize": 751,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
-          "status": 400,
-          "statusText": "Bad Request"
+          "status": 200,
+          "statusText": "OK"
         },
-        "startedDateTime": "2025-10-03T22:34:08.695Z",
-        "time": 62,
+        "startedDateTime": "2026-02-23T21:48:32.422Z",
+        "time": 167,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -451,7 +455,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 62
+          "wait": 167
         }
       }
     ],

--- a/src/test/snapshots/ops/SecretStoreOps.test.js.snap
+++ b/src/test/snapshots/ops/SecretStoreOps.test.js.snap
@@ -706,11 +706,37 @@ exports[`SecretStoreOps Cloud Tests exportSecretStores() 2: Export global Secret
 `;
 
 exports[`SecretStoreOps Cloud Tests importSecretStores() 1: Import ESV secret store 1`] = `
-"TESTING ERROR: Expected a FrodoError, but got a different error.
-Message: Request failed with status code 400"
+[
+  {
+    "_id": "ESV",
+    "_rev": "325689269",
+    "_type": {
+      "_id": "GoogleSecretManagerSecretStoreProvider",
+      "collection": true,
+      "name": "Google Secret Manager",
+    },
+    "expiryDurationSeconds": 600,
+    "mappings": [
+      {
+        "_id": "am.services.oauth2.oidc.signing.EDDSA",
+        "_rev": "1919880477",
+        "_type": {
+          "_id": "mappings",
+          "collection": true,
+          "name": "Mappings",
+        },
+        "aliases": [
+          "esv-test",
+        ],
+        "secretId": "am.services.oauth2.oidc.signing.EDDSA",
+      },
+    ],
+    "project": "&{google.project.id}",
+    "secretFormat": "PEM",
+    "serviceAccount": "default",
+  },
+]
 `;
-
-exports[`SecretStoreOps Cloud Tests importSecretStores() 1: Import ESV secret store 2`] = `[]`;
 
 exports[`SecretStoreOps Cloud Tests readSecretStore() 1: Read ESV secret store 1`] = `
 {

--- a/src/test/snapshots/ops/SecretStoreOps.test.js.snap
+++ b/src/test/snapshots/ops/SecretStoreOps.test.js.snap
@@ -698,6 +698,13 @@ exports[`SecretStoreOps Cloud Tests exportSecretStores() 1: Export realm SecretS
 }
 `;
 
+exports[`SecretStoreOps Cloud Tests exportSecretStores() 2: Export global SecretStores 1`] = `
+{
+  "meta": Any<Object>,
+  "secretstore": {},
+}
+`;
+
 exports[`SecretStoreOps Cloud Tests importSecretStores() 1: Import ESV secret store 1`] = `
 "TESTING ERROR: Expected a FrodoError, but got a different error.
 Message: Request failed with status code 400"
@@ -859,6 +866,8 @@ exports[`SecretStoreOps Cloud Tests readSecretStores() 1: Read realm SecretStore
   },
 ]
 `;
+
+exports[`SecretStoreOps Cloud Tests readSecretStores() 2: Read global SecretStores 1`] = `[]`;
 
 exports[`SecretStoreOps Cloud Tests updateSecretStoreMapping() 1: Update ESV secret store mapping 1`] = `
 {


### PR DESCRIPTION
This PR fixes two minor bugs I discovered for the ESV secretstores:

1. The root realm throws a 403 error when doing a full export. We typically ignore these errors in other places in Frodo, so I modified it so it ignores that error when doing the full export.
2. Secret store mapping imports do not work when the mapping contains the _rev attribute (throws a 400 error when it does), so I updated it to remove that attribute before making the PUT request (and updated tests accordingly). 

No test updates need to be made to the CLI for these changes.