### PR TITLE
feat: remove creation timestamps by default

### DIFF
--- a/src/utils/ExportImportUtils.ts
+++ b/src/utils/ExportImportUtils.ts
@@ -460,6 +460,9 @@ export function saveJsonToFile({
         'lastChangeDate',
         'lastChangedBy',
         'lastChanged',
+        'createdBy',
+        'creationDate',
+        'createdDate',
       ]
     );
   }


### PR DESCRIPTION
Add a few more fields to excluded fields list when saving JSON data to remove created timestamps by default.