### PR TITLE
feat: Add library function to prune old secret versions.

### DIFF
--- a/src/lib/Help.ts
+++ b/src/lib/Help.ts
@@ -6108,6 +6108,19 @@ export const helpMetadata: MethodHelpDoc[] = [
     returns: "{Promise<VersionOfSecretSkeleton>} a promise that resolves to a version object",
   },
   {
+    typeName: "Secret",
+    methodName: "pruneVersionsOfSecret",
+    signature: "pruneVersionsOfSecret( secretId: string, keepLoaded?: boolean, keepDeactivated?: boolean, resultCallback?: ResultCallback<VersionOfSecretSkeleton> ): Promise<VersionOfSecretSkeleton[]>",
+    description: "Prune versions of secret that are not the latest secret version",
+    params: [
+      { name: "secretId", type: "string", description: "secret id/name" },
+      { name: "keepLoaded", type: "boolean", description: "true to keep the currently loaded secret versions regardless of if they are active or not. Default: false" },
+      { name: "keepDeactivated", type: "boolean", description: "true to keep the deactivated versions and only prune the active versions that aren't the latest version. Default: false" },
+      { name: "resultCallback", type: "ResultCallback<VersionOfSecretSkeleton>", description: "Optional callback to process individual results" },
+    ],
+    returns: "{Promise<VersionOfSecretSkeleton[]>} a promise that reolves to the pruned version objects",
+  },
+  {
     typeName: "ServiceAccount",
     methodName: "isServiceAccountsFeatureAvailable",
     signature: "isServiceAccountsFeatureAvailable(): Promise<boolean>",

--- a/src/ops/cloud/SecretsOps.test.ts
+++ b/src/ops/cloud/SecretsOps.test.ts
@@ -33,348 +33,15 @@
  * in case things don't function as expected
  */
 
-import { autoSetupPolly } from '../../utils/AutoSetupPolly';
-import { filterRecording } from '../../utils/PollyUtils';
 import { state } from '../../index';
 import * as SecretsOps from './SecretsOps';
 import { FrodoError } from '../FrodoError';
-
-const ctx = autoSetupPolly();
-
-async function stageSecret(
-  secret: {
-    id: string;
-    value: string;
-    description: string;
-    encoding: string;
-    useInPlaceholders: boolean;
-  },
-  create = true
-) {
-  // delete if exists, then create
-  try {
-    await SecretsOps.deleteSecret({ secretId: secret.id, state });
-  } catch (error) {
-    // ignore
-  } finally {
-    if (create) {
-      await SecretsOps.createSecret({
-        secretId: secret.id,
-        value: secret.value,
-        description: secret.description,
-        encoding: secret.encoding,
-        useInPlaceholders: secret.useInPlaceholders,
-        state: state,
-      });
-    }
-  }
-}
+import * as TestData from '../../test/setup/SecretSetup'
+import { snapshotResultCallback } from '../../test/utils/TestUtils';
 
 describe('SecretsOps', () => {
-  const secret1 = {
-    id: 'esv-frodo-test-secret-1',
-    value: 'value1',
-    description: 'description1',
-    encoding: 'generic',
-    useInPlaceholders: true,
-  };
-  const secret2 = {
-    id: 'esv-frodo-test-secret-2',
-    value: 'value2',
-    description: 'description2',
-    encoding: 'generic',
-    useInPlaceholders: false,
-  };
-  const secret3 = {
-    id: 'esv-frodo-test-secret-3',
-    value: 'value3',
-    description: 'description3',
-    encoding: 'generic',
-    useInPlaceholders: false,
-  };
-  const secret4 = {
-    id: 'esv-frodo-test-secret4',
-    value: `-----BEGIN CERTIFICATE-----
-MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
-A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
-MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
-YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
-ODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
-CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
-ZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl
-8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID
-AQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx
-8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy
-2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0
-Hn+GmxZA
------END CERTIFICATE-----`,
-    newValue: `-----BEGIN CERTIFICATE-----
-MIICXjCCAccCAg4GMA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
-A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
-MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
-YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
-OTI3MTMwMDE0WhcNMTcwOTI2MTMwMDE0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
-CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
-ZS5jb20wgacwEAYHKoZIzj0CAQYFK4EEACcDgZIABAIZ0Rc0Y3jsqPqqptRz3tiS
-AuvTHA9vUigM2gUjM6YkTKofP7RRls4dqt6aM7/1eLbFg4Jdh9DXS4zU1EFeiZQZ
-+drSQYAmAgAtTzpmtmUoy+miwtiSBomu3CSUe6YrVvWb+Oirmvw2x3BCTJW2Xjhy
-5y6tDPVRRyhg0nh5wm/UxZv4jo7AZuJV8ztZKwCEADANBgkqhkiG9w0BAQUFAAOB
-gQBlaOF5O4RyvDQ1qCAuM6oXjmL3kCA3Kp7VfytDYaxbaJVhC8PnE0A8VPX2ypn9
-aQR4yq98e2umPsrSL7gPddoga+OvatusG9GnIviWGSzazQBQTTQdESJxrPdDXE0E
-YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
------END CERTIFICATE-----`,
-    description: 'Frodo Test PEM encoded Secret Four Description',
-    encoding: 'pem',
-    useInPlaceholders: true,
-  };
-  const secret5 = {
-    id: 'esv-frodo-test-secret-5',
-    value: '0nbVGkrNnIm4o5WKzYS/dL3/eo/k9EnSBH2QOOm5dLM=',
-    description: 'description5',
-    encoding: 'base64hmac',
-    useInPlaceholders: false,
-  };
-  const secret6 = {
-    id: 'esv-frodo-test-secret-6',
-    value: 'value6',
-    description: 'description6',
-    encoding: 'generic',
-    useInPlaceholders: true,
-  };
-  const secret7 = {
-    id: 'esv-frodo-test-secret-7',
-    value: 'value7',
-    description: 'description7',
-    encoding: 'generic',
-    useInPlaceholders: true,
-  };
-  const secret8 = {
-    id: 'esv-frodo-test-secret-8',
-    value: 'value8',
-    description: 'description8',
-    encoding: 'generic',
-    useInPlaceholders: true,
-  };
-  const secret9 = {
-    id: 'esv-frodo-test-secret-9',
-    value: 'value9',
-    description: 'description9',
-    encoding: 'generic',
-    useInPlaceholders: true,
-  };
-  const secret10 = {
-    id: 'esv-frodo-test-secret-10',
-    value: 'value10',
-    description: 'description10',
-    encoding: 'generic',
-    useInPlaceholders: true,
-  };
-  const secret11 = {
-    id: 'esv-frodo-test-secret-11',
-    value: 'value11',
-    description: 'description11',
-    encoding: 'generic',
-    useInPlaceholders: true,
-  };
-  const secret6Export: SecretsOps.SecretsExportInterface = {
-    meta: {
-      exportDate: '2024-06-26T17:21:25.297Z',
-      exportTool: 'frodo',
-      exportToolVersion: 'v2.0.0-88 [v20.5.1]',
-      exportedBy: 'volker.scheuber@forgerock.com',
-      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
-      originAmVersion: '7.6.0',
-    },
-    secret: {
-      'esv-frodo-test-secret-6': {
-        _id: 'esv-frodo-test-secret-6',
-        activeVersion: '1',
-        description: 'description6',
-        encoding: 'generic',
-        lastChangeDate: '2024-06-26T17:06:44.729068Z',
-        lastChangedBy: 'Frodo-SA-1701393386423',
-        loaded: true,
-        loadedVersion: '1',
-        useInPlaceholders: true,
-      },
-    },
-  };
-  const secret7Export: SecretsOps.SecretsExportInterface = {
-    meta: {
-      exportDate: '2024-06-26T17:21:25.297Z',
-      exportTool: 'frodo',
-      exportToolVersion: 'v2.0.0-88 [v20.5.1]',
-      exportedBy: 'volker.scheuber@forgerock.com',
-      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
-      originAmVersion: '7.6.0',
-    },
-    secret: {
-      'esv-frodo-test-secret-7': {
-        _id: 'esv-frodo-test-secret-7',
-        activeValue: {
-          $crypto: {
-            type: 'x-simple-encryption',
-            value: {
-              cipher: 'AES/CBC/PKCS5Padding',
-              data: 'pVE6Y1Va4V1DB50A10mqkQ==',
-              iv: '2GjZJDuomoZeBOkr4MWBGQ==',
-              keySize: 16,
-              mac: 'A2TT/N3gBzWdQjhHo3QPjg==',
-              purpose: 'idm.password.encryption',
-              salt: 'Osc1v2DpgdnE6Bqf8SH5ng==',
-              stableId: 'openidm-sym-default',
-            },
-          },
-        },
-        activeVersion: '1',
-        description: 'description7',
-        encoding: 'generic',
-        lastChangeDate: '2024-06-26T17:06:45.868234Z',
-        lastChangedBy: 'Frodo-SA-1701393386423',
-        loaded: true,
-        loadedVersion: '1',
-        useInPlaceholders: true,
-      },
-    },
-  };
-  const secret89Export: SecretsOps.SecretsExportInterface = {
-    meta: {
-      exportDate: '2024-06-26T17:21:25.297Z',
-      exportTool: 'frodo',
-      exportToolVersion: 'v2.0.0-88 [v20.5.1]',
-      exportedBy: 'volker.scheuber@forgerock.com',
-      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
-      originAmVersion: '7.6.0',
-    },
-    secret: {
-      'esv-frodo-test-secret-8': {
-        _id: 'esv-frodo-test-secret-8',
-        activeVersion: '1',
-        description: 'description8',
-        encoding: 'generic',
-        lastChangeDate: '2024-06-26T17:06:46.979708Z',
-        lastChangedBy: 'Frodo-SA-1701393386423',
-        loaded: true,
-        loadedVersion: '1',
-        useInPlaceholders: true,
-      },
-      'esv-frodo-test-secret-9': {
-        _id: 'esv-frodo-test-secret-9',
-        activeVersion: '1',
-        description: 'description9',
-        encoding: 'generic',
-        lastChangeDate: '2024-06-26T17:06:47.977012Z',
-        lastChangedBy: 'Frodo-SA-1701393386423',
-        loaded: true,
-        loadedVersion: '1',
-        useInPlaceholders: true,
-      },
-    },
-  };
-  const secret1011Export: SecretsOps.SecretsExportInterface = {
-    meta: {
-      exportDate: '2024-06-26T17:21:07.599Z',
-      exportTool: 'frodo',
-      exportToolVersion: 'v2.0.0-88 [v20.5.1]',
-      exportedBy: 'volker.scheuber@forgerock.com',
-      origin: 'https://openam-frodo-dev.forgeblocks.com/am',
-      originAmVersion: '7.6.0',
-    },
-    secret: {
-      'esv-frodo-test-secret-10': {
-        _id: 'esv-frodo-test-secret-10',
-        activeValue: {
-          $crypto: {
-            type: 'x-simple-encryption',
-            value: {
-              cipher: 'AES/CBC/PKCS5Padding',
-              data: 'SZ8gU3fq5dGlbhPgd7kT3Q==',
-              iv: 'KCOai4hfGovwyrSswB9mow==',
-              keySize: 16,
-              mac: 'lJdfWa1DkNkxcHBMfqlXuw==',
-              purpose: 'idm.password.encryption',
-              salt: 'bqeoBikq1SB1c+ThqqQDaw==',
-              stableId: 'openidm-sym-default',
-            },
-          },
-        },
-        activeVersion: '1',
-        description: 'description10',
-        encoding: 'generic',
-        lastChangeDate: '2024-06-26T17:06:48.875277Z',
-        lastChangedBy: 'Frodo-SA-1701393386423',
-        loaded: true,
-        loadedVersion: '1',
-        useInPlaceholders: true,
-      },
-      'esv-frodo-test-secret-11': {
-        _id: 'esv-frodo-test-secret-11',
-        activeValue: {
-          $crypto: {
-            type: 'x-simple-encryption',
-            value: {
-              cipher: 'AES/CBC/PKCS5Padding',
-              data: 'Sxb6VWMMUCQ/qBmYB08kCA==',
-              iv: '7rayASsrtPPg+VAojLADdQ==',
-              keySize: 16,
-              mac: 'nx2l6Sx4k8nk3DDVXb5rqQ==',
-              purpose: 'idm.password.encryption',
-              salt: 'i4CP2IeVdFR9vTXvs69/RA==',
-              stableId: 'openidm-sym-default',
-            },
-          },
-        },
-        activeVersion: '1',
-        description: 'description11',
-        encoding: 'generic',
-        lastChangeDate: '2024-06-26T17:06:49.924701Z',
-        lastChangedBy: 'Frodo-SA-1701393386423',
-        loaded: true,
-        loadedVersion: '1',
-        useInPlaceholders: true,
-      },
-    },
-  };
-  // filter out secrets when recording
-  beforeEach(async () => {
-    if (process.env.FRODO_POLLY_MODE === 'record') {
-      ctx.polly.server.any().on('beforePersist', (_req, recording) => {
-        filterRecording(recording);
-      });
-    }
-  });
-  // in recording mode, setup test data before recording
-  beforeAll(async () => {
-    if (process.env.FRODO_POLLY_MODE === 'record') {
-      await stageSecret(secret1);
-      await stageSecret(secret2);
-      await stageSecret(secret3, false);
-      await stageSecret(secret4, false);
-      await stageSecret(secret5, false);
-      await stageSecret(secret6, false);
-      await stageSecret(secret7, false);
-      await stageSecret(secret8, false);
-      await stageSecret(secret9, false);
-      await stageSecret(secret10, false);
-      await stageSecret(secret11, false);
-    }
-  });
-  // in recording mode, remove test data after recording
-  afterAll(async () => {
-    if (process.env.FRODO_POLLY_MODE === 'record') {
-      await stageSecret(secret1, false);
-      await stageSecret(secret2, false);
-      await stageSecret(secret3, false);
-      await stageSecret(secret4, false);
-      await stageSecret(secret5, false);
-      await stageSecret(secret6, false);
-      await stageSecret(secret7, false);
-      await stageSecret(secret8, false);
-      await stageSecret(secret9, false);
-      await stageSecret(secret10, false);
-      await stageSecret(secret11, false);
-    }
-  });
+
+  TestData.setup();
 
   describe('createSecretsExportTemplate()', () => {
     test('0: Method is implemented', async () => {
@@ -421,7 +88,7 @@ YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
 
     test('1: Export secret1', async () => {
       const response = await SecretsOps.exportSecret({
-        secretId: secret1.id,
+        secretId: TestData.secret1._id,
         state: state,
       });
       expect(response).toMatchSnapshot({
@@ -431,7 +98,7 @@ YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
 
     test('2: Export secret2', async () => {
       const response = await SecretsOps.exportSecret({
-        secretId: secret2.id,
+        secretId: TestData.secret2._id,
         state: state,
       });
       expect(response).toMatchSnapshot({
@@ -442,7 +109,7 @@ YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
     test('3: Export secret3 (non-existent)', async () => {
       expect.assertions(2);
       try {
-        await SecretsOps.exportSecret({ secretId: secret3.id, state: state });
+        await SecretsOps.exportSecret({ secretId: TestData.secret3._id, state: state });
       } catch (error) {
         expect(error.name).toEqual('FrodoError');
         expect((error as FrodoError).getCombinedMessage()).toMatchSnapshot();
@@ -451,7 +118,7 @@ YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
 
     test('4: Export secret2 including active value', async () => {
       const response = await SecretsOps.exportSecret({
-        secretId: secret2.id,
+        secretId: TestData.secret2._id,
         options: { includeActiveValues: true },
         state: state,
       });
@@ -469,8 +136,8 @@ YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
     test('1: Import secret6', async () => {
       try {
         const response = await SecretsOps.importSecret({
-          secretId: secret6.id,
-          importData: secret6Export,
+          secretId: TestData.secret6._id,
+          importData: TestData.secret6Export,
           state: state,
         });
         expect(response).toMatchSnapshot();
@@ -483,8 +150,8 @@ YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
     test('2: Import secret7 including active value', async () => {
       try {
         const response = await SecretsOps.importSecret({
-          secretId: secret7.id,
-          importData: secret7Export,
+          secretId: TestData.secret7._id,
+          importData: TestData.secret7Export,
           options: { includeActiveValues: true },
           state: state,
         });
@@ -503,7 +170,7 @@ YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
 
     test('1: Import all secrets (secret8 and secret9)', async () => {
       const response = await SecretsOps.importSecrets({
-        importData: secret89Export,
+        importData: TestData.secret89Export,
         state,
       });
       expect(response).toMatchSnapshot();
@@ -511,7 +178,7 @@ YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
 
     test('2: Import all secrets (secret10 and secret11) including active values', async () => {
       const response = await SecretsOps.importSecrets({
-        importData: secret1011Export,
+        importData: TestData.secret1011Export,
         options: { includeActiveValues: true },
         state: state,
       });
@@ -520,37 +187,84 @@ YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
   });
 
   describe('createSecret()', () => {
-    test(`0: Create pem encoded secret: ${secret4.id} - success`, async () => {
+    test(`0: Create pem encoded secret: ${TestData.secret4._id} - success`, async () => {
       const response = await SecretsOps.createSecret({
-        secretId: secret4.id,
-        value: secret4.value,
-        description: secret4.description,
-        encoding: secret4.encoding,
-        useInPlaceholders: secret4.useInPlaceholders,
+        secretId: TestData.secret4._id,
+        value: TestData.secret4.value,
+        description: TestData.secret4.description,
+        encoding: TestData.secret4.encoding,
+        useInPlaceholders: TestData.secret4.useInPlaceholders,
         state,
       });
       expect(response).toMatchSnapshot();
     });
 
-    test(`1: Create new version of pem encoded secret: ${secret4.id} - success`, async () => {
+    test(`1: Create new version of pem encoded secret: ${TestData.secret4._id} - success`, async () => {
+      const secret4NewValue = `-----BEGIN CERTIFICATE-----
+MIICXjCCAccCAg4GMA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
+A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
+MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
+YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
+OTI3MTMwMDE0WhcNMTcwOTI2MTMwMDE0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
+CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
+ZS5jb20wgacwEAYHKoZIzj0CAQYFK4EEACcDgZIABAIZ0Rc0Y3jsqPqqptRz3tiS
+AuvTHA9vUigM2gUjM6YkTKofP7RRls4dqt6aM7/1eLbFg4Jdh9DXS4zU1EFeiZQZ
++drSQYAmAgAtTzpmtmUoy+miwtiSBomu3CSUe6YrVvWb+Oirmvw2x3BCTJW2Xjhy
+5y6tDPVRRyhg0nh5wm/UxZv4jo7AZuJV8ztZKwCEADANBgkqhkiG9w0BAQUFAAOB
+gQBlaOF5O4RyvDQ1qCAuM6oXjmL3kCA3Kp7VfytDYaxbaJVhC8PnE0A8VPX2ypn9
+aQR4yq98e2umPsrSL7gPddoga+OvatusG9GnIviWGSzazQBQTTQdESJxrPdDXE0E
+YF5PPxAO+0yKGqkl8PepvymXBrMAeszlHaRFXeRojXVALw==
+-----END CERTIFICATE-----`;
       const response = await SecretsOps.createVersionOfSecret({
-        secretId: secret4.id,
-        value: secret4.newValue,
+        secretId: TestData.secret4._id,
+        value: secret4NewValue,
         state,
       });
       expect(response).toMatchSnapshot();
     });
 
-    test(`2: Create base64hmac encoded secret: ${secret5.id} - success`, async () => {
+    test(`2: Create base64hmac encoded secret: ${TestData.secret5._id} - success`, async () => {
       const response = await SecretsOps.createSecret({
-        secretId: secret5.id,
-        value: secret5.value,
-        description: secret5.description,
-        encoding: secret5.encoding,
-        useInPlaceholders: secret5.useInPlaceholders,
+        secretId: TestData.secret5._id,
+        value: TestData.secret5.value,
+        description: TestData.secret5.description,
+        encoding: TestData.secret5.encoding,
+        useInPlaceholders: TestData.secret5.useInPlaceholders,
         state,
       });
       expect(response).toMatchSnapshot();
+    });
+  });
+
+  describe('pruneVersionsOfSecret()', () => {
+    test('0: Method is implemented', async () => {
+      expect(SecretsOps.pruneVersionsOfSecret).toBeDefined();
+    });
+
+    test('1: Prune all versions of secret', async () => {
+      const response = await SecretsOps.pruneVersionsOfSecret({ secretId: TestData.secret12._id, keepLoaded: false, keepDeactivated: false, resultCallback: snapshotResultCallback, state });
+      expect(response).toMatchSnapshot();
+      expect(response.length).toBe(4);
+    });
+
+    test('2: Prune all versions except loaded of secret', async () => {
+      const response = await SecretsOps.pruneVersionsOfSecret({ secretId: TestData.secret13._id, keepLoaded: true, keepDeactivated: false, resultCallback: snapshotResultCallback, state });
+      expect(response).toMatchSnapshot();
+      // Still 4 like previous test since loaded version is the active version
+      expect(response.length).toBe(4);
+    });
+
+    test('3: Prune all versions except deactivated of secret', async () => {
+      const response = await SecretsOps.pruneVersionsOfSecret({ secretId: TestData.secret14._id, keepLoaded: false, keepDeactivated: true, resultCallback: snapshotResultCallback, state });
+      expect(response).toMatchSnapshot();
+      expect(response.length).toBe(2);
+    });
+
+    test('3: Prune all versions except loaded and deactivated of secret', async () => {
+      const response = await SecretsOps.pruneVersionsOfSecret({ secretId: TestData.secret15._id, keepLoaded: true, keepDeactivated: true, resultCallback: snapshotResultCallback, state });
+      expect(response).toMatchSnapshot();
+      // Still 2 like previous test since loaded version is the active version
+      expect(response.length).toBe(2);
     });
   });
 });

--- a/src/ops/cloud/SecretsOps.ts
+++ b/src/ops/cloud/SecretsOps.ts
@@ -11,6 +11,7 @@ import {
   setSecretDescription as _setSecretDescription,
   setStatusOfVersionOfSecret as _setStatusOfVersionOfSecret,
   VersionOfSecretSkeleton,
+  deleteVersionOfSecret,
 } from '../../api/cloud/SecretsApi';
 import FrodoLib from '../../lib/FrodoLib';
 import { State } from '../../shared/State';
@@ -22,11 +23,11 @@ import {
   stopProgressIndicator,
   updateProgressIndicator,
 } from '../../utils/Console';
-import { getMetadata } from '../../utils/ExportImportUtils';
+import { getMetadata, getResult } from '../../utils/ExportImportUtils';
 import { FrodoError } from '../FrodoError';
 import { decrypt, decryptMap, isEncrypted } from '../IdmCryptoOps';
 import { evaluateScript } from '../IdmScriptOps';
-import { ExportMetaData } from '../OpsTypes';
+import { ExportMetaData, ResultCallback } from '../OpsTypes';
 
 export type Secret = {
   /**
@@ -197,6 +198,20 @@ export type Secret = {
     secretId: string,
     version: string
   ): Promise<VersionOfSecretSkeleton>;
+  /**
+   * Prune versions of secret that are not the latest secret version
+   * @param {string} secretId secret id/name
+   * @param {boolean} keepLoaded true to keep the currently loaded secret versions regardless of if they are active or not. Default: false
+   * @param {boolean} keepDeactivated true to keep the deactivated versions and only prune the active versions that aren't the latest version. Default: false
+   * @param {ResultCallback<VersionOfSecretSkeleton>} resultCallback Optional callback to process individual results
+   * @returns {Promise<VersionOfSecretSkeleton[]>} a promise that reolves to the pruned version objects
+   */
+  pruneVersionsOfSecret(
+    secretId: string,
+    keepLoaded?: boolean,
+    keepDeactivated?: boolean,
+    resultCallback?: ResultCallback<VersionOfSecretSkeleton>
+  ): Promise<VersionOfSecretSkeleton[]>;
 };
 
 export default (state: State): Secret => {
@@ -309,6 +324,20 @@ export default (state: State): Secret => {
     },
     async deleteVersionOfSecret(secretId: string, version: string) {
       return _deleteVersionOfSecret({ secretId, version, state });
+    },
+    async pruneVersionsOfSecret(
+      secretId: string,
+      keepLoaded: boolean = false,
+      keepDeactivated: boolean = false,
+      resultCallback: ResultCallback<VersionOfSecretSkeleton> = void 0
+    ): Promise<VersionOfSecretSkeleton[]> {
+      return pruneVersionsOfSecret({
+        secretId,
+        keepLoaded,
+        keepDeactivated,
+        resultCallback,
+        state,
+      });
     },
   };
 };
@@ -1217,5 +1246,84 @@ export async function updateSecretDescription({
       `Error updating description of secret ${secretId}`,
       error
     );
+  }
+}
+
+/**
+ * Prune versions of secret that are not the latest secret version
+ * @param {string} secretId secret id/name
+ * @param {boolean} keepLoaded true to keep the currently loaded secret versions regardless of if they are active or not. Default: false
+ * @param {boolean} keepDeactivated true to keep the deactivated versions and only prune the active versions that aren't the latest version. Default: false
+ * @param {ResultCallback<VersionOfSecretSkeleton>} resultCallback Optional callback to process individual results
+ * @returns {Promise<VersionOfSecretSkeleton[]>} a promise that reolves to the pruned version objects
+ */
+export async function pruneVersionsOfSecret({
+  secretId,
+  keepLoaded = false,
+  keepDeactivated = false,
+  resultCallback = void 0,
+  state,
+}: {
+  secretId: string;
+  keepLoaded?: boolean;
+  keepDeactivated?: boolean;
+  resultCallback?: ResultCallback<VersionOfSecretSkeleton>;
+  state: State;
+}): Promise<VersionOfSecretSkeleton[]> {
+  let indicatorId;
+  try {
+    debugMessage({
+      message: `SecretsOps.pruneVersionsOfSecret: start`,
+      state,
+    });
+    const secret = await readSecret({ secretId, state });
+    const pruned = [];
+    const versions = (await readVersionsOfSecret({ secretId, state })).filter(
+      (v) => {
+        const isActive = v.version === secret.activeVersion;
+        const isDestroyed = v.status === 'DESTROYED';
+        const isLoaded =
+          keepLoaded && (v.loaded || secret.loadedVersion === v.version);
+        const isDeactivated = keepDeactivated && v.status === 'DISABLED';
+        return !isActive && !isDestroyed && !isLoaded && !isDeactivated;
+      }
+    );
+    indicatorId = createProgressIndicator({
+      total: versions.length,
+      message: `Pruning versions of secret ${secretId}...`,
+      state,
+    });
+    for (const v of versions) {
+      pruned.push(
+        await getResult(
+          resultCallback,
+          `Failed to prune version ${v.version} of secret ${secretId}`,
+          deleteVersionOfSecret,
+          { secretId, version: v.version, state }
+        )
+      );
+      updateProgressIndicator({
+        id: indicatorId,
+        message: `Pruned secret version ${v.version}`,
+        state,
+      });
+    }
+    stopProgressIndicator({
+      id: indicatorId,
+      message: `Pruned ${versions.length} versions from secret ${secretId}.`,
+      state,
+    });
+    debugMessage({ message: `SecretsOps.pruneVersionsOfSecret: end`, state });
+    return pruned;
+  } catch (error) {
+    if (indicatorId) {
+      stopProgressIndicator({
+        id: indicatorId,
+        message: `Error pruning versions of secret ${secretId}`,
+        status: 'fail',
+        state,
+      });
+    }
+    throw new FrodoError(`Error pruning versions of secret ${secretId}`, error);
   }
 }

--- a/src/test/mock-recordings/SecretsOps_1659926422/pruneVersionsOfSecret_328609964/1-Prune-all-versions-of-secret_3911065053/recording.har
+++ b/src/test/mock-recordings/SecretsOps_1659926422/pruneVersionsOfSecret_328609964/1-Prune-all-versions-of-secret_3911065053/recording.har
@@ -1,0 +1,632 @@
+{
+  "log": {
+    "_recordingName": "SecretsOps/pruneVersionsOfSecret()/1: Prune all versions of secret",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "1e34fc2f3b01b329b2a6aa272282252a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1873,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-12"
+        },
+        "response": {
+          "bodySize": 253,
+          "content": {
+            "mimeType": "application/json",
+            "size": 253,
+            "text": "{\"_id\":\"esv-frodo-test-secret-12\",\"activeVersion\":\"7\",\"description\":\"description12\",\"encoding\":\"generic\",\"lastChangeDate\":\"2026-08-13T16:37:09.505032Z\",\"lastChangedBy\":\"Frodo-SA-1783448612033\",\"loaded\":false,\"loadedVersion\":\"\",\"useInPlaceholders\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "253"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:50.011Z",
+        "time": 162,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 162
+        }
+      },
+      {
+        "_id": "eeee73f6fa18144884ba75092ef41ae4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1882,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-12/versions"
+        },
+        "response": {
+          "bodySize": 659,
+          "content": {
+            "mimeType": "application/json",
+            "size": 659,
+            "text": "[{\"createDate\":\"2026-08-13T16:37:08.458416Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"7\"},{\"createDate\":\"2026-08-13T16:37:06.537381Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"6\"},{\"createDate\":\"2026-08-13T16:37:04.633672Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"5\"},{\"createDate\":\"2026-08-13T16:37:02.641178Z\",\"loaded\":false,\"status\":\"DISABLED\",\"version\":\"4\"},{\"createDate\":\"2026-08-13T16:37:00.469111Z\",\"loaded\":false,\"status\":\"DISABLED\",\"version\":\"3\"},{\"createDate\":\"2026-08-13T16:36:58.500254Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"2\"},{\"createDate\":\"2026-08-13T16:36:57.324985Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"1\"}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "659"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:50.180Z",
+        "time": 183,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 183
+        }
+      },
+      {
+        "_id": "e2f6011f9b98162012cd32aa6efd5b63",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-12/versions/4"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:37:02.641178Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"4\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:50.372Z",
+        "time": 715,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 715
+        }
+      },
+      {
+        "_id": "8df2f9c00c6d1825e053675f4b4bec78",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-12/versions/3"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:37:00.469111Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"3\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:51.093Z",
+        "time": 678,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 678
+        }
+      },
+      {
+        "_id": "9b5cda4bd5451f3b5555af89247221fa",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-12/versions/2"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:36:58.500254Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:51.779Z",
+        "time": 803,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 803
+        }
+      },
+      {
+        "_id": "9b6ecf17edae451ba9c9ab1165a6c39c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-12/versions/1"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:36:57.324985Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:52.593Z",
+        "time": 890,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 890
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/SecretsOps_1659926422/pruneVersionsOfSecret_328609964/2-Prune-all-versions-except-loaded-of-secret_1096526098/recording.har
+++ b/src/test/mock-recordings/SecretsOps_1659926422/pruneVersionsOfSecret_328609964/2-Prune-all-versions-except-loaded-of-secret_1096526098/recording.har
@@ -1,0 +1,632 @@
+{
+  "log": {
+    "_recordingName": "SecretsOps/pruneVersionsOfSecret()/2: Prune all versions except loaded of secret",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "b6f728c34bf6921811ab5183dc53fd1b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1873,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-13"
+        },
+        "response": {
+          "bodySize": 254,
+          "content": {
+            "mimeType": "application/json",
+            "size": 254,
+            "text": "{\"_id\":\"esv-frodo-test-secret-13\",\"activeVersion\":\"7\",\"description\":\"description13\",\"encoding\":\"generic\",\"lastChangeDate\":\"2026-08-13T16:37:25.166889Z\",\"lastChangedBy\":\"Frodo-SA-1783448612033\",\"loaded\":true,\"loadedVersion\":\"7\",\"useInPlaceholders\":false}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "254"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:53.503Z",
+        "time": 154,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 154
+        }
+      },
+      {
+        "_id": "a84a726b5b4040f7aab91054c8cfec5d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1882,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-13/versions"
+        },
+        "response": {
+          "bodySize": 658,
+          "content": {
+            "mimeType": "application/json",
+            "size": 658,
+            "text": "[{\"createDate\":\"2026-08-13T16:37:23.967028Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"7\"},{\"createDate\":\"2026-08-13T16:37:21.706779Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"6\"},{\"createDate\":\"2026-08-13T16:37:19.016359Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"5\"},{\"createDate\":\"2026-08-13T16:37:16.554518Z\",\"loaded\":false,\"status\":\"DISABLED\",\"version\":\"4\"},{\"createDate\":\"2026-08-13T16:37:14.10671Z\",\"loaded\":false,\"status\":\"DISABLED\",\"version\":\"3\"},{\"createDate\":\"2026-08-13T16:37:11.860304Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"2\"},{\"createDate\":\"2026-08-13T16:37:10.596738Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"1\"}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "658"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:53.662Z",
+        "time": 177,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 177
+        }
+      },
+      {
+        "_id": "4e360c07ff90c48cba4b637480889940",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-13/versions/4"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:37:16.554518Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"4\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:53.846Z",
+        "time": 894,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 894
+        }
+      },
+      {
+        "_id": "f1cd9ea817cf45331ce37d513c5bb67a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-13/versions/3"
+        },
+        "response": {
+          "bodySize": 94,
+          "content": {
+            "mimeType": "application/json",
+            "size": 94,
+            "text": "{\"createDate\":\"2026-08-13T16:37:14.10671Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"3\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "94"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 299,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:54.746Z",
+        "time": 725,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 725
+        }
+      },
+      {
+        "_id": "bf9777f5f27fcb72247876e1dfc3085a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-13/versions/2"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:37:11.860304Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:55.476Z",
+        "time": 793,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 793
+        }
+      },
+      {
+        "_id": "f0e8dea82090f0ca7b890f7f8069ca0a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-13/versions/1"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:37:10.596738Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:56.277Z",
+        "time": 802,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 802
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/SecretsOps_1659926422/pruneVersionsOfSecret_328609964/3-Prune-all-versions-except-deactivated-of-secret_2510453028/recording.har
+++ b/src/test/mock-recordings/SecretsOps_1659926422/pruneVersionsOfSecret_328609964/3-Prune-all-versions-except-deactivated-of-secret_2510453028/recording.har
@@ -1,0 +1,426 @@
+{
+  "log": {
+    "_recordingName": "SecretsOps/pruneVersionsOfSecret()/3: Prune all versions except deactivated of secret",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "97c132042cc7d4961e5fc9bd4ac4ce6a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1873,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-14"
+        },
+        "response": {
+          "bodySize": 253,
+          "content": {
+            "mimeType": "application/json",
+            "size": 253,
+            "text": "{\"_id\":\"esv-frodo-test-secret-14\",\"activeVersion\":\"7\",\"description\":\"description14\",\"encoding\":\"generic\",\"lastChangeDate\":\"2026-08-13T16:37:36.215896Z\",\"lastChangedBy\":\"Frodo-SA-1783448612033\",\"loaded\":false,\"loadedVersion\":\"\",\"useInPlaceholders\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "253"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:57.095Z",
+        "time": 134,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 134
+        }
+      },
+      {
+        "_id": "2500f1a885dc382b905acd686ec5151a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1882,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-14/versions"
+        },
+        "response": {
+          "bodySize": 658,
+          "content": {
+            "mimeType": "application/json",
+            "size": 658,
+            "text": "[{\"createDate\":\"2026-08-13T16:37:35.533572Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"7\"},{\"createDate\":\"2026-08-13T16:37:34.078414Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"6\"},{\"createDate\":\"2026-08-13T16:37:32.151437Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"5\"},{\"createDate\":\"2026-08-13T16:37:30.409444Z\",\"loaded\":false,\"status\":\"DISABLED\",\"version\":\"4\"},{\"createDate\":\"2026-08-13T16:37:29.04609Z\",\"loaded\":false,\"status\":\"DISABLED\",\"version\":\"3\"},{\"createDate\":\"2026-08-13T16:37:27.341886Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"2\"},{\"createDate\":\"2026-08-13T16:37:26.440183Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"1\"}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "658"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:57.234Z",
+        "time": 175,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 175
+        }
+      },
+      {
+        "_id": "7470513825d9de72d224e9c0b7a320ff",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-14/versions/2"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:37:27.341886Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:57.414Z",
+        "time": 507,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 507
+        }
+      },
+      {
+        "_id": "5a0fb4762097b924d31bdb572c0eee31",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-14/versions/1"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:37:26.440183Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:57.928Z",
+        "time": 726,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 726
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/mock-recordings/SecretsOps_1659926422/pruneVersionsOfSecret_328609964/3-Prune-all-versions-except-loaded-and-deactivated-of-secret_158601998/recording.har
+++ b/src/test/mock-recordings/SecretsOps_1659926422/pruneVersionsOfSecret_328609964/3-Prune-all-versions-except-loaded-and-deactivated-of-secret_158601998/recording.har
@@ -1,0 +1,426 @@
+{
+  "log": {
+    "_recordingName": "SecretsOps/pruneVersionsOfSecret()/3: Prune all versions except loaded and deactivated of secret",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "dc86179e256fa4e720e8658952acbb35",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1873,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-15"
+        },
+        "response": {
+          "bodySize": 254,
+          "content": {
+            "mimeType": "application/json",
+            "size": 254,
+            "text": "{\"_id\":\"esv-frodo-test-secret-15\",\"activeVersion\":\"7\",\"description\":\"description15\",\"encoding\":\"generic\",\"lastChangeDate\":\"2026-08-13T16:37:49.615221Z\",\"lastChangedBy\":\"Frodo-SA-1783448612033\",\"loaded\":true,\"loadedVersion\":\"7\",\"useInPlaceholders\":false}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "254"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 300,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:58.669Z",
+        "time": 147,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 147
+        }
+      },
+      {
+        "_id": "7892e8a94ecedfe03e9c99453b52e7db",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1882,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-15/versions"
+        },
+        "response": {
+          "bodySize": 658,
+          "content": {
+            "mimeType": "application/json",
+            "size": 658,
+            "text": "[{\"createDate\":\"2026-08-13T16:37:48.43574Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"7\"},{\"createDate\":\"2026-08-13T16:37:46.481104Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"6\"},{\"createDate\":\"2026-08-13T16:37:44.439673Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"5\"},{\"createDate\":\"2026-08-13T16:37:42.464281Z\",\"loaded\":false,\"status\":\"DISABLED\",\"version\":\"4\"},{\"createDate\":\"2026-08-13T16:37:40.533726Z\",\"loaded\":false,\"status\":\"DISABLED\",\"version\":\"3\"},{\"createDate\":\"2026-08-13T16:37:38.430716Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"2\"},{\"createDate\":\"2026-08-13T16:37:37.109461Z\",\"loaded\":false,\"status\":\"ENABLED\",\"version\":\"1\"}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "658"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:58.829Z",
+        "time": 208,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 208
+        }
+      },
+      {
+        "_id": "9c743cd43179272da98feab7cf8f66b1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-15/versions/2"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:37:38.430716Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 299,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:59.043Z",
+        "time": 785,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 785
+        }
+      },
+      {
+        "_id": "9f3e09dc3718a2849a616b07fcfc6fc2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1887,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-frodo-test-secret-15/versions/1"
+        },
+        "response": {
+          "bodySize": 95,
+          "content": {
+            "mimeType": "application/json",
+            "size": 95,
+            "text": "{\"createDate\":\"2026-08-13T16:37:37.109461Z\",\"loaded\":false,\"status\":\"DESTROYED\",\"version\":\"1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "95"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-08-13T16:37:59.833Z",
+        "time": 1001,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1001
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/test/setup/SecretSetup.ts
+++ b/src/test/setup/SecretSetup.ts
@@ -1,8 +1,13 @@
 import { autoSetupPolly } from '../../utils/AutoSetupPolly';
 import { filterRecording } from '../../utils/PollyUtils';
-import { state } from '../../index';
+import { FrodoError, state } from '../../index';
 import * as SecretsOps from '../../ops/cloud/SecretsOps';
-import { SecretSkeleton, SecretEncodingType } from '../../api/cloud/SecretsApi';
+import {
+  SecretSkeleton,
+  SecretEncodingType,
+  VersionOfSecretStatus,
+  deleteVersionOfSecret,
+} from '../../api/cloud/SecretsApi';
 
 type TestSecret = SecretSkeleton & {
   value: string;
@@ -34,28 +39,216 @@ export const secret3 = createTestSecret({
   useInPlaceholders: true,
 });
 
+export const secret4 = createTestSecret({
+  id: 'esv-frodo-test-secret4',
+  value: `-----BEGIN CERTIFICATE-----
+MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
+A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
+MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
+YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
+ODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
+CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
+ZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl
+8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID
+AQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx
+8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy
+2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0
+Hn+GmxZA
+-----END CERTIFICATE-----`,
+  description: 'Frodo Test PEM encoded Secret Four Description',
+  encoding: 'pem',
+  useInPlaceholders: true,
+});
+
+export const secret5 = createTestSecret({
+  id: 'esv-frodo-test-secret-5',
+  value: '0nbVGkrNnIm4o5WKzYS/dL3/eo/k9EnSBH2QOOm5dLM=',
+  description: 'description5',
+  encoding: 'base64hmac',
+  useInPlaceholders: false,
+});
+
+export const secret6 = createTestSecret({
+  id: 'esv-frodo-test-secret-6',
+  value: 'value6',
+  description: 'description6',
+  encoding: 'generic',
+  useInPlaceholders: true,
+});
+
+export const secret7 = createTestSecret({
+  id: 'esv-frodo-test-secret-7',
+  value: 'value7',
+  description: 'description7',
+  encoding: 'generic',
+  useInPlaceholders: true,
+  activeValue: {
+    $crypto: {
+      type: 'x-simple-encryption',
+      value: {
+        cipher: 'AES/CBC/PKCS5Padding',
+        data: 'pVE6Y1Va4V1DB50A10mqkQ==',
+        iv: '2GjZJDuomoZeBOkr4MWBGQ==',
+        keySize: 16,
+        mac: 'A2TT/N3gBzWdQjhHo3QPjg==',
+        purpose: 'idm.password.encryption',
+        salt: 'Osc1v2DpgdnE6Bqf8SH5ng==',
+        stableId: 'openidm-sym-default',
+      },
+    },
+  },
+});
+
+export const secret8 = createTestSecret({
+  id: 'esv-frodo-test-secret-8',
+  value: 'value8',
+  description: 'description8',
+  encoding: 'generic',
+  useInPlaceholders: true,
+});
+
+export const secret9 = createTestSecret({
+  id: 'esv-frodo-test-secret-9',
+  value: 'value9',
+  description: 'description9',
+  encoding: 'generic',
+  useInPlaceholders: true,
+});
+
+export const secret10 = createTestSecret({
+  id: 'esv-frodo-test-secret-10',
+  value: 'value10',
+  description: 'description10',
+  encoding: 'generic',
+  useInPlaceholders: true,
+  activeValue: {
+    $crypto: {
+      type: 'x-simple-encryption',
+      value: {
+        cipher: 'AES/CBC/PKCS5Padding',
+        data: 'SZ8gU3fq5dGlbhPgd7kT3Q==',
+        iv: 'KCOai4hfGovwyrSswB9mow==',
+        keySize: 16,
+        mac: 'lJdfWa1DkNkxcHBMfqlXuw==',
+        purpose: 'idm.password.encryption',
+        salt: 'bqeoBikq1SB1c+ThqqQDaw==',
+        stableId: 'openidm-sym-default',
+      },
+    },
+  },
+});
+
+export const secret11 = createTestSecret({
+  id: 'esv-frodo-test-secret-11',
+  value: 'value11',
+  description: 'description11',
+  encoding: 'generic',
+  useInPlaceholders: true,
+  activeValue: {
+    $crypto: {
+      type: 'x-simple-encryption',
+      value: {
+        cipher: 'AES/CBC/PKCS5Padding',
+        data: 'Sxb6VWMMUCQ/qBmYB08kCA==',
+        iv: '7rayASsrtPPg+VAojLADdQ==',
+        keySize: 16,
+        mac: 'nx2l6Sx4k8nk3DDVXb5rqQ==',
+        purpose: 'idm.password.encryption',
+        salt: 'i4CP2IeVdFR9vTXvs69/RA==',
+        stableId: 'openidm-sym-default',
+      },
+    },
+  },
+});
+
+export const secret12 = createTestSecret({
+  id: 'esv-frodo-test-secret-12',
+  value: 'value12',
+  description: 'description12',
+  encoding: 'generic',
+  useInPlaceholders: true,
+});
+
+export const secret13 = createTestSecret({
+  id: 'esv-frodo-test-secret-13',
+  value: 'value13',
+  description: 'description13',
+  encoding: 'generic',
+  useInPlaceholders: false,
+});
+
+export const secret14 = createTestSecret({
+  id: 'esv-frodo-test-secret-14',
+  value: 'value14',
+  description: 'description14',
+  encoding: 'generic',
+  useInPlaceholders: true,
+});
+
+export const secret15 = createTestSecret({
+  id: 'esv-frodo-test-secret-15',
+  value: 'value15',
+  description: 'description15',
+  encoding: 'generic',
+  useInPlaceholders: false,
+});
+
+export const secret6Export = createTestSecretExport([secret6]);
+
+export const secret7Export = createTestSecretExport([secret7]);
+
+export const secret89Export = createTestSecretExport([secret8, secret9]);
+
+export const secret1011Export = createTestSecretExport([secret10, secret11]);
+
+export const enabledVersion1 = createSecretVersion('enabled1');
+
+export const enabledVersion2 = createSecretVersion('enabled2');
+
+export const disabledVersion1 = createSecretVersion('disabled1', 'DISABLED');
+
+export const disabledVersion2 = createSecretVersion('disabled2', 'DISABLED');
+
+export const destroyedVersion1 = createSecretVersion('destroyed1', 'DESTROYED');
+
+export const destroyedVersion2 = createSecretVersion('destroyed2', 'DESTROYED');
+
+export const allVersions = [
+  enabledVersion1,
+  enabledVersion2,
+  disabledVersion1,
+  disabledVersion2,
+  destroyedVersion1,
+  destroyedVersion2,
+];
+
 function createTestSecret({
   id,
   description,
   value,
   encoding,
   useInPlaceholders,
+  activeValue,
 }: {
   id: string;
   description: string;
   value: string;
   encoding: SecretEncodingType;
   useInPlaceholders: boolean;
+  activeValue?: any;
 }): TestSecret {
   return {
     _id: id,
     description,
     encoding,
     useInPlaceholders,
+    activeVersion: '1',
+    loadedVersion: '1',
     lastChangeDate: '2024-07-03T03:28:19.227876Z',
     lastChangedBy: 'volker.scheuber@forgerock.com',
-    loaded: false,
+    loaded: true,
     value,
+    activeValue,
   };
 }
 
@@ -75,7 +268,18 @@ export function createTestSecretExport(
   };
 }
 
-export async function stageSecret(secret: TestSecret, create = true) {
+export function createSecretVersion(
+  value: string,
+  status: VersionOfSecretStatus = 'ENABLED'
+): { value: string; status: VersionOfSecretStatus } {
+  return { value, status };
+}
+
+export async function stageSecret(
+  secret: TestSecret,
+  create = true,
+  versions: { value: string; status: VersionOfSecretStatus }[] = []
+) {
   // delete if exists, then create
   try {
     await SecretsOps.deleteSecret({ secretId: secret._id, state });
@@ -83,14 +287,55 @@ export async function stageSecret(secret: TestSecret, create = true) {
     // ignore
   }
   if (create) {
+    // We want the value of the secret to be the current version, so put it at the end of the versions array
+    versions = [...versions, createSecretVersion(secret.value)];
     await SecretsOps.createSecret({
       secretId: secret._id,
-      value: secret.value,
+      value: versions[0].value,
       description: secret.description,
       encoding: secret.encoding,
       useInPlaceholders: secret.useInPlaceholders,
       state,
     });
+    // Create versions if any are provided
+    for (let i = 1; i < versions.length; ++i) {
+      await SecretsOps.createVersionOfSecret({
+        secretId: secret._id,
+        value: versions[i].value,
+        state,
+      });
+      // Set status of the previous version since it's no longer the active version
+      switch (versions[i - 1].status) {
+        case 'DISABLED':
+          await SecretsOps.disableVersionOfSecret({
+            secretId: secret._id,
+            // Use i, not i - 1 since versions are not zero based
+            version: String(i),
+            state,
+          });
+          break;
+        case 'DESTROYED':
+          await deleteVersionOfSecret({
+            secretId: secret._id,
+            // Use i, not i - 1 since versions are not zero based
+            version: String(i),
+            state,
+          });
+          break;
+        case 'ENABLED':
+          await SecretsOps.enableVersionOfSecret({
+            secretId: secret._id,
+            // Use i, not i - 1 since versions are not zero based
+            version: String(i),
+            state,
+          });
+          break;
+        default:
+          throw new FrodoError(
+            `Unknown version status supplied: ${versions[i].status}`
+          );
+      }
+    }
   }
 }
 
@@ -112,6 +357,18 @@ export async function setup() {
       await stageSecret(secret1);
       await stageSecret(secret2);
       await stageSecret(secret3, false);
+      await stageSecret(secret4, false);
+      await stageSecret(secret5, false);
+      await stageSecret(secret6, false);
+      await stageSecret(secret7, false);
+      await stageSecret(secret8, false);
+      await stageSecret(secret9, false);
+      await stageSecret(secret10, false);
+      await stageSecret(secret11, false);
+      await stageSecret(secret12, true, allVersions);
+      await stageSecret(secret13, true, allVersions);
+      await stageSecret(secret14, true, allVersions);
+      await stageSecret(secret15, true, allVersions);
     }
   });
 
@@ -121,6 +378,18 @@ export async function setup() {
       await stageSecret(secret1, false);
       await stageSecret(secret2, false);
       await stageSecret(secret3, false);
+      await stageSecret(secret4, false);
+      await stageSecret(secret5, false);
+      await stageSecret(secret6, false);
+      await stageSecret(secret7, false);
+      await stageSecret(secret8, false);
+      await stageSecret(secret9, false);
+      await stageSecret(secret10, false);
+      await stageSecret(secret11, false);
+      await stageSecret(secret12, false);
+      await stageSecret(secret13, false);
+      await stageSecret(secret14, false);
+      await stageSecret(secret15, false);
     }
   });
 }

--- a/src/test/snapshots/ops/cloud/SecretsOps.test.js.snap
+++ b/src/test/snapshots/ops/cloud/SecretsOps.test.js.snap
@@ -665,3 +665,95 @@ exports[`SecretsOps importSecrets() 2: Import all secrets (secret10 and secret11
   },
 ]
 `;
+
+exports[`SecretsOps pruneVersionsOfSecret() 1: Prune all versions of secret 1`] = `
+[
+  {
+    "createDate": "2026-08-13T16:37:02.641178Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "4",
+  },
+  {
+    "createDate": "2026-08-13T16:37:00.469111Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "3",
+  },
+  {
+    "createDate": "2026-08-13T16:36:58.500254Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "2",
+  },
+  {
+    "createDate": "2026-08-13T16:36:57.324985Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "1",
+  },
+]
+`;
+
+exports[`SecretsOps pruneVersionsOfSecret() 2: Prune all versions except loaded of secret 1`] = `
+[
+  {
+    "createDate": "2026-08-13T16:37:16.554518Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "4",
+  },
+  {
+    "createDate": "2026-08-13T16:37:14.10671Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "3",
+  },
+  {
+    "createDate": "2026-08-13T16:37:11.860304Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "2",
+  },
+  {
+    "createDate": "2026-08-13T16:37:10.596738Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "1",
+  },
+]
+`;
+
+exports[`SecretsOps pruneVersionsOfSecret() 3: Prune all versions except deactivated of secret 1`] = `
+[
+  {
+    "createDate": "2026-08-13T16:37:27.341886Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "2",
+  },
+  {
+    "createDate": "2026-08-13T16:37:26.440183Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "1",
+  },
+]
+`;
+
+exports[`SecretsOps pruneVersionsOfSecret() 3: Prune all versions except loaded and deactivated of secret 1`] = `
+[
+  {
+    "createDate": "2026-08-13T16:37:38.430716Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "2",
+  },
+  {
+    "createDate": "2026-08-13T16:37:37.109461Z",
+    "loaded": false,
+    "status": "DESTROYED",
+    "version": "1",
+  },
+]
+`;


### PR DESCRIPTION
This feature is for the `frodo config-manager push secrets` command in the CLI. We may also end up wanting to do a `frodo esv secret version prune` command in the future (I could see this as being potentially useful, especially if secret versioning ends up playing a more prominent role in AIC), so if that's something we end up doing this feature will be useful for that as well.