### PR TITLE
Bugfix/dup port createpayload

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -3,7 +3,7 @@ name: 'Frodo Library Release Pipeline'
 on:
   pull_request:
     branches:
-      - 'main'
+      - trivir
     paths-ignore:
       - '**/CODE_OF_CONDUCT.md'
       - '**/CONTRIBUTE.md'
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
   push:
     branches:
-      - 'main'
+      - trivir
     paths-ignore:
       - '**/CODE_OF_CONDUCT.md'
       - '**/CONTRIBUTE.md'
@@ -58,13 +58,14 @@ jobs:
         id: version-bump
         uses: 'phips28/gh-action-bump-version@master'
         with:
+          version-type: 'prerelease'
           major-wording: 'MAJOR RELEASE'
           minor-wording: 'MINOR RELEASE'
           patch-wording: 'PATCH RELEASE'
           rc-wording: ''
           tag-prefix: 'v'
           default: prerelease
-          preid: ''
+          preid: 'trivir'
           bump-policy: 'ignore'
           skip-commit: 'true'
           skip-tag: 'true'
@@ -205,7 +206,7 @@ jobs:
           npm audit --omit=dev --audit-level high
 
   npm-release:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/trivir'
     needs: [build, test]
     runs-on: ubuntu-latest
     steps:
@@ -243,10 +244,10 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_ACCESS_TOKEN }}" >> ~/.npmrc
           npm whoami
-          npm dist-tag add @rockcarver/frodo-lib@${{ needs.build.outputs.newVersion }} next
+          npm dist-tag add @trivir/frodo-lib@${{ needs.build.outputs.newVersion }} next
 
   release:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/trivir'
     needs: [build, npm-release]
     name: 'Release'
     runs-on: ubuntu-latest

--- a/jest.config.cjs.json
+++ b/jest.config.cjs.json
@@ -1,0 +1,18 @@
+{
+  "testTimeout": 30000,
+  "testRunner": "jest-jasmine2",
+  "roots": [
+    "<rootDir>/src/"
+  ],
+  "testMatch": [
+    "**/?(*.)(test).ts"
+  ],
+  "testPathIgnorePatterns": [
+    "/node_modules/"
+  ],
+  "transform": {
+    "\\.ts$": ["babel-jest", { "configFile": "./babel.config.cjs.json" }]
+  },
+  "snapshotResolver": "<rootDir>/snapshotResolve.js",
+  "verbose": false
+}

