### PR TITLE
bugfix: Fix Workflow Exports Not Working in Certain Tenants

### DIFF
--- a/src/api/ApiTypes.ts
+++ b/src/api/ApiTypes.ts
@@ -41,9 +41,9 @@ export type PagedResult<Type> = {
 export type SearchResult<Type> = {
   result: Type[];
   resultCount: number;
-  totalCount?: number;
-  totalHits?: number;
-  searchAfterKey?: string[];
+  totalCount?: number | null;
+  totalHits?: number | null;
+  searchAfterKey?: string | string[] | null;
 };
 
 export type EntityType = IdObjectSkeletonInterface & {

--- a/src/api/cloud/iga/IgaWorkflowApi.ts
+++ b/src/api/cloud/iga/IgaWorkflowApi.ts
@@ -257,11 +257,8 @@ export async function queryWorkflows({
   );
   return await governanceApiSearchAll({
     url: urlString,
-    pageOffsetStrategy: 'PAGE',
-    pageSize: 10000,
-    // The page offset starts at 1 instead of 0 for workflows, so we need to add one to it
     queryParamBuilder: (size, offset) =>
-      `_queryString=${queryString}&_pageSize=${size}&_pagedResultsOffset=${offset + 1}`,
+      `_queryString=${queryString}&_pageSize=${size}&_pagedResultsOffset=${offset}`,
     state,
   });
 }

--- a/src/test/mock-recordings/IgaRequestFormOps_264095613/deleteOrphanedRequestFormAssignments_1635092445/3-Delete-orphaned-workflow-form-assignments_4276631981/recording.har
+++ b/src/test/mock-recordings/IgaRequestFormOps_264095613/deleteOrphanedRequestFormAssignments_1635092445/3-Delete-orphaned-workflow-form-assignments_4276631981/recording.har
@@ -136,7 +136,7 @@
         }
       },
       {
-        "_id": "3ae183f581308cceaee9b7766a3d2cd0",
+        "_id": "39cc5612c317a2df586d089a60ea26dd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -185,7 +185,7 @@
               "value": "1"
             }
           ],
-          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=1"
+          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=0"
         },
         "response": {
           "bodySize": 29456,

--- a/src/test/mock-recordings/IgaRequestFormOps_264095613/deleteOrphanedRequestFormAssignments_1635092445/4-Delete-all-other-orphaned-form-assignments_1926187238/recording.har
+++ b/src/test/mock-recordings/IgaRequestFormOps_264095613/deleteOrphanedRequestFormAssignments_1635092445/4-Delete-all-other-orphaned-form-assignments_1926187238/recording.har
@@ -273,7 +273,7 @@
         }
       },
       {
-        "_id": "3ae183f581308cceaee9b7766a3d2cd0",
+        "_id": "39cc5612c317a2df586d089a60ea26dd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -322,7 +322,7 @@
               "value": "1"
             }
           ],
-          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=1"
+          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=0"
         },
         "response": {
           "bodySize": 29463,

--- a/src/test/mock-recordings/IgaWorkflowOps_4285133371/exportWorkflows_1610971952/1-Export-existing-workflows-with-coordinates-string-arrays-dependencies-and-readonly-conf_1776323423/recording.har
+++ b/src/test/mock-recordings/IgaWorkflowOps_4285133371/exportWorkflows_1610971952/1-Export-existing-workflows-with-coordinates-string-arrays-dependencies-and-readonly-conf_1776323423/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "3ae183f581308cceaee9b7766a3d2cd0",
+        "_id": "39cc5612c317a2df586d089a60ea26dd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -57,7 +57,7 @@
               "value": "1"
             }
           ],
-          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=1"
+          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=0"
         },
         "response": {
           "bodySize": 651578,

--- a/src/test/mock-recordings/IgaWorkflowOps_4285133371/exportWorkflows_1610971952/2-Export-existing-workflows-without-coordinates-string-arrays-dependencies-and-readonly-c_2177243306/recording.har
+++ b/src/test/mock-recordings/IgaWorkflowOps_4285133371/exportWorkflows_1610971952/2-Export-existing-workflows-without-coordinates-string-arrays-dependencies-and-readonly-c_2177243306/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "3ae183f581308cceaee9b7766a3d2cd0",
+        "_id": "39cc5612c317a2df586d089a60ea26dd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -57,7 +57,7 @@
               "value": "1"
             }
           ],
-          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=1"
+          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=0"
         },
         "response": {
           "bodySize": 651578,

--- a/src/test/mock-recordings/IgaWorkflowOps_4285133371/importWorkflows_1618477385/1-Import-None_3320571159/recording.har
+++ b/src/test/mock-recordings/IgaWorkflowOps_4285133371/importWorkflows_1618477385/1-Import-None_3320571159/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "3ae183f581308cceaee9b7766a3d2cd0",
+        "_id": "39cc5612c317a2df586d089a60ea26dd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -57,7 +57,7 @@
               "value": "1"
             }
           ],
