### PR TITLE
feat(mcp): semantic skill aliases, config-entity hydration, and executeRecommended auto-dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ out
 
 test/fs_tmp/*
 !test/fs_tmp/.gitkeep
+
+.polaris/

--- a/src/api/IdmSystemApi.ts
+++ b/src/api/IdmSystemApi.ts
@@ -77,6 +77,22 @@ export async function readAvailableSystems({
   return data;
 }
 
+export async function readAvailableConnectors({
+  state,
+}: {
+  state: State;
+}): Promise<SystemStatusInterface[]> {
+  const urlString = util.format(
+    systemActionsUrlTemplate,
+    getIdmBaseUrl(state),
+    'availableConnectors'
+  );
+  const { data } = await generateIdmApi({ requestOverride: {}, state }).post(
+    urlString
+  );
+  return data;
+}
+
 export async function readSystemStatus({
   systemName,
   state,

--- a/src/lib/Help.ts
+++ b/src/lib/Help.ts
@@ -1669,6 +1669,14 @@ export const helpMetadata: MethodHelpDoc[] = [
   },
   {
     typeName: "IdmSystem",
+    methodName: "readAvailableConnectors",
+    signature: "readAvailableConnectors(): Promise<SystemStatusInterface[]>",
+    description: "Read available connectors",
+    params: [],
+    returns: "{Promise<SystemStatusInterface[]>} a promise resolving to an array of connector status objects",
+  },
+  {
+    typeName: "IdmSystem",
     methodName: "readSystemStatus",
     signature: "readSystemStatus(systemName: string): Promise<SystemStatusInterface>",
     description: "Read system/connector status",

--- a/src/mcp/CapabilityMetadata.ts
+++ b/src/mcp/CapabilityMetadata.ts
@@ -695,6 +695,64 @@ export const CAPABILITY_META: Record<string, OperationCapabilityMeta> = {
     notes:
       'Create a config entity with namedArgs { entityId, entityData, wait }. wait defaults to false.',
   },
+  'idm.config.readConfigEntitiesByType': {
+    argumentMode: 'named',
+    scope: 'bulk',
+    parameters: [
+      {
+        name: 'type',
+        type: 'string',
+        required: true,
+        position: 0,
+        description:
+          'IDM config entity type. Use fieldPolicy to read password policies for all realms.',
+        examples: ['fieldPolicy'],
+      },
+      {
+        name: 'includeDefault',
+        type: 'boolean',
+        required: false,
+        position: 1,
+        description:
+          'Include default email templates when reading emailTemplate entities.',
+        defaultValue: false,
+        examples: [false, true],
+      },
+    ],
+    supportsRealm: false,
+    semanticAliases: [
+      'all password policies',
+      'password policies',
+      'field policies',
+      'fieldPolicy',
+    ],
+    notes:
+      'Read password policies across realms with namedArgs { type: "fieldPolicy" }.',
+  },
+  'idm.config.readConfigEntity': {
+    argumentMode: 'named',
+    scope: 'single',
+    parameters: [
+      {
+        name: 'entityId',
+        type: 'string',
+        required: true,
+        position: 0,
+        description:
+          'IDM config entity id. AIC realm-user password policies use fieldPolicy/<realm>_user.',
+        examples: ['fieldPolicy/alpha_user'],
+      },
+    ],
+    supportsRealm: false,
+    semanticAliases: [
+      'realm password policy',
+      'password policy',
+      'field policy',
+      'fieldPolicy',
+    ],
+    notes:
+      'Read one realm password policy with namedArgs { entityId: "fieldPolicy/<realm>_user" }, for example fieldPolicy/alpha_user.',
+  },
   'idm.config.readSubConfigEntity': {
     argumentMode: 'named',
     parameters: [

--- a/src/mcp/CapabilityMetadata.ts
+++ b/src/mcp/CapabilityMetadata.ts
@@ -704,9 +704,7 @@ export const CAPABILITY_META: Record<string, OperationCapabilityMeta> = {
         type: 'string',
         required: true,
         position: 0,
-        description:
-          'IDM config entity type. Use fieldPolicy to read password policies for all realms.',
-        examples: ['fieldPolicy'],
+        description: 'IDM config entity type.',
       },
       {
         name: 'includeDefault',
@@ -724,10 +722,8 @@ export const CAPABILITY_META: Record<string, OperationCapabilityMeta> = {
       'all password policies',
       'password policies',
       'field policies',
-      'fieldPolicy',
     ],
-    notes:
-      'Read password policies across realms with namedArgs { type: "fieldPolicy" }.',
+    notes: 'Read config entities of one type with namedArgs { type }.',
   },
   'idm.config.readConfigEntity': {
     argumentMode: 'named',
@@ -738,9 +734,7 @@ export const CAPABILITY_META: Record<string, OperationCapabilityMeta> = {
         type: 'string',
         required: true,
         position: 0,
-        description:
-          'IDM config entity id. AIC realm-user password policies use fieldPolicy/<realm>_user.',
-        examples: ['fieldPolicy/alpha_user'],
+        description: 'IDM config entity id.',
       },
     ],
     supportsRealm: false,
@@ -748,10 +742,8 @@ export const CAPABILITY_META: Record<string, OperationCapabilityMeta> = {
       'realm password policy',
       'password policy',
       'field policy',
-      'fieldPolicy',
     ],
-    notes:
-      'Read one realm password policy with namedArgs { entityId: "fieldPolicy/<realm>_user" }, for example fieldPolicy/alpha_user.',
+    notes: 'Read one config entity with namedArgs { entityId }.',
   },
   'idm.config.readSubConfigEntity': {
     argumentMode: 'named',

--- a/src/mcp/CapabilityRegistry.test.ts
+++ b/src/mcp/CapabilityRegistry.test.ts
@@ -267,9 +267,9 @@ describe('MCP capability foundation', () => {
     const readNodeType = byId.get('authn.node.readNodeType');
     expect(readNodeType).toBeDefined();
     expect(readNodeType?.argumentMode).toBe('named');
-    expect(readNodeType?.parameters?.map((parameter) => parameter.name)).toEqual(
-      ['nodeType', 'nodeTypeVersion']
-    );
+    expect(
+      readNodeType?.parameters?.map((parameter) => parameter.name)
+    ).toEqual(['nodeType', 'nodeTypeVersion']);
 
     const readNodesByType = byId.get('authn.node.readNodesByType');
     expect(readNodesByType).toBeDefined();
@@ -311,6 +311,41 @@ describe('MCP capability foundation', () => {
     expect(
       createConfigEntity?.parameters?.map((parameter) => parameter.name)
     ).toEqual(['entityId', 'entityData', 'wait']);
+
+    const readConfigEntity = byId.get('idm.config.readConfigEntity');
+    expect(readConfigEntity).toMatchObject({
+      argumentMode: 'named',
+      scope: 'single',
+      semanticAliases: expect.arrayContaining([
+        'password policy',
+        'realm password policy',
+      ]),
+      parameters: [
+        expect.objectContaining({
+          name: 'entityId',
+          examples: ['fieldPolicy/alpha_user'],
+        }),
+      ],
+    });
+
+    const readConfigEntitiesByType = byId.get(
+      'idm.config.readConfigEntitiesByType'
+    );
+    expect(readConfigEntitiesByType).toMatchObject({
+      argumentMode: 'named',
+      scope: 'bulk',
+      semanticAliases: expect.arrayContaining([
+        'all password policies',
+        'password policies',
+      ]),
+      parameters: [
+        expect.objectContaining({
+          name: 'type',
+          examples: ['fieldPolicy'],
+        }),
+        expect.objectContaining({ name: 'includeDefault', required: false }),
+      ],
+    });
 
     const readManagedObject = byId.get('idm.managed.readManagedObject');
     expect(readManagedObject).toBeDefined();

--- a/src/mcp/CapabilityRegistry.test.ts
+++ b/src/mcp/CapabilityRegistry.test.ts
@@ -323,10 +323,10 @@ describe('MCP capability foundation', () => {
       parameters: [
         expect.objectContaining({
           name: 'entityId',
-          examples: ['fieldPolicy/alpha_user'],
         }),
       ],
     });
+    expect(readConfigEntity?.parameters?.[0].examples).toBeUndefined();
 
     const readConfigEntitiesByType = byId.get(
       'idm.config.readConfigEntitiesByType'
@@ -341,11 +341,11 @@ describe('MCP capability foundation', () => {
       parameters: [
         expect.objectContaining({
           name: 'type',
-          examples: ['fieldPolicy'],
         }),
         expect.objectContaining({ name: 'includeDefault', required: false }),
       ],
     });
+    expect(readConfigEntitiesByType?.parameters?.[0].examples).toBeUndefined();
 
     const readManagedObject = byId.get('idm.managed.readManagedObject');
     expect(readManagedObject).toBeDefined();

--- a/src/mcp/CapabilityRegistry.ts
+++ b/src/mcp/CapabilityRegistry.ts
@@ -223,6 +223,9 @@ function buildDescriptor(path: string[]): McpCapabilityDescriptor {
     ...(meta?.notes !== undefined && {
       notes: meta.notes,
     }),
+    ...(meta?.semanticAliases !== undefined && {
+      semanticAliases: meta.semanticAliases,
+    }),
     requiredScopes: [],
     annotations,
   };

--- a/src/mcp/CapabilityTypes.ts
+++ b/src/mcp/CapabilityTypes.ts
@@ -145,6 +145,8 @@ export type McpCapabilityDescriptor = {
   objectTypePatterns?: string[];
   /** Optional human-readable note surfaced in discovery and validation output. */
   notes?: string;