--- a/jest.config.esm.json
+++ b/jest.config.esm.json
@@ -1,0 +1,19 @@
+{
+  "testTimeout": 30000,
+  "testRunner": "jest-jasmine2",
+  "roots": [
+    "<rootDir>/src/"
+  ],
+  "testMatch": [
+    "**/?(*.)(test).ts"
+  ],
+  "testPathIgnorePatterns": [
+    "/node_modules/"
+  ],
+  "transform": {
+    "\\.ts$": ["babel-jest", { "configFile": "./babel.config.esm.json" }]
+  },
+  "extensionsToTreatAsEsm": [".ts"],
+  "snapshotResolver": "<rootDir>/snapshotResolve.js",
+  "verbose": false
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "test": "npm run test:only",
     "test:only": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent",
+    "test:cjs": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --config jest.config.cjs.json",
+    "test:esm": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --config jest.config.esm.json",
     "test:debug": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent=false",
     "test:record": "NODE_OPTIONS=--experimental-vm-modules FRODO_POLLY_MODE=record npx jest --silent=false --runInBand --updateSnapshot",
     "test:record_noauth": "NODE_OPTIONS=--experimental-vm-modules FRODO_POLLY_MODE=record_noauth npx jest --silent=false --updateSnapshot --testPathIgnorePatterns cjs",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rockcarver/frodo-lib",
+  "name": "@trivir/frodo-lib",
   "version": "4.0.0-43",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/src/ops/AdminOps.test.ts
+++ b/src/ops/AdminOps.test.ts
@@ -1,0 +1,25 @@
+import { state } from '../index';
+import * as AdminOps from './AdminOps';
+
+describe('Test AdminOps.getAccessTokeUrl', () => {
+  test('0: Method is implemented', async () => {
+    expect(AdminOps.getAccessTokenUrl).toBeDefined();
+  });
+  test('1: normal call, https & no port', async () => {
+    state.setHost("https://forgetest.someurl.com")
+    expect(AdminOps.getAccessTokenUrl(state)).toBe("https://forgetest.someurl.com:443/oauth2/realms/root/access_token");
+  });
+  test('2: normal call, http & no port', async () => {
+    state.setHost("http://forgetest.someurl.com")
+    expect(AdminOps.getAccessTokenUrl(state)).toBe("http://forgetest.someurl.com:80/oauth2/realms/root/access_token");
+  });
+  test('3: normal call, https & port', async () => {
+    state.setHost("https://forgetest.someurl.com:443")
+    expect(AdminOps.getAccessTokenUrl(state)).toBe("https://forgetest.someurl.com:443/oauth2/realms/root/access_token");
+  });
+  test('4: normal call, http & port', async () => {
+    state.setHost("http://forgetest.someurl.com:80")
+    expect(AdminOps.getAccessTokenUrl(state)).toBe("http://forgetest.someurl.com:80/oauth2/realms/root/access_token");
+  });
+});
+

--- a/src/ops/AdminOps.ts
+++ b/src/ops/AdminOps.ts
@@ -1677,7 +1677,7 @@ export async function trainAA({
   }
 }
 
-function getAccessTokenUrl(state: State) {
+export function getAccessTokenUrl(state: State) {
   const accessTokenUrlTemplate = '%s/oauth2%s/access_token';
   const accessTokenURL = util.format(
     accessTokenUrlTemplate,

--- a/src/ops/AuthenticateOps.test.ts
+++ b/src/ops/AuthenticateOps.test.ts
@@ -111,6 +111,29 @@ describe('AuthenticateOps', () => {
       beforeEach(() => {
         setDefaultState(Constants.CLASSIC_DEPLOYMENT_TYPE_KEY, true);
       });
+      describe('createPayload', () => {
+        test('0: default to port 80', async () => {
+          state.setHost("http://trivirsample.com")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("http://trivirsample.com:80//oauth2/access_token")
+        });
+        test('1: default to port 443', async () => {
+          state.setHost("https://trivirsample.com")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("https://trivirsample.com:443//oauth2/access_token")
+        });
+        test('2: avoid dup port 80', async () => {
+          state.setHost("http://trivirsample.com:80")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("http://trivirsample.com:80//oauth2/access_token")
+        });
+        test('3: avoid dup port 443', async () => {
+          state.setHost("https://trivirsample.com:443")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("https://trivirsample.com:443//oauth2/access_token")
+        });
+      });
+
       describe('getTokens()', () => {  
         test('0: Authenticate successfully as user', async () => {
           // override and reset service account credentials from environment variables in CI/CD pipeline

--- a/src/ops/AuthenticateOps.ts
+++ b/src/ops/AuthenticateOps.ts
@@ -937,10 +937,10 @@ async function getPfUserBearerToken(
   return token;
 }
 
-function createPayload(serviceAccountId: string, host: string) {
+export function createPayload(serviceAccountId: string, host: string) {
   const u = parseUrl(host);
-  const aud = `${u.origin}:${
-    u.port ? u.port : u.protocol === 'https' ? '443' : '80'
+  const aud = `${u.origin}${
+    u.port ? '' : `:${u.protocol === 'https' ? '443' : '80'}`
   }${u.pathname}/oauth2/access_token`;
 
   // Cross platform way of setting JWT expiry time 3 minutes in the future, expressed as number of seconds since EPOCH

--- a/src/shared/Version.test.ts
+++ b/src/shared/Version.test.ts
@@ -2,6 +2,6 @@ import { getUserAgent } from './Version';
 
 describe('Versions', () => {
     test('user agent is compiled from package', () => {
-        expect(getUserAgent()).toMatch(/@rockcarver\/frodo-lib\/[0-9.-]+/);
+        expect(getUserAgent()).toMatch(/@trivir\/frodo-lib\/[0-9.-]+trivir[0-9.]*/);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,6 +66,7 @@
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+     "declarationDir": "./types",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
     /* Interop Constraints */


### PR DESCRIPTION
There's at least two locations that deal with adding the port if missing. Fixes are as follows:

AuthenticateOps.ts - createPayload - Bug found here: :80 or :443 was added again even if already present.
AdminOps.ts - getAccessTokenUrl - no bugs found here.
