### PR TITLE
bugfix: Add AdminOps.test.ts, export getAccessTokenUrl for testing. A…

### DIFF
--- a/src/ops/AdminOps.test.ts
+++ b/src/ops/AdminOps.test.ts
@@ -1,0 +1,26 @@
+import { state } from '../index';
+import * as AdminOps from './AdminOps';
+
+describe('AdminOps', () => {
+  describe('getAccessTokenUrl()', () => {
+    test('0: Method is defined', () => {
+      expect(AdminOps.getAccessTokenUrl).toBeDefined();
+    });
+    test('1: Normal call', () => {
+      state.setHost('https://forgetest.someurl.com');
+      expect(AdminOps.getAccessTokenUrl(state)).toBe('https://forgetest.someurl.com:443/oauth2/realms/root/access_token');
+    });
+    test('2: Normal call - http & no port', () => {
+      state.setHost('http://forgetest.someurl.com');
+      expect(AdminOps.getAccessTokenUrl(state)).toBe('http://forgetest.someurl.com:80/oauth2/realms/root/access_token');
+    });
+    test('3: Normal call - https & no port', () => {
+      state.setHost('https://forgetest.someurl.com:443');
+      expect(AdminOps.getAccessTokenUrl(state)).toBe('https://forgetest.someurl.com:443/oauth2/realms/root/access_token');
+    });
+    test('4: Normal call - http & port', () => {
+      state.setHost('http://forgetest.someurl.com:80');
+      expect(AdminOps.getAccessTokenUrl(state)).toBe('http://forgetest.someurl.com:80/oauth2/readlms/root/access_token');
+    });
+  });
+});

--- a/src/ops/AdminOps.test.ts
+++ b/src/ops/AdminOps.test.ts
@@ -20,7 +20,7 @@ describe('AdminOps', () => {
     });
     test('4: Normal call - http & port', () => {
       state.setHost('http://forgetest.someurl.com:80');
-      expect(AdminOps.getAccessTokenUrl(state)).toBe('http://forgetest.someurl.com:80/oauth2/readlms/root/access_token');
+      expect(AdminOps.getAccessTokenUrl(state)).toBe('http://forgetest.someurl.com:80/oauth2/realms/root/access_token');
     });
   });
 });

--- a/src/ops/AdminOps.ts
+++ b/src/ops/AdminOps.ts
@@ -1677,7 +1677,7 @@ export async function trainAA({
   }
 }
 
-function getAccessTokenUrl(state: State) {
+export function getAccessTokenUrl(state: State) {
   const accessTokenUrlTemplate = '%s/oauth2%s/access_token';
   const accessTokenURL = util.format(
     accessTokenUrlTemplate,

--- a/src/ops/AuthenticateOps.test.ts
+++ b/src/ops/AuthenticateOps.test.ts
@@ -111,6 +111,54 @@ describe('AuthenticateOps', () => {
       beforeEach(() => {
         setDefaultState(Constants.CLASSIC_DEPLOYMENT_TYPE_KEY, true);
       });
+      describe('createPayload', () => {
+        test('0: default to port 80', async () => {
+          state.setHost("http://trivirsample.com")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("http://trivirsample.com:80/oauth2/access_token")
+        });
+        test('1: default to port 443', async () => {
+          state.setHost("https://trivirsample.com")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("https://trivirsample.com:443/oauth2/access_token")
+        });
+        test('2: avoid dup port 80', async () => {
+          state.setHost("http://trivirsample.com:80")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("http://trivirsample.com:80/oauth2/access_token")
+        });
+        test('3: avoid dup port 443', async () => {
+          state.setHost("https://trivirsample.com:443")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("https://trivirsample.com:443/oauth2/access_token")
+        });
+        test('4: avoid port 443, if one is already present', async () => {
+          state.setHost("https://trivirsample.com:1234")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("https://trivirsample.com:1234/oauth2/access_token")
+        });
+        test('5: /am is provided, only', async () => {
+          state.setHost("https://trivirsample.com/am")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("https://trivirsample.com:443/am/oauth2/access_token")
+        });
+        test('6: /am plus port is provided', async () => {
+          state.setHost("https://trivirsample.com:9876/am")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("https://trivirsample.com:9876/am/oauth2/access_token")
+        });
+        test('7: /am is not provided', async () => {
+          state.setHost("https://trivirsample.com")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("https://trivirsample.com:443/oauth2/access_token")
+        });
+        test('7: /am is not provided + port', async () => {
+          state.setHost("https://trivirsample.com:8765")
+          const payload = AuthenticateOps.createPayload('serviceAcctID', state.getHost());
+          expect(payload.aud).toBe("https://trivirsample.com:8765/oauth2/access_token")
+        });
+      });
+
       describe('getTokens()', () => {  
         test('0: Authenticate successfully as user', async () => {
           // override and reset service account credentials from environment variables in CI/CD pipeline

--- a/src/ops/AuthenticateOps.ts
+++ b/src/ops/AuthenticateOps.ts
@@ -937,11 +937,11 @@ async function getPfUserBearerToken(
   return token;
 }
 
-function createPayload(serviceAccountId: string, host: string) {
+export function createPayload(serviceAccountId: string, host: string) {
   const u = parseUrl(host);
-  const aud = `${u.origin}:${
-    u.port ? u.port : u.protocol === 'https' ? '443' : '80'
-  }${u.pathname}/oauth2/access_token`;
+  const aud = `${u.origin}${
+    u.port ? '' : `:${u.protocol === 'https' ? '443' : '80'}`
+  }${u.pathname.replace(/\/$/, '')}/oauth2/access_token`;
 
   // Cross platform way of setting JWT expiry time 3 minutes in the future, expressed as number of seconds since EPOCH
   const exp = Math.floor(new Date().getTime() / 1000 + 180);


### PR DESCRIPTION
…dd AuthenticateOps tests for createPayload.

bugfix: Add fix and test for duplicate port issue in createPayload if already present.

The createPayload function had a bug that would add the port even if it was already there. This fix and test ensures if the port is already present, the port will be left as is in the resulting JWT.

If someone provided the port as shown here, then createPayload would add it again, making the JWT audience invalid.  Example configured line, including port 443.

also: wrap AdminOps tests in their own describe for the 'getAccessTokenURL' call.