+  /** Curated natural-language phrases used to retrieve this capability. */
+  semanticAliases?: string[];
   requiredScopes: string[];
   annotations: McpToolAnnotations;
 };
@@ -239,6 +241,9 @@ export type OperationCapabilityMeta = {
 
   /** Optional human-readable note surfaced in discovery tool output. */
   notes?: string;
+
+  /** Curated natural-language phrases used for capability retrieval. */
+  semanticAliases?: string[];
 
   /** Explicit MCP-facing argument mode override for the capability. */
   argumentMode?: McpCapabilityArgumentMode;

--- a/src/mcp/DiscoveryHydration.test.ts
+++ b/src/mcp/DiscoveryHydration.test.ts
@@ -1,0 +1,91 @@
+import { jest } from '@jest/globals';
+
+import { hydrateMcpDiscoveryContext } from '../index';
+
+describe('MCP discovery hydration', () => {
+  test('hydrates both live catalogs concurrently', async () => {
+    const onEvent = jest.fn();
+    const context = await hydrateMcpDiscoveryContext({
+      frodoInstance: {
+        state: { getDeploymentType: () => 'cloud' },
+        idm: {
+          config: {
+            readManagedObjectTypes: jest.fn(async () => ['alpha_user']),
+            readConfigEntityStubs: jest.fn(async () => [
+              { _id: 'alphaOrgPrivileges' },
+              { _id: 'fieldPolicy/alpha_user' },
+            ]),
+          },
+        },
+      } as any,
+      activeTarget: { host: 'https://example.test', profile: 'all' },
+      onEvent,
+    });
+
+    expect(context).toEqual({
+      managedObjectTypes: ['alpha_user'],
+      managedObjectHydrationStatus: 'available',
+      configEntityIds: ['alphaOrgPrivileges', 'fieldPolicy/alpha_user'],
+      configEntityHydrationStatus: 'available',
+      activeTarget: { host: 'https://example.test', profile: 'all' },
+    });
+    expect(onEvent).toHaveBeenCalledTimes(2);
+  });
+
+  test('isolates catalog failures', async () => {
+    const context = await hydrateMcpDiscoveryContext({
+      frodoInstance: {
+        state: { getDeploymentType: () => 'forgeops' },
+        idm: {
+          config: {
+            readManagedObjectTypes: jest.fn(async () => ['alpha_user']),
+            readConfigEntityStubs: jest.fn(async () => {
+              throw new Error('unavailable');
+            }),
+          },
+        },
+      } as any,
+    });
+
+    expect(context.managedObjectTypes).toEqual(['alpha_user']);
+    expect(context.managedObjectHydrationStatus).toBe('available');
+    expect(context.configEntityIds).toEqual([]);
+    expect(context.configEntityHydrationStatus).toBe('failed');
+  });
+
+  test('bounds catalog hydration with the configured timeout', async () => {
+    const context = await hydrateMcpDiscoveryContext({
+      frodoInstance: {
+        state: { getDeploymentType: () => 'cloud' },
+        idm: {
+          config: {
+            readManagedObjectTypes: () => new Promise<string[]>(() => {}),
+            readConfigEntityStubs: () => new Promise<never>(() => {}),
+          },
+        },
+      } as any,
+      timeoutMs: 1,
+    });
+
+    expect(context.managedObjectHydrationStatus).toBe('timed-out');
+    expect(context.configEntityHydrationStatus).toBe('timed-out');
+  });
+
+  test('skips IDM catalogs for non-IDM deployments', async () => {
+    const readManagedObjectTypes = jest.fn();
+    const readConfigEntityStubs = jest.fn();
+    const context = await hydrateMcpDiscoveryContext({
+      frodoInstance: {
+        state: { getDeploymentType: () => 'classic' },
+        idm: {
+          config: { readManagedObjectTypes, readConfigEntityStubs },
+        },
+      } as any,
+    });
+
+    expect(context.managedObjectHydrationStatus).toBe('not-applicable');
+    expect(context.configEntityHydrationStatus).toBe('not-applicable');
+    expect(readManagedObjectTypes).not.toHaveBeenCalled();
+    expect(readConfigEntityStubs).not.toHaveBeenCalled();
+  });
+});

--- a/src/mcp/DiscoveryHydration.ts
+++ b/src/mcp/DiscoveryHydration.ts
@@ -1,0 +1,123 @@
+import { Frodo, frodo } from '../lib/FrodoLib';
+import {
+  McpCatalogHydrationStatus,
+  McpDiscoveryContext,
+  McpDiscoveryTarget,
+} from './ToolManifest';
+
+const DEFAULT_DISCOVERY_HYDRATION_TIMEOUT_MS = 3000;
+
+export type McpDiscoveryHydrationCatalog =
+  | 'managed-object-types'
+  | 'config-entity-ids';
+
+export type McpDiscoveryHydrationEvent = {
+  catalog: McpDiscoveryHydrationCatalog;
+  status: McpCatalogHydrationStatus;
+  count: number;
+  error?: unknown;
+};
+
+export type McpDiscoveryHydrationOptions = {
+  frodoInstance?: Frodo;
+  timeoutMs?: number;
+  activeTarget?: McpDiscoveryTarget;
+  onEvent?: (event: McpDiscoveryHydrationEvent) => void;
+};
+
+type CatalogHydrationResult = {
+  values: string[];
+  status: McpCatalogHydrationStatus;
+};
+
+/**
+ * Hydrates tenant catalogs used by MCP discovery and semantic skill matching.
+ * Catalog failures are isolated so service construction can continue.
+ */
+export async function hydrateMcpDiscoveryContext(
+  options: McpDiscoveryHydrationOptions = {}
+): Promise<McpDiscoveryContext> {
+  const frodoInstance = options.frodoInstance ?? frodo;
+  const deploymentType = frodoInstance.state.getDeploymentType();
+  const activeTarget = options.activeTarget
+    ? { ...options.activeTarget }
+    : undefined;
+  if (deploymentType !== 'cloud' && deploymentType !== 'forgeops') {
+    options.onEvent?.({
+      catalog: 'managed-object-types',
+      status: 'not-applicable',
+      count: 0,
+    });
+    options.onEvent?.({
+      catalog: 'config-entity-ids',
+      status: 'not-applicable',
+      count: 0,
+    });
+    return {
+      managedObjectTypes: [],
+      managedObjectHydrationStatus: 'not-applicable',
+      configEntityIds: [],
+      configEntityHydrationStatus: 'not-applicable',
+      ...(activeTarget && { activeTarget }),
+    };
+  }
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_DISCOVERY_HYDRATION_TIMEOUT_MS;
+  const [managedObjects, configEntities] = await Promise.all([
+    hydrateCatalog(
+      'managed-object-types',
+      () => frodoInstance.idm.config.readManagedObjectTypes(),
+      timeoutMs,
+      options.onEvent
+    ),
+    hydrateCatalog(
+      'config-entity-ids',
+      async () =>
+        (await frodoInstance.idm.config.readConfigEntityStubs())
+          .map((stub) => stub._id)
+          .filter(Boolean),
+      timeoutMs,
+      options.onEvent
+    ),
+  ]);
+
+  return {
+    managedObjectTypes: managedObjects.values,
+    managedObjectHydrationStatus: managedObjects.status,
+    configEntityIds: configEntities.values,
+    configEntityHydrationStatus: configEntities.status,
+    ...(activeTarget && { activeTarget }),
+  };
+}
+
+async function hydrateCatalog(
+  catalog: McpDiscoveryHydrationCatalog,
+  read: () => Promise<string[]>,
+  timeoutMs: number,
+  onEvent?: (event: McpDiscoveryHydrationEvent) => void
+): Promise<CatalogHydrationResult> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const values = await Promise.race([
+      read(),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error('MCP discovery hydration timed out.')),
+          timeoutMs
+        );
+      }),
+    ]);
+    onEvent?.({ catalog, status: 'available', count: values.length });
+    return { values, status: 'available' };
+  } catch (error) {
+    const status =
+      error instanceof Error &&
+      error.message === 'MCP discovery hydration timed out.'
+        ? 'timed-out'
+        : 'failed';
+    onEvent?.({ catalog, status, count: 0, error });
+    return { values: [], status };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}

--- a/src/mcp/McpService.ts
+++ b/src/mcp/McpService.ts
@@ -68,7 +68,11 @@ export type McpServiceOptions = {
   /** Optional runtime customization hooks. */
   runtimeOptions?: Omit<
     McpToolRuntimeOptions,
-    'frodoRoot' | 'managedObjectTypes' | 'managedObjectHydrationStatus'
+    | 'frodoRoot'
+    | 'managedObjectTypes'
+    | 'managedObjectHydrationStatus'
+    | 'configEntityIds'
+    | 'configEntityHydrationStatus'
   >;
   /** Service-local tenant metadata used only for discovery and search. */
   discoveryContext?: McpDiscoveryContext;
@@ -151,6 +155,9 @@ export function createMcpService(options: McpServiceOptions = {}): McpService {
         managedObjectTypes: options.discoveryContext.managedObjectTypes
           ? [...options.discoveryContext.managedObjectTypes]
           : undefined,
+        configEntityIds: options.discoveryContext.configEntityIds
+          ? [...options.discoveryContext.configEntityIds]
+          : undefined,
       }
     : undefined;
   const manifest = buildToolManifest(capabilities, discoveryContext);
@@ -159,6 +166,8 @@ export function createMcpService(options: McpServiceOptions = {}): McpService {
     managedObjectTypes: discoveryContext?.managedObjectTypes,
     managedObjectHydrationStatus:
       discoveryContext?.managedObjectHydrationStatus,
+    configEntityIds: discoveryContext?.configEntityIds,
+    configEntityHydrationStatus: discoveryContext?.configEntityHydrationStatus,
     ...options.runtimeOptions,
   });
 