-          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=1"
+          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=0"
         },
         "response": {
           "bodySize": 651578,
@@ -256,7 +256,7 @@
         }
       },
       {
-        "_id": "3ae183f581308cceaee9b7766a3d2cd0",
+        "_id": "39cc5612c317a2df586d089a60ea26dd",
         "_order": 1,
         "cache": {},
         "request": {
@@ -305,7 +305,7 @@
               "value": "1"
             }
           ],
-          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=1"
+          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=0"
         },
         "response": {
           "bodySize": 651578,

--- a/src/test/mock-recordings/IgaWorkflowOps_4285133371/importWorkflows_1618477385/3-Import-all_3670337930/recording.har
+++ b/src/test/mock-recordings/IgaWorkflowOps_4285133371/importWorkflows_1618477385/3-Import-all_3670337930/recording.har
@@ -3612,7 +3612,7 @@
         }
       },
       {
-        "_id": "3ae183f581308cceaee9b7766a3d2cd0",
+        "_id": "39cc5612c317a2df586d089a60ea26dd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -3661,7 +3661,7 @@
               "value": "1"
             }
           ],
-          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=1"
+          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=0"
         },
         "response": {
           "bodySize": 629153,
@@ -4350,7 +4350,7 @@
         }
       },
       {
-        "_id": "3ae183f581308cceaee9b7766a3d2cd0",
+        "_id": "39cc5612c317a2df586d089a60ea26dd",
         "_order": 1,
         "cache": {},
         "request": {
@@ -4399,7 +4399,7 @@
               "value": "1"
             }
           ],
-          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=1"
+          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=0"
         },
         "response": {
           "bodySize": 696432,

--- a/src/test/mock-recordings/IgaWorkflowOps_4285133371/readWorkflowGroups_3413709515/1-Read-existing-workflow-groups_2670958916/recording.har
+++ b/src/test/mock-recordings/IgaWorkflowOps_4285133371/readWorkflowGroups_3413709515/1-Read-existing-workflow-groups_2670958916/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "3ae183f581308cceaee9b7766a3d2cd0",
+        "_id": "39cc5612c317a2df586d089a60ea26dd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -57,7 +57,7 @@
               "value": "1"
             }
           ],
-          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=1"
+          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=0"
         },
         "response": {
           "bodySize": 391406,

--- a/src/test/mock-recordings/IgaWorkflowOps_4285133371/readWorkflows_163835750/1-Read-existing-workflows_4289617141/recording.har
+++ b/src/test/mock-recordings/IgaWorkflowOps_4285133371/readWorkflows_163835750/1-Read-existing-workflows_4289617141/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "3ae183f581308cceaee9b7766a3d2cd0",
+        "_id": "39cc5612c317a2df586d089a60ea26dd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -57,7 +57,7 @@
               "value": "1"
             }
           ],
-          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=1"
+          "url": "https://openam-frodo-dev.forgeblocks.com/iga/governance/workflow?_queryString=&_pageSize=10000&_pagedResultsOffset=0"
         },
         "response": {
           "bodySize": 391406,

--- a/src/utils/ExportImportUtils.ts
+++ b/src/utils/ExportImportUtils.ts
@@ -911,10 +911,11 @@ export async function governanceApiSearchAll<T>({
         })
       ).data;
     }
+    // If both totalCount and totalHits are nullish, then resultCount should just be 0, meaning no results found.
     currentSearchTotalCount =
-      currentSearchResult.totalCount !== undefined
-        ? currentSearchResult.totalCount
-        : currentSearchResult.totalHits;
+      currentSearchResult.totalCount ??
+      currentSearchResult.totalHits ??
+      currentSearchResult.resultCount;
     results.push(...currentSearchResult.result);
   } while (
     currentSearchResult.resultCount === pageSize &&


### PR DESCRIPTION
We discovered a bug yesterday while trying to do IGA workflow exports in a client tenant different from the one we typically use for testing IGA with Frodo (which isn't a client facing tenant, but one we use for experimentation). The issue we discovered was that, even though the version of AIC matched between both our test tenant and the client tenant, the workflow export would fail in the client tenant because it was using a completely different paged results strategy than was used in the tenant we used for testing.

The fix I employed was to use the different strategy because it seems to be the correct way of doing it since typically you start at an offset of 0 and not 1 which we were originally doing to get it to work in our testing tenant, not to mention the tenant we are using for testing isn't one that is meant for use in the real world, so I prioritized making it work for the real world tenants. Good news is the offset of 0 still works in our testing tenant, but paging will be broken in that tenant, although it shouldn't be a problem since we are using 10000 for the page size, so unless we end up with more than 10000 workflows in that tenant it shouldn't be an issue. 

For the future we're planning to continue our IGA testing using the test tenant we have, but once we have it working there will confirm it still works in a normal tenant just in case there are differences in how the endpoints function like this one that we found. So far it appears to only affect the workflow endpoint for retrieving workflows, and not any of the other IGA ones we've already implemented for request forms, request types, etc.