### PR TITLE
Add import Raw functions for config manager push commands

### DIFF
--- a/src/api/RawConfigApi.ts
+++ b/src/api/RawConfigApi.ts
@@ -3,6 +3,7 @@ import util from 'util';
 import { State } from '../shared/State';
 import { getHostOnlyUrl, getIdmBaseUrl } from '../utils/ForgeRockUtils';
 import { generateAmApi, generateEnvApi, generateIdmApi } from './BaseApi';
+import { IdObjectSkeletonInterface } from './ApiTypes';
 
 const amTemplate: string = '%s/%s';
 const idmTemplate: string = '%s/%s';
@@ -91,5 +92,81 @@ export async function getRawEnv({
     state,
   }).get(urlString, { withCredentials: true });
 
+  return data;
+}
+
+/**
+ * Performs a put request against the specified AM endpoint
+ * @param {string} endpoint The AM endpoint (e.g. if full URL is https://<tenant-host>/am/<endpoint>, <endpoint> is the value to pass in)
+ * @param {IdObjectSkeletonInterface} payload The AM object data to write to the specified endpoint
+ * @param {ApiVersion} apiVersion The API version to use. Defaults to 2.0 for protocol and 1.0 for resource.
+ * @returns {Promise<any>} The response data from the endpoint
+ */
+export async function putRawAm({
+  endpoint,
+  payload,
+  apiVersion,
+  state,
+}: {
+  endpoint: string;
+  payload: IdObjectSkeletonInterface;
+  apiVersion?: ApiVersion;
+  state: State;
+}): Promise<any> {
+  const urlString = util.format(amTemplate, state.getHost(), endpoint);
+  const { data } = await generateAmApi({
+    resource: getApiConfig(apiVersion),
+    state,
+  }).put(urlString, payload, { withCredentials: true });
+  return data;
+}
+
+/**
+ * Performs a put request against the specified IDM endpoint
+ * @param {string} endpoint The IDM endpoint (e.g. if full URL is https://<tenant-host>/openidm/<endpoint>, <endpoint> is the value to pass in)
+ * @param {IdObjectSkeletonInterface} payload The IDM object data to write to the specified endpoint
+ * @returns {Promise<any>} The response data from the endpoint
+ */
+export async function putRawIdm({
+  endpoint,
+  payload,
+  state,
+}: {
+  endpoint: string;
+  payload: IdObjectSkeletonInterface;
+  state: State;
+}): Promise<any> {
+  const urlString = util.format(idmTemplate, getIdmBaseUrl(state), endpoint);
+  const { data } = await generateIdmApi({ state }).put(urlString, payload);
+  return data;
+}
+
+/**
+ * Performs a put request against the specified Environment endpoint
+ * @param {string} endpoint The Environment endpoint (e.g. if full URL is https://<tenant-host>/environment/<endpoint>, <endpoint> is the value to pass in)
+ * @param {IdObjectSkeletonInterface} payload The object data to write to the specified endpoint
+ * @param {ApiVersion} apiVersion The API version to use. Defaults to 2.0 for protocol and 1.0 for resource.
+ * @returns {Promise<any>} The response data from the endpoint
+ */
+export async function putRawEnv({
+  endpoint,
+  payload,
+  apiVersion,
+  state,
+}: {
+  endpoint: string;
+  payload: IdObjectSkeletonInterface;
+  apiVersion?: ApiVersion;
+  state: State;
+}): Promise<any> {
+  const urlString = util.format(
+    envTemplate,
+    getHostOnlyUrl(state.getHost()),
+    endpoint
+  );
+  const { data } = await generateEnvApi({
+    resource: getApiConfig(apiVersion),
+    state,
+  }).put(urlString, payload, { withCredentials: true });
   return data;
 }

--- a/src/ops/RawConfigOps.test.ts
+++ b/src/ops/RawConfigOps.test.ts
@@ -1,0 +1,118 @@
+/**
+ * To record and update snapshots, you must perform 3 steps in order:
+ *
+ * 1. Record API responses & update ESM snapshots
+ *
+ *    To record and update ESM snapshots, you must call the test:record
+ *    script and override all the connection state variables required
+ *    to connect to the env to record from:
+ *
+ *        FRODO_DEBUG=1 FRODO_HOST=frodo-dev npm run test:record EmailTemplateOps
+ *
+ *    The above command assumes that you have a connection profile for
+ *    'frodo-dev' on your development machine.
+ *
+ * 2. Update CJS snapshots
+ *
+ *    After recording, the ESM snapshots will already be updated as that happens
+ *    in one go, but you musty manually update the CJS snapshots by running:
+ *
+ *        FRODO_DEBUG=1 npm run test:update EmailTemplateOps
+ *
+ * 3. Test your changes
+ *
+ *    If 1 and 2 didn't produce any errors, you are ready to run the tests in
+ *    replay mode and make sure they all succeed as well:
+ *
+ *        npm run test:only EmailTemplateOps
+ *
+ * Note: FRODO_DEBUG=1 is optional and enables debug logging for some output
+ * in case things don't function as expected
+ */
+import { state } from '../index';
+import { customNode1, customNode2 } from '../test/setup/NodeSetup';
+import { template1, template2 } from '../test/setup/EmailTemplateSetup';
+import { variable1, variable2 } from '../test/setup/VariablesSetup';
+import * as TestData from '../test/setup/RawConfigSetup';
+import * as RawConfigOps from './RawConfigOps';
+import { EMAIL_TEMPLATE_TYPE } from './EmailTemplateOps';
+import { encode } from '../utils/Base64Utils';
+
+describe('RawConfigOps', () => {
+  TestData.setup();
+
+  describe('exportRawConfig()', () => {
+    test('0: Method is implemented', async () => {
+      expect(RawConfigOps.exportRawConfig).toBeDefined();
+    });
+
+    test('1: Export raw config am', async () => {
+      const response = await RawConfigOps.exportRawConfig({
+        options: {
+          path: '/am/json/node-designer/node-type/' + customNode1._id,
+          overrides: { _id: 'test' },
+          pushApiVersion: { protocol: '2.1', resource: '2.0' },
+        },
+        state,
+      });
+      expect(response._id).toBe('test');
+      expect(response).toMatchSnapshot();
+    });
+
+    test('2: Export raw config openidm', async () => {
+      const response = await RawConfigOps.exportRawConfig({
+        options: {
+          path: `/openidm/config/${EMAIL_TEMPLATE_TYPE}/${template1._id}`,
+        },
+        state,
+      });
+      expect(response).toMatchSnapshot();
+    });
+
+    test('3: Export raw config environment', async () => {
+      const response = await RawConfigOps.exportRawConfig({
+        options: { path: '/environment/variables/' + variable1._id },
+        state,
+      });
+      expect(response).toMatchSnapshot();
+    });
+  });
+
+  describe('importRawConfig()', () => {
+    test('0: Method is implemented', async () => {
+      expect(RawConfigOps.importRawConfig).toBeDefined();
+    });
+
+    test(`1: importRawConfig am`, async () => {
+      const response = await RawConfigOps.importRawConfig({
+        options: {
+          path: '/am/json/node-designer/node-type/' + customNode2._id,
+        },
+        data: customNode2,
+        state,
+      });
+      expect(response).toMatchSnapshot();
+    });
+
+    test(`2: importRawConfig openidm`, async () => {
+      const response = await RawConfigOps.importRawConfig({
+        options: { path: '/openidm/config/' + template2._id },
+        data: template2,
+        state,
+      });
+      expect(response).toMatchSnapshot();
+    });
+
+    test(`3: importRawConfig environment`, async () => {
+      const variable = { ...variable2 };
+      variable.valueBase64 = encode(variable.value);
+      delete variable.value;
+      const response = await RawConfigOps.importRawConfig({
+        options: { path: '/environment/variables/' + variable2._id },
+        data: variable,
+        state,
+      });
+      expect(response).toMatchSnapshot();
+    });
+  });
+});