--- a/src/mcp/SemanticIdentifiers.test.ts
+++ b/src/mcp/SemanticIdentifiers.test.ts
@@ -1,0 +1,35 @@
+import {
+  matchSemanticIdentifiers,
+  normalizeSemanticIdentifier,
+} from '../index';
+
+describe('semantic identifier normalization', () => {
+  test.each([
+    ['alphaOrgPrivileges', ['alpha', 'organization', 'privilege']],
+    ['alpha organization privileges', ['alpha', 'organization', 'privilege']],
+    ['alpha_organization', ['alpha', 'organization']],
+    ['fieldPolicy/alpha_user', ['field', 'policy', 'alpha', 'user']],
+    ['emailTemplate', ['email', 'template']],
+    ['provisioner.openicf', ['provisioner', 'openicf']],
+  ])('normalizes %s', (value, expected) => {
+    expect(normalizeSemanticIdentifier(value)).toEqual(expected);
+  });
+
+  test('prefers the fully qualified live identifier', () => {
+    expect(
+      matchSemanticIdentifiers(
+        ['default alpha organization privileges for members'],
+        ['alphaOrgPrivileges', 'bravoOrgPrivileges', 'privilegeAssignments']
+      ).map((match) => match.identifier)
+    ).toEqual(['alphaOrgPrivileges']);
+  });
+
+  test('retains equally plausible live identifiers', () => {
+    expect(
+      matchSemanticIdentifiers(
+        ['organization privileges'],
+        ['alphaOrgPrivileges', 'bravoOrgPrivileges', 'privilegeAssignments']
+      ).map((match) => match.identifier)
+    ).toEqual(['alphaOrgPrivileges', 'bravoOrgPrivileges']);
+  });
+});

--- a/src/mcp/SemanticIdentifiers.ts
+++ b/src/mcp/SemanticIdentifiers.ts
@@ -1,0 +1,72 @@
+import pluralize from 'pluralize';
+
+export const MCP_SEMANTIC_TERM_SYNONYMS: Readonly<Record<string, string>> = {
+  org: 'organization',
+};
+
+/**
+ * Converts a technical identifier or natural-language phrase into canonical
+ * semantic terms while preserving enough structure for catalog matching.
+ */
+export function normalizeSemanticIdentifier(value: string): string[] {
+  return [
+    ...new Set(
+      value
+        .trim()
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+        .toLowerCase()
+        .split(/[^a-z0-9*]+/)
+        .filter(Boolean)
+        .map((term) => {
+          const singular = pluralize.singular(term);
+          return MCP_SEMANTIC_TERM_SYNONYMS[singular] ?? singular;
+        })
+    ),
+  ];
+}
+
+export type McpSemanticIdentifierMatch = {
+  identifier: string;
+  matchedTerms: string[];
+  score: number;
+};
+
+/**
+ * Ranks live catalog identifiers against one or more semantic phrases and
+ * returns every identifier tied for the best positive score.
+ */
+export function matchSemanticIdentifiers(
+  phrases: readonly string[],
+  identifiers: readonly string[]
+): McpSemanticIdentifierMatch[] {
+  const requestedTerms = new Set(
+    phrases.flatMap((phrase) => normalizeSemanticIdentifier(phrase))
+  );
+  if (requestedTerms.size === 0) return [];
+
+  const ranked = identifiers
+    .map((identifier) => {
+      const identifierTerms = normalizeSemanticIdentifier(identifier);
+      const matchedTerms = identifierTerms.filter((term) =>
+        requestedTerms.has(term)
+      );
+      const completeMatch = matchedTerms.length === identifierTerms.length;
+      return {
+        identifier,
+        matchedTerms,
+        score:
+          matchedTerms.length * 100 +
+          Math.round((matchedTerms.length / identifierTerms.length) * 50) +
+          (completeMatch ? 50 : 0),
+      };
+    })
+    .filter((match) => match.matchedTerms.length > 0)
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        left.identifier.localeCompare(right.identifier)
+    );
+  if (ranked.length === 0) return [];
+  return ranked.filter((match) => match.score === ranked[0].score);
+}

--- a/src/mcp/SemanticObjectFamilies.ts
+++ b/src/mcp/SemanticObjectFamilies.ts
@@ -1,5 +1,6 @@
 import { distance } from 'fastest-levenshtein';
