### PR TITLE
Refactor realm naming to allow for dashes in the name

### DIFF
--- a/src/test/mock-recordings/ForgeRockUtils_2197175650/getRealmsForExport_1804686052/1-Get-Realms-in-Export-Format_1292157576/recording.har
+++ b/src/test/mock-recordings/ForgeRockUtils_2197175650/getRealmsForExport_1804686052/1-Get-Realms-in-Export-Format_1292157576/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "ForgeRockUtils/getRealmsForExport/1: Get Realms in Export Format",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "eb697468085abfef6b608e5d514d9750",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-38"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-dcc1f9a0-7c2f-4b87-ac95-2ea729101a41"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 569,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "http://openam-frodo-dev.classic.com:8080/am/json/global-config/realms/?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 1962,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1962,
+            "text": "{\"result\":[{\"_id\":\"Lw\",\"_rev\":\"1024858941\",\"parentPath\":null,\"active\":true,\"name\":\"/\",\"aliases\":[\"openam-frodo-dev.classic.com\",\"am-config\"]},{\"_id\":\"L3Rlc3QtcmVhbG0td2l0aC1kYXNoZXM\",\"_rev\":\"370641471\",\"parentPath\":\"/\",\"active\":true,\"name\":\"test-realm-with-dashes\",\"aliases\":[]},{\"_id\":\"L3Rlc3Q\",\"_rev\":\"1983000027\",\"parentPath\":\"/\",\"active\":true,\"name\":\"test\",\"aliases\":[]},{\"_id\":\"L3Rlc3QvcmVhbG0\",\"_rev\":\"-28313219\",\"parentPath\":\"/test\",\"active\":true,\"name\":\"realm\",\"aliases\":[]},{\"_id\":\"L3Rlc3QvcmVhbG0vd2l0aA\",\"_rev\":\"1901869272\",\"parentPath\":\"/test/realm\",\"active\":true,\"name\":\"with\",\"aliases\":[]},{\"_id\":\"L3Rlc3QvcmVhbG0vd2l0aC9kYXNoZXM\",\"_rev\":\"-1617405148\",\"parentPath\":\"/test/realm/with\",\"active\":true,\"name\":\"dashes\",\"aliases\":[]},{\"_id\":\"L3Rlc3RfcmVhbG1fd2l0aF91bmRlcnNjb3Jl\",\"_rev\":\"-1660714760\",\"parentPath\":\"/\",\"active\":true,\"name\":\"test_realm_with_underscore\",\"aliases\":[]},{\"_id\":\"L2FscGhhLXRlc3Q\",\"_rev\":\"-1522240144\",\"parentPath\":\"/\",\"active\":true,\"name\":\"alpha-test\",\"aliases\":[]},{\"_id\":\"L2FscGhhLXRlc3QvYnJhdm8tdGVzdA\",\"_rev\":\"-44744295\",\"parentPath\":\"/alpha-test\",\"active\":true,\"name\":\"bravo-test\",\"aliases\":[]},{\"_id\":\"L2FscGhhLXRlc3QvYnJhdm8tdGVzdC9jaGFybGllLXRlc3Q\",\"_rev\":\"1792155215\",\"parentPath\":\"/alpha-test/bravo-test\",\"active\":true,\"name\":\"charlie-test\",\"aliases\":[]},{\"_id\":\"L3RyaXBsZS0tLWRhc2gtLS0tLS1mdW4\",\"_rev\":\"1037493590\",\"parentPath\":\"/\",\"active\":true,\"name\":\"triple---dash------fun\",\"aliases\":[]},{\"_id\":\"Ly0tLS0\",\"_rev\":\"-336931627\",\"parentPath\":\"/\",\"active\":true,\"name\":\"----\",\"aliases\":[]},{\"_id\":\"Ly0\",\"_rev\":\"1716068039\",\"parentPath\":\"/\",\"active\":true,\"name\":\"-\",\"aliases\":[]},{\"_id\":\"Ly0t\",\"_rev\":\"1718480574\",\"parentPath\":\"/\",\"active\":true,\"name\":\"--\",\"aliases\":[]},{\"_id\":\"L2FscGhhLS0tLS0tdGVzdA\",\"_rev\":\"725869966\",\"parentPath\":\"/\",\"active\":true,\"name\":\"alpha------test\",\"aliases\":[]}],\"resultCount\":15,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1962"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 27 Apr 2026 17:47:18 GMT"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=20"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 493,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-27T17:47:18.795Z",
+        "time": 32,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 32
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/snapshots/utils/ForgeRockUtils.test.js.snap
+++ b/src/test/snapshots/utils/ForgeRockUtils.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ForgeRockUtils getRealmsForExport 1: Get Realms in Export Format 1`] = `
+[
+  "root",
+  "root-test--realm--with--dashes",
+  "root-test",
+  "root-test-realm",
+  "root-test-realm-with",
+  "root-test-realm-with-dashes",
+  "root-test_realm_with_underscore",
+  "root-alpha--test",
+  "root-alpha--test-bravo--test",
+  "root-alpha--test-bravo--test-charlie--test",
+  "root-triple------dash------------fun",
+  "root---------",
+  "root---",
+  "root-----",
+  "root-alpha------------test",
+]
+`;

--- a/src/utils/ForgeRockUtils.test.ts
+++ b/src/utils/ForgeRockUtils.test.ts
@@ -7,10 +7,34 @@
  * in case things don't function as expected
  */
 import * as ForgeRockUtils from './ForgeRockUtils';
+import { autoSetupPolly, setDefaultState } from "../utils/AutoSetupPolly";
+import { filterRecording } from "../utils/PollyUtils";
 import { state } from '../index';
 import Constants from '../shared/Constants';
 
+const ctx = autoSetupPolly();
+
 describe('ForgeRockUtils', () => {
+  beforeEach(async () => {
+    setDefaultState(Constants.CLASSIC_DEPLOYMENT_TYPE_KEY);
+    if (process.env.FRODO_POLLY_MODE === 'record') {
+      ctx.polly.server.any().on('beforePersist', (_req, recording) => {
+        filterRecording(recording);
+      });
+    }
+  });
+
+  describe('getRealmsForExport', () => {
+    test('0: Method is implemented', async () => {
+      expect(ForgeRockUtils.getRealmsForExport).toBeDefined();
+    });
+
+    test('1: Get Realms in Export Format', async () => {
+      const response = await ForgeRockUtils.getRealmsForExport({ state });
+      expect(response).toMatchSnapshot();
+    });
+  });
+
   describe('getRealmUsingExportFormat()', () => {
     test('Should get root realm', () => {
       const realm = 'root';
@@ -29,6 +53,31 @@ describe('ForgeRockUtils', () => {
       const testString = ForgeRockUtils.getRealmUsingExportFormat(realm);
       expect(testString).toBe('/alpha/beta/gamma');
     });
+
+    test('Should handle hyphen escape', () => {
+      const realm = 'root-alpha--test';
+      const testString = ForgeRockUtils.getRealmUsingExportFormat(realm);
+      expect(testString).toBe('/alpha-test');
+    });
+    
+    test('Should handle nested hyphenated names in realms', () => {
+      const realm = 'root-alpha--test-bravo--test-charlie--test';
+      const testString = ForgeRockUtils.getRealmUsingExportFormat(realm);
+      expect(testString).toBe('/alpha-test/bravo-test/charlie-test');
+    });
+
+    test('Odd number of dashes splits into literal dash + nesting', () => {
+      const realm = 'root-alpha---test';
+      const testString = ForgeRockUtils.getRealmUsingExportFormat(realm);
+      expect(testString).toBe('/alpha-/test');
+    });
+
+    test('Even number of dashes splits into literal dashes only', () => {
+      const realm = 'root-alpha------test';
+      const testString = ForgeRockUtils.getRealmUsingExportFormat(realm);
+      expect(testString).toBe('/alpha---test');
+    });
+  
   });
 
   describe('getConfigPath()', () => {

--- a/src/utils/ForgeRockUtils.ts
+++ b/src/utils/ForgeRockUtils.ts
@@ -116,13 +116,17 @@ export async function getRealmsForExport({
 }: {
   state: State;
 }): Promise<string[]> {
-  return (await getRealms({ state })).map((r) =>
-    !r.name || r.name === '/' || !r.parentPath
-      ? 'root'
-      : `root${r.parentPath.replace('/', '-')}${
-          r.parentPath !== '/' ? '-' : ''
-        }${r.name}`
-  );
+  return (await getRealms({ state })).map((r) => {
+    const names = ['root'];
+    if (r.parentPath)
+      names.push(
+        ...`${r.parentPath}/${r.name}`
+          .replaceAll('-', '--')
+          .split('/')
+          .filter(Boolean)
+      );
+    return names.join('-');
+  });
 }
 
 /**
@@ -132,10 +136,9 @@ export async function getRealmsForExport({
  * @param realm realm in export format
  */
 export function getRealmUsingExportFormat(realm: string): string {
-  if (realm === 'root') {
-    return '/';
-  }
-  return realm.replace('root-', '/').replaceAll('-', '/');
+  return realm === 'root'
+    ? '/'
+    : realm.replace(/^root-|--|-/g, (m) => (m === '--' ? '-' : '/'));
 }
 
 /**


### PR DESCRIPTION
This fixes realm naming for import and exports to allow for dashes in the realm name by escaping '-' using '--' to keep it backwards compatible.