### PR TITLE
Curlirize write through printMessage

### DIFF
--- a/src/ext/axios-curlirize/curlirize.ts
+++ b/src/ext/axios-curlirize/curlirize.ts
@@ -1,12 +1,13 @@
 /* eslint-disable no-console */
+import { printError, printMessage } from '../../utils/Console';
 import { CurlHelper } from './lib/CurlHelper';
 
 function defaultLogCallback(curlResult, err = undefined) {
   const { command } = curlResult;
   if (err) {
-    console.error(err);
+    printError(err);
   } else {
-    console.info(command);
+    printMessage(command['brightBlue']);
   }
 }
 


### PR DESCRIPTION
This resolves a bug where indeterminate loading spinners and curlirize messages were conflicting in the console because they were both being written directly to stderr. This fix pushes curlirize messaging through printMessage and printError so the progress indicators can be cleared and messages printed properly.