-import pluralize from 'pluralize';
+
+import { normalizeSemanticIdentifier } from './SemanticIdentifiers';
 
 export const MCP_SEMANTIC_OBJECT_SYNONYMS: Readonly<Record<string, string>> = {
   identity: 'user',
@@ -34,13 +35,7 @@ type FamilyCandidate = {
 };
 
 export function normalizeSemanticObjectFamily(value: string): string {
-  const words = value
-    .trim()
-    .toLowerCase()
-    .replace(/[_-]+/g, ' ')
-    .replace(/[^a-z0-9 ]+/g, ' ')
-    .replace(/\s+/g, ' ');
-  return pluralize.singular(words).replace(/\s+/g, '');
+  return normalizeSemanticIdentifier(value).join('');
 }
 
 export function discoverManagedObjectFamilies(

--- a/src/mcp/ToolManifest.test.ts
+++ b/src/mcp/ToolManifest.test.ts
@@ -20,12 +20,14 @@ import {
 } from '../index';
 
 describe('MCP tool manifest builder', () => {
-  test('includes target metadata and managed type count without the catalog', () => {
+  test('includes target metadata and catalog counts without catalog contents', () => {
     const inventory = buildCapabilityInventory(frodo, {
       includeTopLevelDomains: ['idm'],
     });
     const manifest = buildToolManifest(inventory, {
       managedObjectTypes: ['alpha_user', 'group'],
+      configEntityIds: ['alphaOrgPrivileges', 'fieldPolicy/alpha_user'],
+      configEntityHydrationStatus: 'available',
       activeTarget: {
         host: 'https://example.test',
         profile: 'managed-objects',
@@ -37,7 +39,12 @@ describe('MCP tool manifest builder', () => {
       profile: 'managed-objects',
     });
     expect(manifest.discoveryTool.managedObjectTypeCount).toBe(2);
+    expect(manifest.discoveryTool.configEntityIdCount).toBe(2);
+    expect(manifest.discoveryTool.configEntityHydrationStatus).toBe(
+      'available'
+    );
     expect(manifest.discoveryTool).not.toHaveProperty('managedObjectTypes');
+    expect(manifest.discoveryTool).not.toHaveProperty('configEntityIds');
   });
 
   test('produces a valid manifest shape from a domain inventory', () => {

--- a/src/mcp/ToolManifest.ts
+++ b/src/mcp/ToolManifest.ts
@@ -222,6 +222,10 @@ export type McpDiscoveryEntry = {
   managedObjectTypeCount?: number;
   /** Whether tenant managed-object type hydration completed successfully. */
   managedObjectHydrationStatus?: McpManagedObjectHydrationStatus;
+  /** Number of tenant config entity IDs available to semantic discovery. */
+  configEntityIdCount?: number;
+  /** Whether tenant config entity hydration completed successfully. */
+  configEntityHydrationStatus?: McpCatalogHydrationStatus;
   /** Sorted list of all domain keys present in the manifest. */
   domains: string[];
   /**
@@ -256,14 +260,18 @@ export type McpDiscoveryTarget = {
 export type McpDiscoveryContext = {
   managedObjectTypes?: readonly string[];
   managedObjectHydrationStatus?: McpManagedObjectHydrationStatus;
+  configEntityIds?: readonly string[];
+  configEntityHydrationStatus?: McpCatalogHydrationStatus;
   activeTarget?: McpDiscoveryTarget;
 };
 
-export type McpManagedObjectHydrationStatus =
+export type McpCatalogHydrationStatus =
   | 'available'
   | 'not-applicable'
   | 'failed'
   | 'timed-out';
+
+export type McpManagedObjectHydrationStatus = McpCatalogHydrationStatus;
 
 /**
  * The complete reduced tool surface derived from a policy-filtered capability
@@ -342,6 +350,13 @@ export function buildToolManifest(
     discoveryTool.managedObjectHydrationStatus =
       discoveryContext.managedObjectHydrationStatus;
   }
+  if (discoveryContext.configEntityIds) {
+    discoveryTool.configEntityIdCount = discoveryContext.configEntityIds.length;
+  }
+  if (discoveryContext.configEntityHydrationStatus) {
+    discoveryTool.configEntityHydrationStatus =
+      discoveryContext.configEntityHydrationStatus;
+  }
 
   // Keep domains comprehensive for discovery even when a domain is represented
   // only by special capabilities.
@@ -365,7 +380,7 @@ function buildCanonicalTools(): McpCanonicalTool[] {
     {
       toolName: FIND_SKILLS_TOOL_NAME,
       description:
-        'Search available skills under the active target and profile using concise intent or structured selectors. Compatible skills are returned by default; matched native managed-object types are included when available.',
+        'Search available skills under the active target and profile. A unique deterministic read-only recommendation executes automatically by default and is returned as execution.data; answer from that result without further discovery. Set executeRecommended=false only for diagnostics.',
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -387,7 +402,7 @@ function buildCanonicalTools(): McpCanonicalTool[] {
     {
       toolName: DISPATCH_READ_ONLY_TOOL_NAME,
       description:
-        'Execute a read-only skill (count/read/list/search) by skill id or by operation/domain/objectType selector.',
+        'Execute a read-only skill (count/read/list/search). Prefer the exact tool name and arguments returned as recommendedDispatch by frodo_find_skills.',
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/src/mcp/ToolRuntime.test.ts
+++ b/src/mcp/ToolRuntime.test.ts
@@ -6,6 +6,7 @@ import { jest } from '@jest/globals';
 
 import {
   McpCapabilityDescriptor,
+  McpToolExecutionResult,
   McpToolRuntimeTraceEvent,
   McpToolManifest,
   createToolRuntime,
@@ -380,6 +381,59 @@ describe('MCP hybrid runtime', () => {
     }
   );
 
+  test('find_skills derives hydrated config entity type matches', async () => {
+    const descriptor = makeDescriptor({
+      id: 'idm.config.readConfigEntitiesByType',
+      toolName: 'frodo.idm.config.readConfigEntitiesByType',
+      methodName: 'readConfigEntitiesByType',
+      modulePath: ['idm', 'config'],
+      domain: 'idm',
+      objectType: 'ConfigEntity',
+      argumentMode: 'named',
+      scope: 'bulk',
+      semanticAliases: ['password policies', 'field policies'],
+      parameters: [
+        {
+          name: 'type',
+          type: 'string',
+          required: true,
+          position: 0,
+        },
+      ],
+    });
+    const runtime = createToolRuntime(
+      makeManifest([descriptor]),
+      [descriptor],
+      {
+        configEntityIds: [
+          'fieldPolicy/alpha_user',
+          'fieldPolicy/bravo_user',
+          'emailTemplate/welcome',
+        ],
+      }
+    );
+
+    const result = await runtime.executeTool({
+      toolName: 'frodo_find_skills',
+      arguments: {
+        query: 'list all password policies',
+        operationTypes: ['read'],
+      },
+      context: { auth: { mode: 'state-config', config: {} } },
+    });
+    const payload = result.data as {
+      skills: Array<{
+        matchedConfigEntityTypes?: string[];
+        matchedConfigEntityTypeCount?: number;
+      }>;
+    };
+
+    expect(payload.skills[0]).toMatchObject({
+      matchedConfigEntityTypes: ['fieldPolicy'],
+      matchedConfigEntityTypeCount: 1,
+    });
+  });
+
   test.each(['cloud', 'forgeops'] as const)(
     'find_skills maps user.User coordinates to managed identities on %s',
     async (deploymentType) => {
@@ -435,6 +489,178 @@ describe('MCP hybrid runtime', () => {
       expect(payload.guidance).toBeUndefined();
     }
   );
+
+  test('find_skills maps a user domain without requiring objectType and recommends aggregate dispatch', async () => {
+    const descriptor = makeDescriptor({
+      id: 'idm.managed.countManagedObjects',
+      toolName: 'frodo.idm.managed.countManagedObjects',
+      methodName: 'countManagedObjects',
+      modulePath: ['idm', 'managed'],
+      domain: 'idm',
+      objectType: 'ManagedObject',
+      operationType: 'count',
+      deploymentTypes: ['cloud', 'forgeops'],
+      preferredDeploymentTypes: ['cloud', 'forgeops'],
+      identitySurface: 'managed',
+      objectTypePatterns: ['*'],
+    });
+    const runtime = createToolRuntime(
+      makeManifest([descriptor]),
+      [descriptor],
+      {
+        managedObjectTypes: ['alpha_user', 'bravo_user'],
+      }
+    );
+
+    const result = await runtime.executeTool({
+      toolName: 'frodo_find_skills',
+      arguments: {
+        query: 'count users in volker-dev',
+        objectFamily: 'user',
+        domain: 'user',
+        operationTypes: ['count'],
+        limit: 20,
+      },
+      context: {
+        auth: {
+          mode: 'state-config',
+          config: { deploymentType: 'cloud' },
+        },
+      },
+    });
+    const payload = result.data as {
+      returned: number;
+      guidance?: string;
+      nextAction?: string;
+      recommendedDispatch?: Record<string, unknown>;
+      skills: Array<Record<string, unknown>>;
+    };
+
+    expect(payload.returned).toBe(1);
+    expect(payload.guidance).toBeUndefined();
+    expect(payload.nextAction).toContain('Do not call frodo_discover');
+    expect(payload.recommendedDispatch).toEqual({
+      toolName: 'frodo_dispatch_read_only',
+      arguments: {
+        skillId: 'idm.managed.countManagedObjects',
+        semanticTarget: { family: 'user' },
+      },
+    });
+    expect(payload.skills[0]).toMatchObject({
+      skillId: 'idm.managed.countManagedObjects',
+      recommendedDispatch: {
+        toolName: 'frodo_dispatch_read_only',
+        arguments: {
+          skillId: 'idm.managed.countManagedObjects',
+          semanticTarget: { family: 'user' },
+        },
+      },
+    });
+  });
+
+  test('find_skills executes a unique read-only recommendation when host policy enables it', async () => {
+    const countManagedObjects = jest.fn(async (type: string) =>
+      type === 'alpha_user' ? 2020 : 2
+    );
+    const descriptor = makeDescriptor({
+      id: 'idm.managed.countManagedObjects',
+      toolName: 'frodo.idm.managed.countManagedObjects',
+      methodName: 'countManagedObjects',
+      modulePath: ['idm', 'managed'],
+      domain: 'idm',
+      objectType: 'ManagedObject',
+      operationType: 'count',
+      deploymentTypes: ['cloud', 'forgeops'],
+      preferredDeploymentTypes: ['cloud', 'forgeops'],
+      identitySurface: 'managed',
+      objectTypePatterns: ['*'],
+    });
+    const runtime = createToolRuntime(makeManifest([descriptor]), [descriptor], {
+      managedObjectTypes: ['alpha_user', 'bravo_user'],
+      managedObjectHydrationStatus: 'available',
+      executeRecommendedByDefault: true,
+      resolveFrodoForRequest: () =>
+        ({
+          login: { getTokens: jest.fn(async () => {}) },
+          idm: { managed: { countManagedObjects } },
+        }) as any,
+    });
+
+    const result = await runtime.executeTool({
+      toolName: 'frodo_find_skills',
+      arguments: {
+        query: 'count users in volker-dev',
+        objectFamily: 'user',
+        domain: 'idm',
+        operationTypes: ['count'],
+      },
+      context: {
+        auth: {
+          mode: 'state-config',
+          config: { deploymentType: 'cloud' },
+        },
+      },
+    });
+    const payload = result.data as {
+      nextAction?: string;
+      execution?: McpToolExecutionResult;
+    };
+
+    expect(payload.nextAction).toContain('execution.data');
+    expect(payload.execution).toMatchObject({
+      toolName: 'frodo_dispatch_read_only',
+      descriptorId: 'idm.managed.countManagedObjects',
+      data: {
+        family: 'user',
+        total: 2022,
+        breakdown: [
+          { type: 'alpha_user', realm: 'alpha', count: 2020 },
+          { type: 'bravo_user', realm: 'bravo', count: 2 },
+        ],
+      },
+    });
+    expect(countManagedObjects).toHaveBeenCalledTimes(2);
+  });
+
+  test('find_skills recommends exact dispatch for an explicit managed-object type', async () => {
+    const descriptor = makeDescriptor({
+      id: 'idm.managed.countManagedObjects',
+      domain: 'idm',
+      objectType: 'ManagedObject',
+      operationType: 'count',
+      identitySurface: 'managed',
+      objectTypePatterns: ['*'],
+    });
+    const runtime = createToolRuntime(
+      makeManifest([descriptor]),
+      [descriptor],
+      {
+        managedObjectTypes: ['alpha_user', 'bravo_user'],
+      }
+    );
+
+    const result = await runtime.executeTool({
+      toolName: 'frodo_find_skills',
+      arguments: {
+        query: 'count alpha_user',
+        objectFamily: 'user',
+        domain: 'idm',
+        operationTypes: ['count'],
+      },
+      context: { auth: { mode: 'state-config', config: {} } },
+    });
+    const payload = result.data as {
+      recommendedDispatch?: Record<string, unknown>;
+    };
+
+    expect(payload.recommendedDispatch).toEqual({
+      toolName: 'frodo_dispatch_read_only',
+      arguments: {
+        skillId: 'idm.managed.countManagedObjects',
+        namedArgs: { type: 'alpha_user' },
+      },
+    });
+  });
 
   test('find_skills keeps user.User coordinates on the classic AM surface', async () => {
     const managedDescriptor = makeDescriptor({
@@ -743,6 +969,66 @@ describe('MCP hybrid runtime', () => {
     expect(payload.skills[0].matchedObjectTypes).toContain('alpha_user');
     expect(payload.skills[0].matchedObjectTypes).not.toContain('bravo_user');
   });
+
+  test.each([
+    [
+      'default alpha organization privileges for members',
+      ['alphaOrgPrivileges'],
+    ],
+    [
+      'default organization privileges for members',
+      ['alphaOrgPrivileges', 'bravoOrgPrivileges'],
+    ],
+  ])(
+    'find_skills returns hydrated config entity matches: %s',
+    async (query, expectedIds) => {
+      const descriptor = makeDescriptor({
+        id: 'idm.config.readConfigEntity',
+        toolName: 'frodo.idm.config.readConfigEntity',
+        methodName: 'readConfigEntity',
+        modulePath: ['idm', 'config'],
+        domain: 'idm',
+        objectType: 'ConfigEntity',
+        argumentMode: 'named',
+        parameters: [
+          {
+            name: 'entityId',
+            type: 'string',
+            required: true,
+            position: 0,
+          },
+        ],
+      });
+      const runtime = createToolRuntime(
+        makeManifest([descriptor]),
+        [descriptor],
+        {
+          configEntityIds: [
+            'alphaOrgPrivileges',
+            'bravoOrgPrivileges',
+            'privilegeAssignments',
+          ],
+        }
+      );
+
+      const result = await runtime.executeTool({
+        toolName: 'frodo_find_skills',
+        arguments: { query, operationTypes: ['read'] },
+        context: { auth: { mode: 'state-config', config: {} } },
+      });
+      const payload = result.data as {
+        skills: Array<{
+          matchedConfigEntityIds?: string[];
+          matchedConfigEntityIdCount?: number;
+        }>;
+      };
+
+      expect(payload.skills[0]).toMatchObject({
+        matchedConfigEntityIds: expectedIds,
+        matchedConfigEntityIdCount: expectedIds.length,
+      });
+    }
+  );
 
   test.each([
     ['users', 'user', ['alpha_user', 'bravo_user']],

--- a/src/mcp/ToolRuntime.test.ts
+++ b/src/mcp/ToolRuntime.test.ts
@@ -309,57 +309,130 @@ describe('MCP hybrid runtime', () => {
     expect(payload.skills[0].skillId).toBe('authn.journey.readJourney');
   });
 
+  test.each([
+    [
+      "what's the alpha realm password policy in volker-dev?",
+      'idm.config.readConfigEntity',
+      'realm password policy',
+    ],
+    [
+      'list all realm password policies',
+      'idm.config.readConfigEntitiesByType',
+      'all password policies',
+    ],
+  ])(
+    'find_skills ranks password-policy intent: %s',
+    async (query, expectedSkillId, expectedAlias) => {
+      const singleDescriptor = makeDescriptor({
+        id: 'idm.config.readConfigEntity',
+        toolName: 'frodo.idm.config.readConfigEntity',
+        methodName: 'readConfigEntity',
+        modulePath: ['idm', 'config'],
+        domain: 'idm',
+        objectType: 'ConfigEntity',
+        scope: 'single',
+        semanticAliases: [
+          'realm password policy',
+          'password policy',
+          'field policy',
+        ],
+      });
+      const bulkDescriptor = makeDescriptor({
+        id: 'idm.config.readConfigEntitiesByType',
+        toolName: 'frodo.idm.config.readConfigEntitiesByType',
+        methodName: 'readConfigEntitiesByType',
+        modulePath: ['idm', 'config'],
+        domain: 'idm',
+        objectType: 'ConfigEntity',
+        scope: 'bulk',
+        semanticAliases: [
+          'all password policies',
+          'password policies',
+          'field policies',
+        ],
+      });
+      const descriptors = [singleDescriptor, bulkDescriptor];
+      const runtime = createToolRuntime(
+        makeManifest(descriptors),
+        descriptors,
+        {
+          resolveFrodoForRequest: () =>
+            ({ login: { getTokens: jest.fn(async () => {}) } }) as any,
+        }
+      );
+
+      const result = await runtime.executeTool({
+        toolName: 'frodo_find_skills',
+        arguments: { query, operationTypes: ['read'] },
+        context: { auth: { mode: 'state-config', config: {} } },
+      });
+      const payload = result.data as {
+        skills: Array<{
+          skillId: string;
+          matchedSemanticAliases?: string[];
+        }>;
+      };
+
+      expect(payload.skills[0]).toMatchObject({
+        skillId: expectedSkillId,
+        matchedSemanticAliases: expect.arrayContaining([expectedAlias]),
+      });
+    }
+  );
+
   test.each(['cloud', 'forgeops'] as const)(
     'find_skills maps user.User coordinates to managed identities on %s',
     async (deploymentType) => {
-    const descriptor = makeDescriptor({
-      id: 'idm.managed.countManagedObjects',
-      domain: 'idm',
-      objectType: 'ManagedObject',
-      operationType: 'count',
-      deploymentTypes: ['cloud', 'forgeops'],
-      preferredDeploymentTypes: ['cloud', 'forgeops'],
-      identitySurface: 'managed',
-      objectTypePatterns: ['user', '*_user'],
-    });
-    const runtime = createToolRuntime(makeManifest([descriptor]), [descriptor]);
+      const descriptor = makeDescriptor({
+        id: 'idm.managed.countManagedObjects',
+        domain: 'idm',
+        objectType: 'ManagedObject',
+        operationType: 'count',
+        deploymentTypes: ['cloud', 'forgeops'],
+        preferredDeploymentTypes: ['cloud', 'forgeops'],
+        identitySurface: 'managed',
+        objectTypePatterns: ['user', '*_user'],
+      });
+      const runtime = createToolRuntime(makeManifest([descriptor]), [
+        descriptor,
+      ]);
 
-    const result = await runtime.executeTool({
-      toolName: 'frodo_find_skills',
-      arguments: {
-        query: 'count users exact total',
-        domain: 'user',
-        objectType: 'User',
-        operationTypes: ['count'],
-        riskClasses: ['low'],
-        limit: 10,
-      },
-      context: {
-        auth: {
-          mode: 'state-config',
-          config: { deploymentType },
+      const result = await runtime.executeTool({
+        toolName: 'frodo_find_skills',
+        arguments: {
+          query: 'count users exact total',
+          domain: 'user',
+          objectType: 'User',
+          operationTypes: ['count'],
+          riskClasses: ['low'],
+          limit: 10,
         },
-      },
-    });
-    const payload = result.data as {
-      returned: number;
-      skills: Array<{
-        skillId: string;
-        domain: string;
-        objectType: string;
-        routingStatus: string;
-      }>;
-      guidance?: string;
-    };
+        context: {
+          auth: {
+            mode: 'state-config',
+            config: { deploymentType },
+          },
+        },
+      });
+      const payload = result.data as {
+        returned: number;
+        skills: Array<{
+          skillId: string;
+          domain: string;
+          objectType: string;
+          routingStatus: string;
+        }>;
+        guidance?: string;
+      };
 
-    expect(payload.returned).toBe(1);
-    expect(payload.skills[0]).toMatchObject({
-      skillId: 'idm.managed.countManagedObjects',
-      domain: 'idm',
-      objectType: 'ManagedObject',
-      routingStatus: 'preferred',
-    });
-    expect(payload.guidance).toBeUndefined();
+      expect(payload.returned).toBe(1);
+      expect(payload.skills[0]).toMatchObject({
+        skillId: 'idm.managed.countManagedObjects',
+        domain: 'idm',
+        objectType: 'ManagedObject',
+        routingStatus: 'preferred',
+      });
+      expect(payload.guidance).toBeUndefined();
     }
   );
 
@@ -575,41 +648,43 @@ describe('MCP hybrid runtime', () => {
     'managed object user list query identity cloud total count',
     'users',
     'users/groups',
-  ])('find_skills semantically matches managed user intent: %s', async (query) => {
-    const managedDescriptor = makeDescriptor({
-      id: 'idm.managed.countManagedObjects',
-      toolName: 'frodo.idm.managed.countManagedObjects',
-      methodName: 'countManagedObjects',
-      modulePath: ['idm', 'managed'],
-      domain: 'idm',
-      objectType: 'ManagedObject',
-      operationType: 'count',
-      deploymentTypes: ['cloud', 'forgeops'],
-      preferredDeploymentTypes: ['cloud', 'forgeops'],
-      identitySurface: 'managed',
-      objectTypePatterns: ['user', '*_user', 'group', '*_group'],
-      notes: 'Count or query managed identities and native object types.',
-    });
-    const runtime = createToolRuntime(
-      makeManifest([managedDescriptor]),
-      [managedDescriptor]
-    );
+  ])(
+    'find_skills semantically matches managed user intent: %s',
+    async (query) => {
+      const managedDescriptor = makeDescriptor({
+        id: 'idm.managed.countManagedObjects',
+        toolName: 'frodo.idm.managed.countManagedObjects',
+        methodName: 'countManagedObjects',
+        modulePath: ['idm', 'managed'],
+        domain: 'idm',
+        objectType: 'ManagedObject',
+        operationType: 'count',
+        deploymentTypes: ['cloud', 'forgeops'],
+        preferredDeploymentTypes: ['cloud', 'forgeops'],
+        identitySurface: 'managed',
+        objectTypePatterns: ['user', '*_user', 'group', '*_group'],
+        notes: 'Count or query managed identities and native object types.',
+      });
+      const runtime = createToolRuntime(makeManifest([managedDescriptor]), [
+        managedDescriptor,
+      ]);
 
-    const result = await runtime.executeTool({
-      toolName: 'frodo_find_skills',
-      arguments: { query },
-      context: {
-        auth: {
-          mode: 'state-config',
-          config: { deploymentType: 'cloud' },
+      const result = await runtime.executeTool({
+        toolName: 'frodo_find_skills',
+        arguments: { query },
+        context: {
+          auth: {
+            mode: 'state-config',
+            config: { deploymentType: 'cloud' },
+          },
         },
-      },
-    });
-    const payload = result.data as { skills: Array<{ skillId: string }> };
-    expect(payload.skills[0]?.skillId).toBe(
-      'idm.managed.countManagedObjects'
-    );
-  });
+      });
+      const payload = result.data as { skills: Array<{ skillId: string }> };
+      expect(payload.skills[0]?.skillId).toBe(
+        'idm.managed.countManagedObjects'
+      );
+    }
+  );
 
   test('find_skills rejects a non-boolean includeIncompatible value', async () => {
     const descriptor = makeDescriptor();
@@ -819,9 +894,13 @@ describe('MCP hybrid runtime', () => {
       deploymentTypes: ['cloud'],
       objectTypePatterns: ['*'],
     });
-    const runtime = createToolRuntime(makeManifest([descriptor]), [descriptor], {
-      managedObjectTypes: ['alpha_entitlement', 'bravo_entitlement'],
-    });
+    const runtime = createToolRuntime(
+      makeManifest([descriptor]),
+      [descriptor],
+      {
+        managedObjectTypes: ['alpha_entitlement', 'bravo_entitlement'],
+      }
+    );
 
     const result = await runtime.executeTool({
       toolName: 'frodo_find_skills',
@@ -936,6 +1015,44 @@ describe('MCP hybrid runtime', () => {
     expect(result.data).toEqual({ id: 'journey-123' });
   });
 
+  test('dispatch_read_only directs named-argument errors to describe_skill', async () => {
+    const descriptor = makeDescriptor({
+      argumentMode: 'named',
+      parameters: [
+        {
+          name: 'entityId',
+          type: 'string',
+          required: true,
+          position: 0,
+        },
+      ],
+    });
+    const runtime = createToolRuntime(
+      makeManifest([descriptor]),
+      [descriptor],
+      {
+        resolveFrodoForRequest: () =>
+          ({
+            login: { getTokens: jest.fn(async () => {}) },
+            authn: { journey: { readJourney: jest.fn() } },
+          }) as any,
+      }
+    );
+
+    await expect(
+      runtime.executeTool({
+        toolName: 'frodo_dispatch_read_only',
+        arguments: {
+          skillId: descriptor.id,
+          positionalArgs: ['alphaOrgPrivileges'],
+        },
+        context: { auth: { mode: 'state-config', config: {} } },
+      })
+    ).rejects.toThrow(
+      'requires namedArgs. Use frodo_describe_skill for the exact parameter contract.'
+    );
+  });
+
   test('dispatch_read_only aggregates a dynamic family across IDM realms', async () => {
     const countManagedObjects = jest.fn(async (type: string) =>
       type === 'alpha_family' ? 12 : type === 'bravo_family' ? 8 : 3
@@ -1015,13 +1132,17 @@ describe('MCP hybrid runtime', () => {
     const trace = jest.fn<(event: McpToolRuntimeTraceEvent) => void>();
     const readJourney = jest.fn(async () => ({ secretResult: 'hidden' }));
     const descriptor = makeDescriptor();
-    const runtime = createToolRuntime(makeManifest([descriptor]), [descriptor], {
-      resolveFrodoForRequest: () =>
-        ({
-          login: { getTokens: jest.fn(async () => {}) },
-          authn: { journey: { readJourney } },
-        }) as any,
-    });
+    const runtime = createToolRuntime(
+      makeManifest([descriptor]),
+      [descriptor],
+      {
+        resolveFrodoForRequest: () =>
+          ({
+            login: { getTokens: jest.fn(async () => {}) },
+            authn: { journey: { readJourney } },
+          }) as any,
+      }
+    );
 
     await runtime.executeTool({
       toolName: 'frodo_dispatch_read_only',
@@ -1120,14 +1241,18 @@ describe('MCP hybrid runtime', () => {
       identitySurface: 'am-user',
       objectTypePatterns: ['user'],
     });
-    const runtime = createToolRuntime(makeManifest([descriptor]), [descriptor], {
-      resolveFrodoForRequest: () =>
-        ({
-          state: { getDeploymentType: () => detectedDeployment },
-          login: { getTokens },
-          user: { countUsers },
-        }) as any,
-    });
+    const runtime = createToolRuntime(
+      makeManifest([descriptor]),
+      [descriptor],
+      {
+        resolveFrodoForRequest: () =>
+          ({
+            state: { getDeploymentType: () => detectedDeployment },
+            login: { getTokens },
+            user: { countUsers },
+          }) as any,
+      }
+    );
 
     await expect(
       runtime.executeTool({

--- a/src/mcp/ToolRuntime.ts
+++ b/src/mcp/ToolRuntime.ts
@@ -25,6 +25,7 @@ import {
   McpDeploymentType,
 } from './CapabilityTypes';
 import {
+  McpCatalogHydrationStatus,
   McpDiscoveryEntry,
   McpGenericTool,
   McpManagedObjectHydrationStatus,
@@ -47,6 +48,7 @@ import {
   normalizeSemanticObjectFamily,
   resolveSemanticObjectFamily,
 } from './SemanticObjectFamilies';
+import { matchSemanticIdentifiers } from './SemanticIdentifiers';
 
 const FIND_SKILLS_TOOL_NAME = 'frodo_find_skills';
 const DESCRIBE_SKILL_TOOL_NAME = 'frodo_describe_skill';
@@ -228,6 +230,8 @@ export type McpFindSkillsArguments = {
   kind?: 'generic' | 'special';
   limit?: number;
   includeIncompatible?: boolean;
+  /** Execute a unique deterministic read-only recommendation. Defaults to true. */
+  executeRecommended?: boolean;
 };
 
 export type McpDiscoverArguments = {
@@ -415,6 +419,12 @@ export type McpToolRuntimeOptions = {
   managedObjectTypes?: readonly string[];
   /** Outcome of tenant managed-object type hydration. */
   managedObjectHydrationStatus?: McpManagedObjectHydrationStatus;
+  /** Tenant config entity IDs available to service-local semantic search. */
+  configEntityIds?: readonly string[];
+  /** Outcome of tenant config entity hydration. */
+  configEntityHydrationStatus?: McpCatalogHydrationStatus;
+  /** Execute unique deterministic read-only recommendations unless a request opts out. */
+  executeRecommendedByDefault?: boolean;
 };
 
 /**
@@ -493,6 +503,8 @@ export function createToolRuntime(
         activeTarget,
         managedObjectTypeCount,
         managedObjectHydrationStatus,
+        configEntityIdCount,
+        configEntityHydrationStatus,
         ...discoveryDetails
       } = manifest.discoveryTool;
       const commonDiscoveryData = {
@@ -504,6 +516,8 @@ export function createToolRuntime(
         ...(managedObjectHydrationStatus && {
           managedObjectHydrationStatus,
         }),
+        ...(configEntityIdCount !== undefined && { configEntityIdCount }),
+        ...(configEntityHydrationStatus && { configEntityHydrationStatus }),
       };
       return {
         toolName: request.toolName,
@@ -516,6 +530,8 @@ export function createToolRuntime(
                 objectFamilies: discoverManagedObjectFamilies(
                   options.managedObjectTypes ?? []
                 ),
+                guidance:
+                  'Bootstrap is complete. Do not call frodo_discover again for this task. Call frodo_find_skills once, then execute its recommendedDispatch when present.',
                 nextSteps: [
                   FIND_SKILLS_TOOL_NAME,
                   DESCRIBE_SKILL_TOOL_NAME,
@@ -537,8 +553,19 @@ export function createToolRuntime(
         capabilities,
         args,
         deploymentType,
-        options.managedObjectTypes
+        options.managedObjectTypes,
+        options.configEntityIds
       );
+      const recommendedExecution =
+        (args.executeRecommended ??
+          options.executeRecommendedByDefault ??
+          false) && result.recommendedDispatch
+          ? await executeTool({
+              toolName: result.recommendedDispatch.toolName,
+              arguments: result.recommendedDispatch.arguments,
+              context: request.context,
+            })
+          : undefined;
       emitRuntimeTrace(request, options, {
         event: 'discovery',
         toolName: request.toolName,
@@ -556,7 +583,14 @@ export function createToolRuntime(
       });
       return {
         toolName: request.toolName,
-        data: result,
+        data: recommendedExecution
+          ? {
+              ...result,
+              nextAction:
+                'Answer the user from execution.data. The recommended read-only skill has already run; do not call any more discovery tools.',
+              execution: recommendedExecution,
+            }
+          : result,
       };
     }
 
@@ -1340,6 +1374,14 @@ function parseFindSkillsArguments(raw: unknown): McpFindSkillsArguments {
       `MCP runtime error: '${FIND_SKILLS_TOOL_NAME}' requires includeIncompatible to be a boolean when provided.`
     );
   }
+  if (
+    args.executeRecommended !== undefined &&
+    typeof args.executeRecommended !== 'boolean'
+  ) {
+    throw new FrodoError(
+      `MCP runtime error: '${FIND_SKILLS_TOOL_NAME}' requires executeRecommended to be a boolean when provided.`
+    );
+  }
   return args;
 }
 
@@ -1488,11 +1530,17 @@ function findSkills(
   capabilities: McpCapabilityDescriptor[],
   args: McpFindSkillsArguments,
   deploymentType?: McpDeploymentType,
-  managedObjectTypes: readonly string[] = []
+  managedObjectTypes: readonly string[] = [],
+  configEntityIds: readonly string[] = []
 ): {
   total: number;
   returned: number;
   guidance?: string;
+  nextAction?: string;
+  recommendedDispatch?: {
+    toolName: typeof DISPATCH_READ_ONLY_TOOL_NAME;
+    arguments: McpDispatchExecutionArguments;
+  };
   skills: Array<{
     skillId: string;
     kind: McpCapabilityDescriptor['kind'];
@@ -1514,9 +1562,24 @@ function findSkills(
     argumentMode?: McpCapabilityDescriptor['argumentMode'];
     scope?: string;
     matchedSemanticAliases?: string[];
+    matchedConfigEntityIds?: string[];
+    matchedConfigEntityIdCount?: number;
+    matchedConfigEntityTypes?: string[];
+    matchedConfigEntityTypeCount?: number;
+    recommendedDispatch?: {
+      toolName: typeof DISPATCH_READ_ONLY_TOOL_NAME;
+      arguments: McpDispatchExecutionArguments;
+    };
   }>;
 } {
   const queryTerms = normalizeSearchTerms(args.query);
+  const configEntityTypes = [
+    ...new Set(
+      configEntityIds
+        .map((id) => id.split('/')[0])
+        .filter((type): type is string => !!type)
+    ),
+  ];
   const requestedResolution = args.objectFamily
     ? resolveSemanticObjectFamily(args.objectFamily, managedObjectTypes)
     : undefined;
@@ -1618,9 +1681,25 @@ function findSkills(
       descriptor,
       args.query
     );
+    const semanticPhrases = [args.query ?? '', ...matchedSemanticAliases];
+    const configEntityMatches = descriptor.parameters?.some(
+      (parameter) => parameter.name === 'entityId'
+    )
+      ? matchSemanticIdentifiers(semanticPhrases, configEntityIds)
+      : [];
+    const configTypeMatches =
+      descriptor.modulePath.join('.') === 'idm.config' &&
+      descriptor.parameters?.some((parameter) => parameter.name === 'type')
+        ? matchSemanticIdentifiers(semanticPhrases, configEntityTypes)
+        : [];
     const relevance =
       scoreCapabilitySearch(descriptor, queryTerms) +
       scoreSemanticAliasPhrases(matchedSemanticAliases, args.query) +
+      Math.max(
+        configEntityMatches[0]?.matchedTerms.length ?? 0,
+        configTypeMatches[0]?.matchedTerms.length ?? 0
+      ) *
+        12 +
       (descriptor.scope === 'bulk' && queryTerms.includes('all') ? 32 : 0) +
       [...queryFamilies].filter((family) =>
         descriptorPatternsSupportFamily(descriptor.objectTypePatterns, family)
@@ -1635,6 +1714,8 @@ function findSkills(
             routing,
             managedObjectMatches,
             matchedSemanticAliases,
+            configEntityMatches,
+            configTypeMatches,
           },
         ]
       : [];
@@ -1656,10 +1737,31 @@ function findSkills(
         routing,
         managedObjectMatches,
         matchedSemanticAliases,
+        configEntityMatches,
+        configTypeMatches,
       }) => {
         const matchedObjectFamilies = [...queryFamilies].filter((family) =>
           descriptorPatternsSupportFamily(descriptor.objectTypePatterns, family)
         );
+        const semanticCountFamily =
+          descriptor.id === 'idm.managed.countManagedObjects' &&
+          matchedObjectFamilies.length === 1
+            ? matchedObjectFamilies[0]
+            : undefined;
+        const exactManagedObjectType = managedObjectMatches.matches.find(
+          (type) => args.query?.toLowerCase().includes(type.toLowerCase())
+        );
+        const recommendedCountArguments = exactManagedObjectType
+          ? {
+              skillId: descriptor.id,
+              namedArgs: { type: exactManagedObjectType },
+            }
+          : semanticCountFamily
+            ? {
+                skillId: descriptor.id,
+                semanticTarget: { family: semanticCountFamily },
+              }
+            : undefined;
         return {
           skillId: descriptor.id,
           kind: descriptor.kind,
@@ -1683,13 +1785,38 @@ function findSkills(
           argumentMode: descriptor.argumentMode,
           scope: descriptor.scope,
           ...(matchedSemanticAliases.length > 0 && { matchedSemanticAliases }),
+          ...(configEntityMatches.length > 0 && {
+            matchedConfigEntityIds: configEntityMatches
+              .slice(0, 5)
+              .map((match) => match.identifier),
+            matchedConfigEntityIdCount: configEntityMatches.length,
+          }),
+          ...(configTypeMatches.length > 0 && {
+            matchedConfigEntityTypes: configTypeMatches
+              .slice(0, 5)
+              .map((match) => match.identifier),
+            matchedConfigEntityTypeCount: configTypeMatches.length,
+          }),
+          ...(recommendedCountArguments && {
+            recommendedDispatch: {
+              toolName: 'frodo_dispatch_read_only' as const,
+              arguments: recommendedCountArguments,
+            },
+          }),
         };
       }
     );
 
+  const recommendedDispatch =
+    results.length === 1 ? results[0].recommendedDispatch : undefined;
   return {
     total: filtered.length,
     returned: results.length,
+    ...(recommendedDispatch && {
+      nextAction:
+        'Execute recommendedDispatch now. Do not call frodo_discover, frodo_find_skills, or frodo_describe_skill again for this read-only task.',
+      recommendedDispatch,
+    }),
     ...(results.length === 0 &&
       (args.domain || args.objectType || args.skillIdPrefix) && {
         guidance:
@@ -1706,7 +1833,7 @@ function findSkills(
 function isUserIdentitySelector(args: McpFindSkillsArguments): boolean {
   return (
     args.domain?.toLowerCase() === 'user' &&
-    args.objectType?.toLowerCase() === 'user'
+    (!args.objectType || args.objectType.toLowerCase() === 'user')
   );
 }
 

--- a/src/mcp/ToolRuntime.ts
+++ b/src/mcp/ToolRuntime.ts
@@ -1513,6 +1513,7 @@ function findSkills(
     routingReason: string;
     argumentMode?: McpCapabilityDescriptor['argumentMode'];
     scope?: string;
+    matchedSemanticAliases?: string[];
   }>;
 } {
   const queryTerms = normalizeSearchTerms(args.query);
@@ -1613,15 +1614,29 @@ function findSkills(
       managedObjectTypes,
       queryFamilies
     );
+    const matchedSemanticAliases = findMatchedSemanticAliases(
+      descriptor,
+      args.query
+    );
     const relevance =
       scoreCapabilitySearch(descriptor, queryTerms) +
+      scoreSemanticAliasPhrases(matchedSemanticAliases, args.query) +
+      (descriptor.scope === 'bulk' && queryTerms.includes('all') ? 32 : 0) +
       [...queryFamilies].filter((family) =>
         descriptorPatternsSupportFamily(descriptor.objectTypePatterns, family)
       ).length *
         8 +
       managedObjectMatches.matches.length * 6;
     return queryTerms.length === 0 || relevance > 0
-      ? [{ descriptor, relevance, routing, managedObjectMatches }]
+      ? [
+          {
+            descriptor,
+            relevance,
+            routing,
+            managedObjectMatches,
+            matchedSemanticAliases,
+          },
+        ]
       : [];
   });
 
@@ -1635,34 +1650,42 @@ function findSkills(
         left.descriptor.id.localeCompare(right.descriptor.id)
     )
     .slice(0, limit)
-    .map(({ descriptor, routing, managedObjectMatches }) => {
-      const matchedObjectFamilies = [...queryFamilies].filter((family) =>
-        descriptorPatternsSupportFamily(descriptor.objectTypePatterns, family)
-      );
-      return {
-        skillId: descriptor.id,
-        kind: descriptor.kind,
-        operationType: descriptor.operationType,
-        domain: descriptor.domain,
-        objectType: descriptor.objectType,
-        methodName: descriptor.methodName,
-        modulePath: descriptor.modulePath.join('.'),
-        riskClass: descriptor.riskClass,
-        deploymentTypes: descriptor.deploymentTypes,
-        preferredDeploymentTypes: descriptor.preferredDeploymentTypes,
-        identitySurface: descriptor.identitySurface,
-        objectTypePatterns: descriptor.objectTypePatterns,
-        ...(matchedObjectFamilies.length > 0 && { matchedObjectFamilies }),
-        ...(managedObjectMatches.total > 0 && {
-          matchedObjectTypes: managedObjectMatches.matches,
-          matchedObjectTypeCount: managedObjectMatches.total,
-        }),
-        routingStatus: routing.status,
-        routingReason: routing.reason,
-        argumentMode: descriptor.argumentMode,
-        scope: descriptor.scope,
-      };
-    });
+    .map(
+      ({
+        descriptor,
+        routing,
+        managedObjectMatches,
+        matchedSemanticAliases,
+      }) => {
+        const matchedObjectFamilies = [...queryFamilies].filter((family) =>
+          descriptorPatternsSupportFamily(descriptor.objectTypePatterns, family)
+        );
+        return {
+          skillId: descriptor.id,
+          kind: descriptor.kind,
+          operationType: descriptor.operationType,
+          domain: descriptor.domain,
+          objectType: descriptor.objectType,
+          methodName: descriptor.methodName,
+          modulePath: descriptor.modulePath.join('.'),
+          riskClass: descriptor.riskClass,
+          deploymentTypes: descriptor.deploymentTypes,
+          preferredDeploymentTypes: descriptor.preferredDeploymentTypes,
+          identitySurface: descriptor.identitySurface,
+          objectTypePatterns: descriptor.objectTypePatterns,
+          ...(matchedObjectFamilies.length > 0 && { matchedObjectFamilies }),
+          ...(managedObjectMatches.total > 0 && {
+            matchedObjectTypes: managedObjectMatches.matches,
+            matchedObjectTypeCount: managedObjectMatches.total,
+          }),
+          routingStatus: routing.status,
+          routingReason: routing.reason,
+          argumentMode: descriptor.argumentMode,
+          scope: descriptor.scope,
+          ...(matchedSemanticAliases.length > 0 && { matchedSemanticAliases }),
+        };
+      }
+    );
 
   return {
     total: filtered.length,
@@ -1938,6 +1961,9 @@ function scoreCapabilitySearch(
       [parameter.name, 4] as [string, number],
       [parameter.description ?? '', 2] as [string, number],
     ]),
+    ...(descriptor.semanticAliases ?? []).map(
+      (alias) => [alias, 10] as [string, number]
+    ),
     [descriptor.notes ?? '', 2],
   ];
   const operationAliases = [
@@ -1966,6 +1992,34 @@ function scoreCapabilitySearch(
       ? 8
       : 0;
     return score + Math.max(fieldScore, semanticScore);
+  }, 0);
+}
+
+function findMatchedSemanticAliases(
+  descriptor: McpCapabilityDescriptor,
+  query?: string
+): string[] {
+  if (!query) return [];
+  const queryTerms = new Set(normalizeSearchTerms(query));
+  return (descriptor.semanticAliases ?? []).filter((alias) => {
+    const aliasTerms = normalizeSearchTerms(alias);
+    return (
+      aliasTerms.length > 0 && aliasTerms.every((term) => queryTerms.has(term))
+    );
+  });
+}
+
+function scoreSemanticAliasPhrases(
+  aliases: readonly string[],
+  query?: string
+): number {
+  if (!query || aliases.length === 0) return 0;
+  const normalizedQuery = normalizeSearchTerms(query).join(' ');
+  return aliases.reduce((best, alias) => {
+    const normalizedAlias = normalizeSearchTerms(alias).join(' ');
+    return normalizedAlias && normalizedQuery.includes(normalizedAlias)
+      ? Math.max(best, normalizedAlias.split(' ').length * 12)
+      : best;
   }, 0);
 }
 
@@ -2142,7 +2196,7 @@ function validateInvocationArguments(
 
   if (argumentMode === 'named' && hasPositional) {
     throw new FrodoError(
-      `MCP runtime error: descriptor '${descriptor.id}' requires namedArgs. Use frodo_discover for the exact parameter contract.`
+      `MCP runtime error: descriptor '${descriptor.id}' requires namedArgs. Use frodo_describe_skill for the exact parameter contract.`
     );
   }
   if (argumentMode === 'named' && !hasNamed && requiresNamedParameters) {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -25,6 +25,12 @@ export {
   rankCapabilitiesForDeployment,
 } from './CapabilityRouting';
 export {
+  McpDiscoveryHydrationCatalog,
+  McpDiscoveryHydrationEvent,
+  McpDiscoveryHydrationOptions,
+  hydrateMcpDiscoveryContext,
+} from './DiscoveryHydration';
+export {
   MCP_AMBIGUOUS_OBJECT_CONCEPTS,
   MCP_SEMANTIC_OBJECT_SYNONYMS,
   McpManagedObjectFamilyMatch,
@@ -36,6 +42,12 @@ export {
   normalizeSemanticObjectFamily,
   resolveSemanticObjectFamily,
 } from './SemanticObjectFamilies';
+export {
+  MCP_SEMANTIC_TERM_SYNONYMS,
+  McpSemanticIdentifierMatch,
+  matchSemanticIdentifiers,
+  normalizeSemanticIdentifier,
+} from './SemanticIdentifiers';
 export {
   capabilityMatchesAnyProfile,
   capabilityMatchesDisabled,
@@ -52,6 +64,7 @@ export {
 } from './CapabilityRegistry';
 export {
   McpCanonicalTool,
+  McpCatalogHydrationStatus,
   McpDiscoveryContext,
   McpDiscoveryEntry,
   McpDiscoveryTarget,

--- a/src/ops/IdmSystemOps.test.ts
+++ b/src/ops/IdmSystemOps.test.ts
@@ -328,6 +328,12 @@ describe('IdmSystemOps', () => {
       });
     });
 
+    describe('readAvailableConnectors()', () => {
+      test('0: Method is implemented', async () => {
+        expect(IdmSystemOps.readAvailableConnectors).toBeDefined();
+      });
+    });
+
     describe('readSystemObject()', () => {
       test('0: Method is implemented', async () => {
         expect(IdmSystemOps.readSystemObject).toBeDefined();

--- a/src/ops/IdmSystemOps.ts
+++ b/src/ops/IdmSystemOps.ts
@@ -10,6 +10,7 @@ import {
   putSystemObject as _putSystemObject,
   queryAllSystemObjectIds as _queryAllSystemObjectIds,
   querySystemObjects as _querySystemObjects,
+  readAvailableConnectors as _readAvailableConnectors,
   readAvailableSystems as _readAvailableSystems,
   readSystemStatus as _readSystemStatus,
   runSystemScript as _runSystemScript,
@@ -32,6 +33,11 @@ export type IdmSystem = {
    * @returns {Promise<SystemStatusInterface[]>} a promise resolving to an array of system status objects
    */
   readAvailableSystems(): Promise<SystemStatusInterface[]>;
+  /**
+   * Read available connectors
+   * @returns {Promise<SystemStatusInterface[]>} a promise resolving to an array of connector status objects
+   */
+  readAvailableConnectors(): Promise<SystemStatusInterface[]>;
   /**
    * Read system/connector status
    * @returns {Promise<SystemStatusInterface>} a promise resolving to a system status object
@@ -175,6 +181,9 @@ export default (state: State): IdmSystem => {
     },
     async readAvailableSystems(): Promise<SystemStatusInterface[]> {
       return readAvailableSystems({ state });
+    },
+    async readAvailableConnectors(): Promise<SystemStatusInterface[]> {
+      return readAvailableConnectors({ state });
     },
     async readSystemStatus(systemName: string): Promise<SystemStatusInterface> {
       return readSystemStatus({ systemName, state });
@@ -333,6 +342,18 @@ export async function readAvailableSystems({
     return _readAvailableSystems({ state });
   } catch (error) {
     throw new FrodoError(`Error reading available systems`, error);
+  }
+}
+
+export async function readAvailableConnectors({
+  state,
+}: {
+  state: State;
+}): Promise<SystemStatusInterface[]> {
+  try {
+    return _readAvailableConnectors({ state });
+  } catch (error) {
+    throw new FrodoError(`Error reading available connectors`, error);
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds semantic skill alias scoring (`SemanticIdentifiers.ts`): `normalizeSemanticIdentifier()` and `matchSemanticIdentifiers()` for fuzzy catalog-term matching in discovery — enables object-family resolution without exact-string coupling
- Unifies discovery hydration (`DiscoveryHydration.ts`): new `hydrateMcpDiscoveryContext()` runs both managed-object type hydration and config entity ID hydration in one pass, returning a unified `McpDiscoveryContext`; exported from `src/mcp/index.ts` for frodo-cli consumption
- Wires `configEntityIds` and `configEntityHydrationStatus` into `McpService` and `ToolRuntime`
- Adds `executeRecommendedByDefault` to `McpToolRuntimeOptions`: when set, tools that return a single unambiguous read-only recommendation auto-execute it without a follow-up call; requests opt out per-call via `executeRecommended: false`
- Adds `readAvailableConnectors` to `IdmSystemOps.ts` to support connector-family discovery
- Excludes `.polaris/` local workflow state directory from git tracking

## Details

### `SemanticIdentifiers.ts` (new)

Normalization pipeline: lowercase, strip punctuation, split camelCase. `matchSemanticIdentifiers()` scores a query against a candidate list and returns ranked results above threshold. Used by the discovery layer to resolve object families by concept rather than exact type name.

### `DiscoveryHydration.ts` (new)

`hydrateMcpDiscoveryContext()` replaces the previous managed-object-only hydration path in frodo-cli with a single call that hydrates both managed objects and config entity types. The unified `McpDiscoveryContext` return type consolidates hydration status for both catalogs.

### `executeRecommendedByDefault` in `McpToolRuntimeOptions`

Opt-in service-wide flag. When true, `frodo_find_skills` responses that contain a single deterministic read-only `recommendedDispatch` execute the recommendation automatically, reducing round-trips for unambiguous lookup intent. Agents retain full control via per-call `executeRecommended: false`.

## Test plan

- [ ] `npm run build` succeeds (tsup CJS + ESM + generate-types)
- [ ] `npm test` passes

## Notes

The companion frodo-cli PR depends on `hydrateMcpDiscoveryContext` and `executeRecommendedByDefault` from this library — please merge this PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)