--- a/src/ops/RawConfigOps.ts
+++ b/src/ops/RawConfigOps.ts
@@ -4,6 +4,9 @@ import {
   getRawAm,
   getRawEnv,
   getRawIdm,
+  putRawAm,
+  putRawEnv,
+  putRawIdm,
 } from '../api/RawConfigApi';
 import { State } from '../shared/State';
 import { mergeDeep } from '../utils/JsonUtils';
@@ -18,6 +21,16 @@ export type RawConfig = {
   exportRawConfig(
     options: RawExportOptions
   ): Promise<IdObjectSkeletonInterface>;
+  /**
+   * Imports raw configuration
+   * @param {RawImportOptions} options The import options, including the path to the resource
+   * @param {IdObjectSkeletonInterface} data the import data that will be pushed
+   * @returns {Promise<IdObjectSkeletonInterface>} The raw configuration JSON object at the specified path
+   */
+  importRawConfig(
+    options: RawImportOptions,
+    data: IdObjectSkeletonInterface
+  ): Promise<IdObjectSkeletonInterface>;
 };
 
 export default (state: State): RawConfig => {
@@ -26,6 +39,12 @@ export default (state: State): RawConfig => {
       options: RawExportOptions
     ): Promise<IdObjectSkeletonInterface> {
       return exportRawConfig({ options, state });
+    },
+    async importRawConfig(
+      options: RawImportOptions,
+      data: IdObjectSkeletonInterface
+    ): Promise<IdObjectSkeletonInterface> {
+      return importRawConfig({ options, data, state });
     },
   };
 };
@@ -46,6 +65,16 @@ export interface RawExportOptions {
    * An optional object containing the properties 'protocol' and 'resource' to be used in the API version header. This allows specific values for specific configuration. The default is { protocol: "2.0". resource: "1.0" }. Only used for configuration under /am or /environment
    */
   pushApiVersion?: ApiVersion;
+}
+
+/**
+ * Raw config import options from fr-config-manager (https://github.com/ForgeRock/fr-config-manager/blob/main/docs/raw.md)
+ */
+export interface RawImportOptions {
+  /**
+   * The URL path for the configuration object, relative to the tenant base URL
+   */
+  path: string;
 }
 
 /**
@@ -102,6 +131,71 @@ export async function exportRawConfig({
   } catch (error) {
     throw new FrodoError(
       `Error in exportRawIdm with relative url: ${options.path}`,
+      error
+    );
+  }
+}
+
+/**
+ * Imports raw configuration
+ * @param {RawImportOptions} options The import options, including the path to the resource
+ * @param {IdObjectSkeletonInterface} data the import data that will be pushed
+ * @returns {Promise<IdObjectSkeletonInterface>} The raw configuration JSON object at the specified path
+ */
+export async function importRawConfig({
+  options,
+  data,
+  state,
+}: {
+  options: RawImportOptions;
+  data: IdObjectSkeletonInterface;
+  state: State;
+}): Promise<IdObjectSkeletonInterface> {
+  try {
+    let response: IdObjectSkeletonInterface;
+
+    // remove starting slash from path if it exists
+    const path = options.path.startsWith('/')
+      ? options.path.substring(1)
+      : options.path;
+
+    const urlParts: string[] = path.split('/');
+    const startPath: string = urlParts[0];
+    const noStart: string = urlParts.slice(1).join('/');
+
+    const { _pushApiVersion, ...payload } = data;
+
+    // support for only three root paths: am, openidm, and environment
+    switch (startPath) {
+      case 'am':
+        response = await putRawAm({
+          endpoint: noStart,
+          payload,
+          apiVersion: _pushApiVersion as ApiVersion,
+          state,
+        });
+        break;
+      case 'openidm':
+        response = await putRawIdm({ endpoint: noStart, payload, state });
+        break;
+      case 'environment':
+        response = await putRawEnv({
+          endpoint: noStart,
+          payload,
+          apiVersion: _pushApiVersion as ApiVersion,
+          state,
+        });
+        break;
+      default:
+        throw new FrodoError(
+          `URL paths that start with ${startPath} are not supported`
+        );
+    }
+
+    return response;
+  } catch (error) {
+    throw new FrodoError(
+      `Error in importRawConfig with relative url: ${options.path}`,
       error
     );
   }

--- a/src/ops/cloud/VariablesOps.test.ts
+++ b/src/ops/cloud/VariablesOps.test.ts
@@ -33,362 +33,16 @@
  * in case things don't function as expected
  */
 
-import { autoSetupPolly } from '../../utils/AutoSetupPolly';
-import { filterRecording } from '../../utils/PollyUtils';
 import { state } from '../../index';
 import * as VariablesOps from './VariablesOps';
 import { VariableExpressionType } from '../../api/cloud/VariablesApi';
 import { FrodoError } from '../FrodoError';
 import { encode } from '../../utils/Base64Utils';
-
-const ctx = autoSetupPolly();
-
-async function stageVariable(
-  variable: {
-    id: string;
-    value: string;
-    description: string;
-    expressionType: string;
-  },
-  create = true
-) {
-  // delete if exists, then create
-  try {
-    await VariablesOps.deleteVariable({ variableId: variable.id, state });
-  } catch (error) {
-    // ignore
-  } finally {
-    if (create) {
-      await VariablesOps.createVariable({
-        variableId: variable.id,
-        value: variable.value,
-        description: variable.description,
-        expressionType: variable.expressionType as VariableExpressionType,
-        state: state,
-      });
-    }
-  }
-}
+import * as TestData from '../../test/setup/VariablesSetup'
 
 describe('VariablesOps', () => {
-  const variable1 = {
-    id: 'esv-frodo-test-variable-1',
-    value: 'value1',
-    description: 'description1',
-    expressionType: 'string',
-  };
-  const variable2 = {
-    id: 'esv-frodo-test-variable-2',
-    value: '42',
-    description: 'description2',
-    expressionType: 'int',
-  };
-  const variable3 = {
-    id: 'esv-frodo-test-variable-3',
-    value: 'true',
-    description: 'description3',
-    expressionType: 'bool',
-  };
-  const variable4 = {
-    id: 'esv-frodo-test-variable-4',
-    value: 'value4',
-    description: 'description4',
-    expressionType: 'string',
-  };
-  const variable4Export: VariablesOps.VariablesExportInterface = {
-    meta: {
-      exportDate: '2024-07-03T03:29:28.835Z',
-      exportTool: 'frodo',
-      exportToolVersion: 'v2.0.0-89 [v20.5.1]',
-      exportedBy: 'volker.scheuber@forgerock.com',
-      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
-      originAmVersion: '7.6.0',
-    },
-    variable: {
-      'esv-frodo-test-variable-4': {
-        _id: 'esv-frodo-test-variable-4',
-        description: 'description4',
-        expressionType: 'string',
-        lastChangeDate: '2024-07-03T03:28:19.227876Z',
-        lastChangedBy: 'volker.scheuber@forgerock.com',
-        loaded: false,
-        value: 'value4',
-      },
-    },
-  };
-  const variable5 = {
-    id: 'esv-frodo-test-variable-5',
-    value: 'value5',
-    description: 'description5',
-    expressionType: 'string',
-  };
-  const variable5Export: VariablesOps.VariablesExportInterface = {
-    meta: {
-      exportDate: '2024-07-03T03:29:28.835Z',
-      exportTool: 'frodo',
-      exportToolVersion: 'v2.0.0-89 [v20.5.1]',
-      exportedBy: 'volker.scheuber@forgerock.com',
-      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
-      originAmVersion: '7.6.0',
-    },
-    variable: {
-      'esv-frodo-test-variable-5': {
-        _id: 'esv-frodo-test-variable-5',
-        description: 'description5',
-        expressionType: 'string',
-        lastChangeDate: '2024-07-03T03:28:19.227876Z',
-        lastChangedBy: 'volker.scheuber@forgerock.com',
-        loaded: false,
-        value: 'value5',
-      },
-    },
-  };
-  const variable6 = {
-    id: 'esv-frodo-test-variable-6',
-    value: 'value6',
-    description: 'description6',
-    expressionType: 'string',
-  };
-  const variable6Export: VariablesOps.VariablesExportInterface = {
-    meta: {
-      exportDate: '2024-07-03T03:29:28.835Z',
-      exportTool: 'frodo',
-      exportToolVersion: 'v2.0.0-89 [v20.5.1]',
-      exportedBy: 'volker.scheuber@forgerock.com',
-      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
-      originAmVersion: '7.6.0',
-    },
-    variable: {
-      'esv-frodo-test-variable-6': {
-        _id: 'esv-frodo-test-variable-6',
-        description: 'description6',
-        expressionType: 'string',
-        lastChangeDate: '2024-07-03T03:28:19.227876Z',
-        lastChangedBy: 'volker.scheuber@forgerock.com',
-        loaded: false,
-        value: 'value6',
-      },
-    },
-  };
-  const variable7 = {
-    id: 'esv-frodo-test-variable-7',
-    value: 'value7',
-    description: 'description7',
-    expressionType: 'string',
-  };
-  const variable7Export: VariablesOps.VariablesExportInterface = {
-    meta: {
-      exportDate: '2024-07-03T03:29:28.835Z',
-      exportTool: 'frodo',
-      exportToolVersion: 'v2.0.0-89 [v20.5.1]',
-      exportedBy: 'volker.scheuber@forgerock.com',
-      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
-      originAmVersion: '7.6.0',
-    },
-    variable: {
-      'esv-frodo-test-variable-7': {
-        _id: 'esv-frodo-test-variable-7',
-        description: 'description7',
-        expressionType: 'string',
-        lastChangeDate: '2024-07-03T03:28:19.227876Z',
-        lastChangedBy: 'volker.scheuber@forgerock.com',
-        loaded: false,
-        value: 'value7',
-      },
-    },
-  };
-  const variable8 = {
-    id: 'esv-frodo-test-variable-8',
-    value: 'value8',
-    description: 'description8',
-    expressionType: 'string',
-  };
-  const variable9 = {
-    id: 'esv-frodo-test-variable-9',
-    value: 'value9',
-    description: 'description9',
-    expressionType: 'string',
-  };
-  const variables89Export: VariablesOps.VariablesExportInterface = {
-    meta: {
-      exportDate: '2024-07-03T03:48:18.901Z',
-      exportTool: 'frodo',
-      exportToolVersion: 'v2.0.0-89 [v20.5.1]',
-      exportedBy: 'volker.scheuber@forgerock.com',
-      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
-      originAmVersion: '7.6.0',
-    },
-    variable: {
-      'esv-frodo-test-variable-8': {
-        _id: 'esv-frodo-test-variable-8',
-        description: 'description8',
-        expressionType: 'string',
-        lastChangeDate: '2024-07-03T03:46:04.882539Z',
-        lastChangedBy: 'Frodo-SA-1701393386423',
-        loaded: false,
-        value: 'value8',
-        valueBase64: 'dmFsdWU4',
-      },
-      'esv-frodo-test-variable-9': {
-        _id: 'esv-frodo-test-variable-9',
-        description: 'description9',
-        expressionType: 'string',
-        lastChangeDate: '2024-07-03T03:46:05.676501Z',
-        lastChangedBy: 'Frodo-SA-1701393386423',
-        loaded: false,
-        value: 'value9',
-        valueBase64: 'dmFsdWU5',
-      },
-    },
-  };
-  const variable10 = {
-    id: 'esv-frodo-test-variable-10',
-    value: 'value10',
-    description: 'description10',
-    expressionType: 'string',
-  };
-  const variable11 = {
-    id: 'esv-frodo-test-variable-11',
-    value: 'value11',
-    description: 'description11',
-    expressionType: 'string',
-  };
-  const variables1011Export: VariablesOps.VariablesExportInterface = {
-    meta: {
-      exportDate: '2024-07-03T03:48:18.901Z',
-      exportTool: 'frodo',
-      exportToolVersion: 'v2.0.0-89 [v20.5.1]',
-      exportedBy: 'volker.scheuber@forgerock.com',
-      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
-      originAmVersion: '7.6.0',
-    },
-    variable: {
-      'esv-frodo-test-variable-10': {
-        _id: 'esv-frodo-test-variable-10',
-        description: 'description10',
-        expressionType: 'string',
-        lastChangeDate: '2024-07-03T03:45:51.06282Z',
-        lastChangedBy: 'Frodo-SA-1701393386423',
-        loaded: false,
-        value: 'value10',
-        valueBase64: 'dmFsdWUxMA==',
-      },
-      'esv-frodo-test-variable-11': {
-        _id: 'esv-frodo-test-variable-11',
-        description: 'description11',
-        expressionType: 'string',
-        lastChangeDate: '2024-07-03T03:45:52.248873Z',
-        lastChangedBy: 'Frodo-SA-1701393386423',
-        loaded: false,
-        value: 'value11',
-        valueBase64: 'dmFsdWUxMQ==',
-      },
-    },
-  };
-  const variable12 = {
-    id: 'esv-frodo-test-variable-12',
-    value: 'value12',
-    description: 'description12',
-    expressionType: 'string',
-  };
-  const variable13 = {
-    id: 'esv-frodo-test-variable-13',
-    value: 'value13',
-    description: 'description13',
-    expressionType: 'string',
-  };
-  const variable14 = {
-    id: 'esv-frodo-test-variable-14',
-    value: 'value14',
-    description: 'description14',
-    expressionType: 'string',
-  };
-  const variable15 = {
-    id: 'esv-frodo-test-variable-15',
-    value: 'value15',
-    description: 'description15',
-    expressionType: 'string',
-  };
-  const variable16 = {
-    id: 'esv-frodo-test-variable-16',
-    value: 'value16',
-    description: 'description16',
-    expressionType: 'string',
-  };
-  const variable17 = {
-    id: 'esv-frodo-test-variable-17',
-    value: 'value17',
-    description: 'description17',
-    expressionType: 'string',
-  };
-  const variable18 = {
-    id: 'esv-frodo-test-variable-18',
-    value: 'value18',
-    description: 'description18',
-    expressionType: 'string',
-  };
-  const variable19 = {
-    id: 'esv-frodo-test-variable-19',
-    value: 'value19',
-    description: 'description19',
-    expressionType: 'string',
-  };
-  // filter out secrets when recording
-  beforeEach(async () => {
-    if (process.env.FRODO_POLLY_MODE === 'record') {
-      ctx.polly.server.any().on('beforePersist', (_req, recording) => {
-        filterRecording(recording);
-      });
-    }
-  });
-  // in recording mode, setup test data before recording
-  beforeAll(async () => {
-    if (process.env.FRODO_POLLY_MODE === 'record') {
-      await stageVariable(variable1);
-      await stageVariable(variable2);
-      await stageVariable(variable3, false);
-      await stageVariable(variable4, false);
-      await stageVariable(variable5, false);
-      await stageVariable(variable6, false);
-      await stageVariable(variable7, false);
-      await stageVariable(variable8, false);
-      await stageVariable(variable9, false);
-      await stageVariable(variable10, false);
-      await stageVariable(variable11, false);
-      await stageVariable(variable12, false);
-      await stageVariable(variable13, false);
-      await stageVariable(variable14);
-      await stageVariable(variable15);
-      await stageVariable(variable16, false);
-      await stageVariable(variable17, false);
-      await stageVariable(variable18);
-      await stageVariable(variable19);
-    }
-  });
-  // in recording mode, remove test data after recording
-  afterAll(async () => {
-    if (process.env.FRODO_POLLY_MODE === 'record') {
-      await stageVariable(variable1, false);
-      await stageVariable(variable2, false);
-      await stageVariable(variable3, false);
-      await stageVariable(variable4, false);
-      await stageVariable(variable5, false);
-      await stageVariable(variable6, false);
-      await stageVariable(variable7, false);
-      await stageVariable(variable8, false);
-      await stageVariable(variable9, false);
-      await stageVariable(variable10, false);
-      await stageVariable(variable11, false);
-      await stageVariable(variable12, false);
-      await stageVariable(variable13, false);
-      await stageVariable(variable14, false);
-      await stageVariable(variable15, false);
-      await stageVariable(variable16, false);
-      await stageVariable(variable17, false);
-      await stageVariable(variable18, false);
-      await stageVariable(variable19, false);
-    }
-  });
+
+  TestData.setup();
 
   describe('createVariablesExportTemplate()', () => {
     test('0: Method is implemented', async () => {
@@ -438,7 +92,7 @@ describe('VariablesOps', () => {
 
     test('1: Export variable1', async () => {
       const response = await VariablesOps.exportVariable({
-        variableId: variable1.id,
+        variableId: TestData.variable1._id,
         noDecode: false,
         state: state,
       });
@@ -449,7 +103,7 @@ describe('VariablesOps', () => {
 
     test('2: Export variable2 without decoding', async () => {
       const response = await VariablesOps.exportVariable({
-        variableId: variable2.id,
+        variableId: TestData.variable2._id,
         noDecode: true,
         state: state,
       });
@@ -462,7 +116,7 @@ describe('VariablesOps', () => {
       expect.assertions(2);
       try {
         await VariablesOps.exportVariable({
-          variableId: variable3.id,
+          variableId: TestData.variable3._id,
           noDecode: false,
           state: state,
         });
@@ -502,7 +156,7 @@ describe('VariablesOps', () => {
 
     test('1: Read variable1', async () => {
       const response = await VariablesOps.readVariable({
-        variableId: variable1.id,
+        variableId: TestData.variable1._id,
         noDecode: false,
         state: state,
       });
@@ -511,7 +165,7 @@ describe('VariablesOps', () => {
 
     test('2: Read variable2 without decoding', async () => {
       const response = await VariablesOps.readVariable({
-        variableId: variable2.id,
+        variableId: TestData.variable2._id,
         noDecode: true,
         state: state,
       });
@@ -522,7 +176,7 @@ describe('VariablesOps', () => {
       expect.assertions(2);
       try {
         await VariablesOps.readVariable({
-          variableId: variable3.id,
+          variableId: TestData.variable3._id,
           noDecode: false,
           state: state,
         });
@@ -540,8 +194,8 @@ describe('VariablesOps', () => {
 
     test('1: Import variable4', async () => {
       const response = await VariablesOps.importVariable({
-        variableId: variable4.id,
-        importData: variable4Export,
+        variableId: TestData.variable4._id,
+        importData: TestData.createTestVariableExport([TestData.variable4]),
         state: state,
       });
       expect(response).toMatchSnapshot();
@@ -549,8 +203,8 @@ describe('VariablesOps', () => {
 
     test('2: Import variable5 (decoded)', async () => {
       const response = await VariablesOps.importVariable({
-        variableId: variable5.id,
-        importData: variable5Export,
+        variableId: TestData.variable5._id,
+        importData: TestData.createTestVariableExport([TestData.variable5]),
         state: state,
       });
       expect(response).toMatchSnapshot();
@@ -559,7 +213,7 @@ describe('VariablesOps', () => {
     test('3: Import first variable6', async () => {
       const response = await VariablesOps.importVariable({
         variableId: undefined,
-        importData: variable6Export,
+        importData: TestData.createTestVariableExport([TestData.variable6]),
         state: state,
       });
       expect(response).toMatchSnapshot();
@@ -568,7 +222,7 @@ describe('VariablesOps', () => {
     test('4: Import first variable7 (decoded)', async () => {
       const response = await VariablesOps.importVariable({
         variableId: undefined,
-        importData: variable7Export,
+        importData: TestData.createTestVariableExport([TestData.variable7]),
         state: state,
       });
       expect(response).toMatchSnapshot();
@@ -582,7 +236,7 @@ describe('VariablesOps', () => {
 
     test('1: Import all variables', async () => {
       const response = await VariablesOps.importVariables({
-        importData: variables89Export,
+        importData: TestData.createTestVariableExport([TestData.variable8, TestData.variable9]),
         state: state,
       });
       expect(response).toMatchSnapshot();
@@ -590,7 +244,7 @@ describe('VariablesOps', () => {
 
     test('2: Import all variables (decoded)', async () => {
       const response = await VariablesOps.importVariables({
-        importData: variables1011Export,
+        importData: TestData.createTestVariableExport([TestData.variable10, TestData.variable11]),
         state: state,
       });
       expect(response).toMatchSnapshot();
@@ -604,10 +258,10 @@ describe('VariablesOps', () => {
 
     test('1: Create variable12 (pre-encoded)', async () => {
       const response = await VariablesOps.createVariable({
-        variableId: variable12.id,
-        value: encode(variable12.value),
-        description: variable12.description,
-        expressionType: variable12.expressionType as VariableExpressionType,
+        variableId: TestData.variable12._id,
+        value: encode(TestData.variable12.value),
+        description: TestData.variable12.description,
+        expressionType: TestData.variable12.expressionType as VariableExpressionType,
         noEncode: true,
         state: state,
       });
@@ -616,10 +270,10 @@ describe('VariablesOps', () => {
 
     test('2: Create variable13 (not encoded)', async () => {
       const response = await VariablesOps.createVariable({
-        variableId: variable13.id,
-        value: variable13.value,
-        description: variable13.description,
-        expressionType: variable13.expressionType as VariableExpressionType,
+        variableId: TestData.variable13._id,
+        value: TestData.variable13.value,
+        description: TestData.variable13.description,
+        expressionType: TestData.variable13.expressionType as VariableExpressionType,
         noEncode: false,
         state: state,
       });
@@ -634,10 +288,10 @@ describe('VariablesOps', () => {
 
     test('1: Update existing variable14 (pre-encoded)', async () => {
       const response = await VariablesOps.updateVariable({
-        variableId: variable14.id,
-        value: encode(variable14.value),
-        description: variable14.description,
-        expressionType: variable14.expressionType as VariableExpressionType,
+        variableId: TestData.variable14._id,
+        value: encode(TestData.variable14.value),
+        description: TestData.variable14.description,
+        expressionType: TestData.variable14.expressionType as VariableExpressionType,
         noEncode: true,
         state: state,
       });
@@ -646,10 +300,10 @@ describe('VariablesOps', () => {
 
     test('2: Update existing variable15 (not encoded)', async () => {
       const response = await VariablesOps.updateVariable({
-        variableId: variable15.id,
-        value: variable15.value,
-        description: variable15.description,
-        expressionType: variable15.expressionType as VariableExpressionType,
+        variableId: TestData.variable15._id,
+        value: TestData.variable15.value,
+        description: TestData.variable15.description,
+        expressionType: TestData.variable15.expressionType as VariableExpressionType,
         noEncode: false,
         state: state,
       });
@@ -658,10 +312,10 @@ describe('VariablesOps', () => {
 
     test('3: Update/create non-existing variable16 (pre-encoded)', async () => {
       const response = await VariablesOps.updateVariable({
-        variableId: variable16.id,
-        value: encode(variable16.value),
-        description: variable16.description,
-        expressionType: variable16.expressionType as VariableExpressionType,
+        variableId: TestData.variable16._id,
+        value: encode(TestData.variable16.value),
+        description: TestData.variable16.description,
+        expressionType: TestData.variable16.expressionType as VariableExpressionType,
         noEncode: true,
         state: state,
       });
@@ -670,10 +324,10 @@ describe('VariablesOps', () => {
 
     test('4: Update/create non-existing variable17 (not encoded)', async () => {
       const response = await VariablesOps.updateVariable({
-        variableId: variable17.id,
-        value: variable17.value,
-        description: variable17.description,
-        expressionType: variable17.expressionType as VariableExpressionType,
+        variableId: TestData.variable17._id,
+        value: TestData.variable17.value,
+        description: TestData.variable17.description,
+        expressionType: TestData.variable17.expressionType as VariableExpressionType,
         noEncode: false,
         state: state,
       });
@@ -688,8 +342,8 @@ describe('VariablesOps', () => {
 
     test('1: Update variable18 description', async () => {
       const response = await VariablesOps.updateVariableDescription({
-        variableId: variable18.id,
-        description: variable18.description,
+        variableId: TestData.variable18._id,
+        description: TestData.variable18.description,
         state: state,
       });
       expect(response).toMatchSnapshot();
@@ -703,7 +357,7 @@ describe('VariablesOps', () => {
 
     test('1: Delete variable19', async () => {
       const response = await VariablesOps.deleteVariable({
-        variableId: variable19.id,
+        variableId: TestData.variable19._id,
         state: state,
       });
       expect(response).toMatchSnapshot();
@@ -713,7 +367,7 @@ describe('VariablesOps', () => {
       expect.assertions(2);
       try {
         await VariablesOps.deleteVariable({
-          variableId: variable3.id,
+          variableId: TestData.variable3._id,
           state: state,
         });
       } catch (e: any) {

--- a/src/test/mock-recordings/RawConfigOps_1553594733/exportRawConfig_3913946198/1-Export-raw-config-am_1331050674/recording.har
+++ b/src/test/mock-recordings/RawConfigOps_1553594733/exportRawConfig_3913946198/1-Export-raw-config-am_1331050674/recording.har
@@ -1,0 +1,165 @@
+{
+  "log": {
+    "_recordingName": "RawConfigOps/exportRawConfig()/1: Export raw config am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "0fd5b8444ee4325c096dbe851da4a968",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-24"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ba652515-18a6-4f1e-b6c7-98c9e5811271"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2033,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/node-designer/node-type/a605506774a848f7877b4d17a453bd39-1"
+        },
+        "response": {
+          "bodySize": 547,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 547,
+            "text": "{\"_id\":\"a605506774a848f7877b4d17a453bd39-1\",\"_rev\":\"2897436\",\"serviceName\":\"a605506774a848f7877b4d17a453bd39\",\"version\":1,\"displayName\":\"Has Session - TEST\",\"description\":\"Checks if the user has a current session.\",\"outcomes\":[\"True\",\"False\"],\"outputs\":[],\"inputs\":[],\"script\":\"var SCRIPT_OUTCOMES = {\\n    TRUE: 'True',\\n    FALSE: 'False'\\n}\\n\\nfunction main() {\\n    action.goTo(typeof existingSession === \\\"undefined\\\" ? SCRIPT_OUTCOMES.FALSE : SCRIPT_OUTCOMES.TRUE);\\n}\\n\\nmain();\\n\",\"errorOutcome\":false,\"tags\":[\"utilities\"],\"properties\":{}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"2897436\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "547"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Mar 2026 21:03:03 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ba652515-18a6-4f1e-b6c7-98c9e5811271"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 783,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-11T21:03:03.142Z",
+        "time": 83,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 83
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/RawConfigOps_1553594733/exportRawConfig_3913946198/2-Export-raw-config-openidm_2942430219/recording.har
+++ b/src/test/mock-recordings/RawConfigOps_1553594733/exportRawConfig_3913946198/2-Export-raw-config-openidm_2942430219/recording.har
@@ -1,0 +1,157 @@
+{
+  "log": {
+    "_recordingName": "RawConfigOps/exportRawConfig()/2: Export raw config openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "c895e106bcb39dd27a2d267154431b99",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-24"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ba652515-18a6-4f1e-b6c7-98c9e5811271"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1972,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/emailTemplate/FrodoTestEmailTemplate1"
+        },
+        "response": {
+          "bodySize": 511,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 511,
+            "text": "{\"_id\":\"emailTemplate/FrodoTestEmailTemplate1\",\"defaultLocale\":\"en\",\"displayName\":\"Frodo Test Email Template One\",\"enabled\":true,\"from\":\"\",\"message\":{\"en\":\"<h3>Click to reset your password</h3><h4><a href=\\\"{{object.resumeURI}}\\\">Password reset link</a></h4>\",\"fr\":\"<h3>Cliquez pour réinitialiser votre mot de passe</h3><h4><a href=\\\"{{object.resumeURI}}\\\">Mot de passe lien de réinitialisation</a></h4>\"},\"mimeType\":\"text/html\",\"subject\":{\"en\":\"Reset your password\",\"fr\":\"Réinitialisez votre mot de passe\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 11 Mar 2026 21:03:03 GMT"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "511"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ba652515-18a6-4f1e-b6c7-98c9e5811271"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 678,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-11T21:03:03.238Z",
+        "time": 50,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 50
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/RawConfigOps_1553594733/exportRawConfig_3913946198/3-Export-raw-config-environment_996280347/recording.har
+++ b/src/test/mock-recordings/RawConfigOps_1553594733/exportRawConfig_3913946198/3-Export-raw-config-environment_996280347/recording.har
@@ -1,0 +1,117 @@
+{
+  "log": {
+    "_recordingName": "RawConfigOps/exportRawConfig()/3: Export raw config environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "08d2dea99990c33037034cf27a34b5ad",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-24"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1943,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/variables/esv-frodo-test-variable-1"
+        },
+        "response": {
+          "bodySize": 219,
+          "content": {
+            "mimeType": "application/json",
+            "size": 219,
+            "text": "{\"_id\":\"esv-frodo-test-variable-1\",\"description\":\"description1\",\"expressionType\":\"string\",\"lastChangeDate\":\"2026-03-11T21:02:59.165396Z\",\"lastChangedBy\":\"Frodo-SA-1773261131370\",\"loaded\":false,\"valueBase64\":\"dmFsdWUx\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Mar 2026 21:03:03 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "219"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "9f6e2b8b-26a0-48c9-839f-098ab58091ff"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-11T21:03:03.298Z",
+        "time": 251,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 251
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/RawConfigOps_1553594733/importRawConfig_118059239/1-importRawConfig-am_72846809/recording.har
+++ b/src/test/mock-recordings/RawConfigOps_1553594733/importRawConfig_118059239/1-importRawConfig-am_72846809/recording.har
@@ -1,0 +1,178 @@
+{
+  "log": {
+    "_recordingName": "RawConfigOps/importRawConfig()/1: importRawConfig am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "01301945c173e73f762aebd7509b339b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1832,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-24"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ba652515-18a6-4f1e-b6c7-98c9e5811271"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "1832"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2055,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"aaaa3fb2f5dc42dd9772bedc93898bd8-1\",\"serviceName\":\"aaaa3fb2f5dc42dd9772bedc93898bd8\",\"displayName\":\"Display State - TEST\",\"description\":\"Debug node that displays the shared and transient state of the journey for debugging purposes.\",\"outcomes\":[\"outcome\"],\"outputs\":[],\"inputs\":[],\"script\":\"var SCRIPT_OUTCOMES = {\\n  OUTCOME: \\\"outcome\\\"\\n};\\n\\nfunction main() {\\n    if (!callbacks.isEmpty()) {\\n        action.goTo(SCRIPT_OUTCOMES.OUTCOME);\\n        return;\\n    }\\n    var keySet = nodeState.keys(); // Java Set<String>\\n    var keys = Array.from(keySet); // Make it into JavaScript array\\n    debugState = {};\\n    for (var i in keys) {\\n        var k = new String(keys[i]);\\n        var item = nodeState.get(k);\\n        if (typeof item === \\\"object\\\") {\\n            debugState[k] = nodeState.getObject(k);\\n        } else {\\n            debugState[k] = nodeState.get(k);\\n        }\\n    }\\n    if (properties.displayFormat === \\\"JSON\\\") {\\n        callbacksBuilder.textOutputCallback(0, `<pre style=\\\"text-align: left;\\\">${JSON.stringify(debugState, null, 2)}</pre>`);\\n        return;\\n    }\\n    callbacksBuilder.textOutputCallback(0, `<table><tr><td style=\\\"border: 1px solid black;\\\">Key</td><td style=\\\"border: 1px solid black;\\\">Value</td></tr>${Array.from(Object.keys(debugState).map(k => `<tr><td style=\\\"border: 1px solid black;\\\"><pre style=\\\"text-align: left;\\\">${k}</pre></td><td style=\\\"border: 1px solid black;\\\"><pre style=\\\"text-align: left;\\\">${debugState[k]}</pre></td></tr>`))}</table>`);\\n}\\n\\nmain();\\n\",\"errorOutcome\":false,\"tags\":[\"debug\",\"testing\"],\"properties\":{\"displayFormat\":{\"title\":\"Display Format\",\"description\":\"The format in which to display the states.\",\"type\":\"STRING\",\"required\":true,\"defaultValue\":\"TABLE\",\"options\":{\"TABLE\":\"HTML Table\",\"JSON\":\"Raw JSON\"},\"multivalued\":false}}}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/node-designer/node-type/aaaa3fb2f5dc42dd9772bedc93898bd8-1"
+        },
+        "response": {
+          "bodySize": 1864,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1864,
+            "text": "{\"_id\":\"aaaa3fb2f5dc42dd9772bedc93898bd8-1\",\"_rev\":\"1283850900\",\"serviceName\":\"aaaa3fb2f5dc42dd9772bedc93898bd8\",\"version\":1,\"displayName\":\"Display State - TEST\",\"description\":\"Debug node that displays the shared and transient state of the journey for debugging purposes.\",\"outcomes\":[\"outcome\"],\"outputs\":[],\"inputs\":[],\"script\":\"var SCRIPT_OUTCOMES = {\\n  OUTCOME: \\\"outcome\\\"\\n};\\n\\nfunction main() {\\n    if (!callbacks.isEmpty()) {\\n        action.goTo(SCRIPT_OUTCOMES.OUTCOME);\\n        return;\\n    }\\n    var keySet = nodeState.keys(); // Java Set<String>\\n    var keys = Array.from(keySet); // Make it into JavaScript array\\n    debugState = {};\\n    for (var i in keys) {\\n        var k = new String(keys[i]);\\n        var item = nodeState.get(k);\\n        if (typeof item === \\\"object\\\") {\\n            debugState[k] = nodeState.getObject(k);\\n        } else {\\n            debugState[k] = nodeState.get(k);\\n        }\\n    }\\n    if (properties.displayFormat === \\\"JSON\\\") {\\n        callbacksBuilder.textOutputCallback(0, `<pre style=\\\"text-align: left;\\\">${JSON.stringify(debugState, null, 2)}</pre>`);\\n        return;\\n    }\\n    callbacksBuilder.textOutputCallback(0, `<table><tr><td style=\\\"border: 1px solid black;\\\">Key</td><td style=\\\"border: 1px solid black;\\\">Value</td></tr>${Array.from(Object.keys(debugState).map(k => `<tr><td style=\\\"border: 1px solid black;\\\"><pre style=\\\"text-align: left;\\\">${k}</pre></td><td style=\\\"border: 1px solid black;\\\"><pre style=\\\"text-align: left;\\\">${debugState[k]}</pre></td></tr>`))}</table>`);\\n}\\n\\nmain();\\n\",\"errorOutcome\":false,\"tags\":[\"debug\",\"testing\"],\"properties\":{\"displayFormat\":{\"title\":\"Display Format\",\"description\":\"The format in which to display the states.\",\"type\":\"STRING\",\"required\":true,\"defaultValue\":\"TABLE\",\"options\":{\"TABLE\":\"HTML Table\",\"JSON\":\"Raw JSON\"},\"multivalued\":false}}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1283850900\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "https://openam-frodo-dev.forgeblocks.com/am/json/node-designer/node-type/aaaa3fb2f5dc42dd9772bedc93898bd8-1"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1864"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Mar 2026 21:03:03 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ba652515-18a6-4f1e-b6c7-98c9e5811271"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 906,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://openam-frodo-dev.forgeblocks.com/am/json/node-designer/node-type/aaaa3fb2f5dc42dd9772bedc93898bd8-1",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2026-03-11T21:03:03.558Z",
+        "time": 145,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 145
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/RawConfigOps_1553594733/importRawConfig_118059239/2-importRawConfig-openidm_2869658630/recording.har
+++ b/src/test/mock-recordings/RawConfigOps_1553594733/importRawConfig_118059239/2-importRawConfig-openidm_2869658630/recording.har
@@ -1,0 +1,166 @@
+{
+  "log": {
+    "_recordingName": "RawConfigOps/importRawConfig()/2: importRawConfig openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ea3e109d0e7fc224418bcf2afc70ea14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 290,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-24"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ba652515-18a6-4f1e-b6c7-98c9e5811271"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "290"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1979,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"FrodoTestEmailTemplate2\",\"defaultLocale\":\"en\",\"displayName\":\"Frodo Test Email Template Two\",\"enabled\":true,\"from\":\"\",\"message\":{\"en\":\"<h3>This is your one-time password:</h3><h4>{{object.description}}</a></h4>\"},\"mimeType\":\"text/html\",\"subject\":{\"en\":\"One-Time Password for login\"}}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/config/FrodoTestEmailTemplate2"
+        },
+        "response": {
+          "bodySize": 290,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 290,
+            "text": "{\"_id\":\"FrodoTestEmailTemplate2\",\"defaultLocale\":\"en\",\"displayName\":\"Frodo Test Email Template Two\",\"enabled\":true,\"from\":\"\",\"message\":{\"en\":\"<h3>This is your one-time password:</h3><h4>{{object.description}}</a></h4>\"},\"mimeType\":\"text/html\",\"subject\":{\"en\":\"One-Time Password for login\"}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 11 Mar 2026 21:03:03 GMT"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "290"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ba652515-18a6-4f1e-b6c7-98c9e5811271"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 678,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-11T21:03:03.712Z",
+        "time": 56,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 56
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/RawConfigOps_1553594733/importRawConfig_118059239/3-importRawConfig-environment_3187597630/recording.har
+++ b/src/test/mock-recordings/RawConfigOps_1553594733/importRawConfig_118059239/3-importRawConfig-environment_3187597630/recording.har
@@ -1,0 +1,126 @@
+{
+  "log": {
+    "_recordingName": "RawConfigOps/importRawConfig()/3: importRawConfig environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "f23579fb32798b97c0722649c7d3623a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 218,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-24"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "218"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1964,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"esv-frodo-test-variable-2\",\"description\":\"description2\",\"expressionType\":\"int\",\"lastChangeDate\":\"2024-07-03T03:28:19.227876Z\",\"lastChangedBy\":\"volker.scheuber@forgerock.com\",\"loaded\":false,\"valueBase64\":\"NDI=\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/variables/esv-frodo-test-variable-2"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "{\"_id\":\"esv-frodo-test-variable-2\",\"description\":\"description2\",\"expressionType\":\"int\",\"lastChangeDate\":\"2026-03-11T21:03:01.986547Z\",\"lastChangedBy\":\"Frodo-SA-1773261131370\",\"loaded\":false,\"valueBase64\":\"NDI=\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 11 Mar 2026 21:03:04 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "212"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "0625ac40-1360-40d9-9785-624961d10666"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-11T21:03:03.777Z",
+        "time": 721,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 721
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/setup/EmailTemplateSetup.ts
+++ b/src/test/setup/EmailTemplateSetup.ts
@@ -79,7 +79,7 @@ export async function stageEmailTemplate(
   template: EmailTemplateOps.EmailTemplateSkeleton,
   createNew = false
 ) {
-  const entityId = `${EMAIL_TEMPLATE_TYPE}/${template.id}`;
+  const entityId = `${EMAIL_TEMPLATE_TYPE}/${template._id}`;
   try {
     await deleteConfigEntity({
       entityId,

--- a/src/test/setup/RawConfigSetup.ts
+++ b/src/test/setup/RawConfigSetup.ts
@@ -1,0 +1,43 @@
+import { state } from '../../index';
+import { autoSetupPolly } from '../../utils/AutoSetupPolly';
+import { filterRecording } from '../../utils/PollyUtils';
+import { stageEmailTemplate, template1, template2 } from './EmailTemplateSetup';
+import { customNode1, customNode2, stageCustomNode } from './NodeSetup';
+import { stageVariable, variable1, variable2 } from './VariablesSetup';
+
+export function setup() {
+  const ctx = autoSetupPolly();
+
+  beforeEach(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      ctx.polly.server.any().on('beforePersist', (_req, recording) => {
+        // Filter recordings
+        filterRecording(recording, true, state);
+      });
+    }
+  });
+
+  // in recording mode, setup test data before recording
+  beforeAll(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      await stageVariable(variable1, true);
+      await stageVariable(variable2);
+      await stageCustomNode(customNode1, true);
+      await stageCustomNode(customNode2);
+      await stageEmailTemplate(template1, true);
+      await stageEmailTemplate(template2);
+    }
+  });
+
+  // in recording mode, remove test data after recording
+  afterAll(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      await stageVariable(variable1);
+      await stageVariable(variable2);
+      await stageCustomNode(customNode1);
+      await stageCustomNode(customNode2);
+      await stageEmailTemplate(template1);
+      await stageEmailTemplate(template2);
+    }
+  });
+}

--- a/src/test/setup/VariablesSetup.ts
+++ b/src/test/setup/VariablesSetup.ts
@@ -1,0 +1,258 @@
+import { autoSetupPolly } from '../../utils/AutoSetupPolly';
+import { filterRecording } from '../../utils/PollyUtils';
+import { state } from '../../index';
+import * as VariablesOps from '../../ops/cloud/VariablesOps';
+import {
+  VariableExpressionType,
+  VariableSkeleton,
+} from '../../api/cloud/VariablesApi';
+
+export const variable1 = createTestVariable({
+  id: 'esv-frodo-test-variable-1',
+  value: 'value1',
+  description: 'description1',
+  expressionType: 'string',
+});
+
+export const variable2 = createTestVariable({
+  id: 'esv-frodo-test-variable-2',
+  value: '42',
+  description: 'description2',
+  expressionType: 'int',
+});
+
+export const variable3 = createTestVariable({
+  id: 'esv-frodo-test-variable-3',
+  value: 'true',
+  description: 'description3',
+  expressionType: 'bool',
+});
+
+export const variable4 = createTestVariable({
+  id: 'esv-frodo-test-variable-4',
+  value: 'value4',
+  description: 'description4',
+  expressionType: 'string',
+});
+
+export const variable5 = createTestVariable({
+  id: 'esv-frodo-test-variable-5',
+  value: 'value5',
+  description: 'description5',
+  expressionType: 'string',
+});
+
+export const variable6 = createTestVariable({
+  id: 'esv-frodo-test-variable-6',
+  value: 'value6',
+  description: 'description6',
+  expressionType: 'string',
+});
+
+export const variable7 = createTestVariable({
+  id: 'esv-frodo-test-variable-7',
+  value: 'value7',
+  description: 'description7',
+  expressionType: 'string',
+});
+
+export const variable8 = createTestVariable({
+  id: 'esv-frodo-test-variable-8',
+  value: 'value8',
+  description: 'description8',
+  expressionType: 'string',
+});
+
+export const variable9 = createTestVariable({
+  id: 'esv-frodo-test-variable-9',
+  value: 'value9',
+  description: 'description9',
+  expressionType: 'string',
+});
+
+export const variable10 = createTestVariable({
+  id: 'esv-frodo-test-variable-10',
+  value: 'value10',
+  description: 'description10',
+  expressionType: 'string',
+});
+
+export const variable11 = createTestVariable({
+  id: 'esv-frodo-test-variable-11',
+  value: 'value11',
+  description: 'description11',
+  expressionType: 'string',
+});
+
+export const variable12 = createTestVariable({
+  id: 'esv-frodo-test-variable-12',
+  value: 'value12',
+  description: 'description12',
+  expressionType: 'string',
+});
+
+export const variable13 = createTestVariable({
+  id: 'esv-frodo-test-variable-13',
+  value: 'value13',
+  description: 'description13',
+  expressionType: 'string',
+});
+
+export const variable14 = createTestVariable({
+  id: 'esv-frodo-test-variable-14',
+  value: 'value14',
+  description: 'description14',
+  expressionType: 'string',
+});
+
+export const variable15 = createTestVariable({
+  id: 'esv-frodo-test-variable-15',
+  value: 'value15',
+  description: 'description15',
+  expressionType: 'string',
+});
+
+export const variable16 = createTestVariable({
+  id: 'esv-frodo-test-variable-16',
+  value: 'value16',
+  description: 'description16',
+  expressionType: 'string',
+});
+
+export const variable17 = createTestVariable({
+  id: 'esv-frodo-test-variable-17',
+  value: 'value17',
+  description: 'description17',
+  expressionType: 'string',
+});
+
+export const variable18 = createTestVariable({
+  id: 'esv-frodo-test-variable-18',
+  value: 'value18',
+  description: 'description18',
+  expressionType: 'string',
+});
+
+export const variable19 = createTestVariable({
+  id: 'esv-frodo-test-variable-19',
+  value: 'value19',
+  description: 'description19',
+  expressionType: 'string',
+});
+
+function createTestVariable({
+  id,
+  description,
+  expressionType,
+  value,
+}: {
+  id: string;
+  description: string;
+  expressionType: VariableExpressionType;
+  value: string;
+}): VariableSkeleton {
+  return {
+    _id: id,
+    description,
+    expressionType,
+    lastChangeDate: '2024-07-03T03:28:19.227876Z',
+    lastChangedBy: 'volker.scheuber@forgerock.com',
+    loaded: false,
+    value,
+  };
+}
+
+export function createTestVariableExport(
+  variables: VariableSkeleton[]
+): VariablesOps.VariablesExportInterface {
+  return {
+    meta: {
+      exportDate: '2024-07-03T03:48:18.901Z',
+      exportTool: 'frodo',
+      exportToolVersion: 'v2.0.0-89 [v20.5.1]',
+      exportedBy: 'volker.scheuber@forgerock.com',
+      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
+      originAmVersion: '7.6.0',
+    },
+    variable: Object.fromEntries(variables.map((v) => [v._id, v])),
+  };
+}
+
+export async function stageVariable(variable: VariableSkeleton, create = true) {
+  // delete if exists, then create
+  await VariablesOps.deleteVariable({ variableId: variable._id, state });
+
+  // ignore
+  if (create) {
+    await VariablesOps.createVariable({
+      variableId: variable._id,
+      value: variable.value,
+      description: variable.description,
+      expressionType: variable.expressionType as VariableExpressionType,
+      state: state,
+    });
+  }
+}
+
+export async function setup() {
+  const ctx = autoSetupPolly();
+
+  // filter out secrets when recording
+  beforeEach(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      ctx.polly.server.any().on('beforePersist', (_req, recording) => {
+        filterRecording(recording);
+      });
+    }
+  });
+
+  // in recording mode, setup test data before recording
+  beforeAll(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      await stageVariable(variable1);
+      await stageVariable(variable2);
+      await stageVariable(variable3, false);
+      await stageVariable(variable4, false);
+      await stageVariable(variable5, false);
+      await stageVariable(variable6, false);
+      await stageVariable(variable7, false);
+      await stageVariable(variable8, false);
+      await stageVariable(variable9, false);
+      await stageVariable(variable10, false);
+      await stageVariable(variable11, false);
+      await stageVariable(variable12, false);
+      await stageVariable(variable13, false);
+      await stageVariable(variable14);
+      await stageVariable(variable15);
+      await stageVariable(variable16, false);
+      await stageVariable(variable17, false);
+      await stageVariable(variable18);
+      await stageVariable(variable19);
+    }
+  });
+
+  // in recording mode, remove test data after recording
+  afterAll(async () => {
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      await stageVariable(variable1, false);
+      await stageVariable(variable2, false);
+      await stageVariable(variable3, false);
+      await stageVariable(variable4, false);
+      await stageVariable(variable5, false);
+      await stageVariable(variable6, false);
+      await stageVariable(variable7, false);
+      await stageVariable(variable8, false);
+      await stageVariable(variable9, false);
+      await stageVariable(variable10, false);
+      await stageVariable(variable11, false);
+      await stageVariable(variable12, false);
+      await stageVariable(variable13, false);
+      await stageVariable(variable14, false);
+      await stageVariable(variable15, false);
+      await stageVariable(variable16, false);
+      await stageVariable(variable17, false);
+      await stageVariable(variable18, false);
+      await stageVariable(variable19, false);
+    }
+  });
+}

--- a/src/test/snapshots/ops/RawConfigOps.test.js.snap
+++ b/src/test/snapshots/ops/RawConfigOps.test.js.snap
@@ -1,0 +1,163 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`RawConfigOps exportRawConfig() 1: Export raw config am 1`] = `
+{
+  "_id": "test",
+  "_pushApiVersion": {
+    "protocol": "2.1",
+    "resource": "2.0",
+  },
+  "_rev": "2897436",
+  "description": "Checks if the user has a current session.",
+  "displayName": "Has Session - TEST",
+  "errorOutcome": false,
+  "inputs": [],
+  "outcomes": [
+    "True",
+    "False",
+  ],
+  "outputs": [],
+  "properties": {},
+  "script": "var SCRIPT_OUTCOMES = {
+    TRUE: 'True',
+    FALSE: 'False'
+}
+
+function main() {
+    action.goTo(typeof existingSession === "undefined" ? SCRIPT_OUTCOMES.FALSE : SCRIPT_OUTCOMES.TRUE);
+}
+
+main();
+",
+  "serviceName": "a605506774a848f7877b4d17a453bd39",
+  "tags": [
+    "utilities",
+  ],
+  "version": 1,
+}
+`;
+
+exports[`RawConfigOps exportRawConfig() 2: Export raw config openidm 1`] = `
+{
+  "_id": "emailTemplate/FrodoTestEmailTemplate1",
+  "defaultLocale": "en",
+  "displayName": "Frodo Test Email Template One",
+  "enabled": true,
+  "from": "",
+  "message": {
+    "en": "<h3>Click to reset your password</h3><h4><a href="{{object.resumeURI}}">Password reset link</a></h4>",
+    "fr": "<h3>Cliquez pour réinitialiser votre mot de passe</h3><h4><a href="{{object.resumeURI}}">Mot de passe lien de réinitialisation</a></h4>",
+  },
+  "mimeType": "text/html",
+  "subject": {
+    "en": "Reset your password",
+    "fr": "Réinitialisez votre mot de passe",
+  },
+}
+`;
+
+exports[`RawConfigOps exportRawConfig() 3: Export raw config environment 1`] = `
+{
+  "_id": "esv-frodo-test-variable-1",
+  "description": "description1",
+  "expressionType": "string",
+  "lastChangeDate": "2026-03-11T21:02:59.165396Z",
+  "lastChangedBy": "Frodo-SA-1773261131370",
+  "loaded": false,
+  "valueBase64": "dmFsdWUx",
+}
+`;
+
+exports[`RawConfigOps importRawConfig() 1: importRawConfig am 1`] = `
+{
+  "_id": "aaaa3fb2f5dc42dd9772bedc93898bd8-1",
+  "_rev": "1283850900",
+  "description": "Debug node that displays the shared and transient state of the journey for debugging purposes.",
+  "displayName": "Display State - TEST",
+  "errorOutcome": false,
+  "inputs": [],
+  "outcomes": [
+    "outcome",
+  ],
+  "outputs": [],
+  "properties": {
+    "displayFormat": {
+      "defaultValue": "TABLE",
+      "description": "The format in which to display the states.",
+      "multivalued": false,
+      "options": {
+        "JSON": "Raw JSON",
+        "TABLE": "HTML Table",
+      },
+      "required": true,
+      "title": "Display Format",
+      "type": "STRING",
+    },
+  },
+  "script": "var SCRIPT_OUTCOMES = {
+  OUTCOME: "outcome"
+};
+
+function main() {
+    if (!callbacks.isEmpty()) {
+        action.goTo(SCRIPT_OUTCOMES.OUTCOME);
+        return;
+    }
+    var keySet = nodeState.keys(); // Java Set<String>
+    var keys = Array.from(keySet); // Make it into JavaScript array
+    debugState = {};
+    for (var i in keys) {
+        var k = new String(keys[i]);
+        var item = nodeState.get(k);
+        if (typeof item === "object") {
+            debugState[k] = nodeState.getObject(k);
+        } else {
+            debugState[k] = nodeState.get(k);
+        }
+    }
+    if (properties.displayFormat === "JSON") {
+        callbacksBuilder.textOutputCallback(0, \`<pre style="text-align: left;">\${JSON.stringify(debugState, null, 2)}</pre>\`);
+        return;
+    }
+    callbacksBuilder.textOutputCallback(0, \`<table><tr><td style="border: 1px solid black;">Key</td><td style="border: 1px solid black;">Value</td></tr>\${Array.from(Object.keys(debugState).map(k => \`<tr><td style="border: 1px solid black;"><pre style="text-align: left;">\${k}</pre></td><td style="border: 1px solid black;"><pre style="text-align: left;">\${debugState[k]}</pre></td></tr>\`))}</table>\`);
+}
+
+main();
+",
+  "serviceName": "aaaa3fb2f5dc42dd9772bedc93898bd8",
+  "tags": [
+    "debug",
+    "testing",
+  ],
+  "version": 1,
+}
+`;
+
+exports[`RawConfigOps importRawConfig() 2: importRawConfig openidm 1`] = `
+{
+  "_id": "FrodoTestEmailTemplate2",
+  "defaultLocale": "en",
+  "displayName": "Frodo Test Email Template Two",
+  "enabled": true,
+  "from": "",
+  "message": {
+    "en": "<h3>This is your one-time password:</h3><h4>{{object.description}}</a></h4>",
+  },
+  "mimeType": "text/html",
+  "subject": {
+    "en": "One-Time Password for login",
+  },
+}
+`;
+
+exports[`RawConfigOps importRawConfig() 3: importRawConfig environment 1`] = `
+{
+  "_id": "esv-frodo-test-variable-2",
+  "description": "description2",
+  "expressionType": "int",
+  "lastChangeDate": "2026-03-11T21:03:01.986547Z",
+  "lastChangedBy": "Frodo-SA-1773261131370",
+  "loaded": false,
+  "valueBase64": "NDI=",
+}
+`;


### PR DESCRIPTION
I added API functions to import raw configuration for fr-config-manager push raw command.

I also refactored the variables tests to have a setup file so I could use the same test data for the RawOps functions. 