### PR TITLE
fix(mcp): stop probing IDM version on every login, resolve it lazily for forgeops discovery only

### DIFF
--- a/src/mcp/ToolRuntime.ts
+++ b/src/mcp/ToolRuntime.ts
@@ -15,7 +15,9 @@
 
 import { Frodo, frodo } from '../lib/FrodoLib';
 import { FrodoError } from '../ops/FrodoError';
+import { getSemanticVersion } from '../ops/AuthenticateOps';
 import * as ManagedObjectApi from '../api/ManagedObjectApi';
+import { getIdmServerVersionInfo } from '../api/ServerInfoApi';
 import { StateInterface } from '../shared/State';
 import {
   McpCapabilityDescriptor,
@@ -492,6 +494,10 @@ export function createToolRuntime(
           frodoRoot,
           options.resolveFrodoForRequest
         );
+      await ensureIdmVersionResolvedForDiscovery(
+        deploymentType,
+        discoveryScopedFrodo
+      );
       const docsContext = resolveDocsContext(
         deploymentType,
         discoveryScopedFrodo?.state?.getAmVersion?.(),
@@ -1189,6 +1195,34 @@ async function resolveDeploymentAndFrodoForDiscovery(
     deploymentType: resolveScopedDeploymentType(scopedFrodo, context),
     scopedFrodo,
   };
+}
+
+/**
+ * Lazily resolves and caches the IDM version on a scoped instance's state,
+ * for forgeops deployments only (the only deployment type whose docs
+ * routing consults it — see DocsContext.ts). Deferred out of the shared
+ * login path so plain authentication never pays for an IDM round trip that
+ * only the discovery tool's forgeops docs routing needs. Best-effort: an
+ * unreachable or misbehaving IDM instance must not fail discovery, so
+ * failures here are swallowed and simply leave the IDM version unresolved.
+ */
+async function ensureIdmVersionResolvedForDiscovery(
+  deploymentType: McpDeploymentType | undefined,
+  scopedFrodo: Frodo | undefined
+): Promise<void> {
+  const state = scopedFrodo?.state;
+  if (deploymentType !== 'forgeops' || !state || state.getIdmVersion()) {
+    return;
+  }
+  try {
+    const idmVersionInfo = await getIdmServerVersionInfo({ state });
+    const idmVersion = getSemanticVersion({
+      version: idmVersionInfo?.productVersion,
+    });
+    state.setIdmVersion(idmVersion);
+  } catch {
+    // leave the IDM version unresolved; DocsContext reports it as such
+  }
 }
 
 async function resolveDeploymentForDiscovery(

--- a/src/ops/AuthenticateOps.ts
+++ b/src/ops/AuthenticateOps.ts
@@ -13,11 +13,7 @@ import {
   step,
 } from '../api/AuthenticateApi';
 import { ServiceAccountScope } from '../api/cloud/EnvServiceAccountScopesApi';
-import {
-  getIdmServerVersionInfo,
-  getServerInfo,
-  getServerVersionInfo,
-} from '../api/ServerInfoApi';
+import { getServerInfo, getServerVersionInfo } from '../api/ServerInfoApi';
 import Constants from '../shared/Constants';
 import { State } from '../shared/State';
 import { encodeBase64Url } from '../utils/Base64Utils';
@@ -1287,27 +1283,10 @@ async function determineDeploymentTypeAndDefaultRealmAndVersion(
   const version = await getSemanticVersion(versionInfo);
   state.setAmVersion(version);
 
-  // IDM only exists alongside AM on cloud and forgeops deployments, never on
-  // classic (self-managed AM only). Best-effort: an unreachable or misbehaving
-  // IDM instance must never fail login, so failures here are swallowed and
-  // simply leave the IDM version unresolved.
-  if (
-    state.getDeploymentType() === Constants.CLOUD_DEPLOYMENT_TYPE_KEY ||
-    state.getDeploymentType() === Constants.FORGEOPS_DEPLOYMENT_TYPE_KEY
-  ) {
-    try {
-      const idmVersionInfo = await getIdmServerVersionInfo({ state });
-      const idmVersion = await getSemanticVersion({
-        version: idmVersionInfo?.productVersion,
-      });
-      state.setIdmVersion(idmVersion);
-    } catch (error) {
-      debugMessage({
-        message: `AuthenticateOps.determineDeploymentTypeAndDefaultRealmAndVersion: could not determine IDM version: ${error}`,
-        state,
-      });
-    }
-  }
+  // IDM version is deliberately NOT probed here. It is only ever consumed by
+  // MCP's forgeops docs routing (see mcp/DocsContext.ts), which fetches and
+  // caches it lazily on first use instead of paying for an extra IDM round
+  // trip on every login regardless of whether anything needs it.
 
   debugMessage({
     message: `AuthenticateOps.determineDeploymentTypeAndDefaultRealmAndVersion: end`,


### PR DESCRIPTION
## Summary

`determineDeploymentTypeAndDefaultRealmAndVersion()` (added in #628) unconditionally fetched `GET /openidm/info/version` on every login for cloud/forgeops deployments. IDM version is only ever consumed by MCP's forgeops docs routing (`DocsContext.ts`) inside the `frodo_discover` tool — cloud ignores it by design — so this was wasted work on every single login, and it broke frodo-cli's e2e suite wholesale: any Polly-recorded fixture without that new request throws a replay error, and since nearly every e2e test authenticates first, ~377 of 538 test suites failed immediately, before the command under test ever ran.

## Fix

- `src/ops/AuthenticateOps.ts`: removed the eager IDM version probe from the shared login path.
- `src/mcp/ToolRuntime.ts`: added `ensureIdmVersionResolvedForDiscovery()`, called only from the `frodo_discover` tool handler, only for `forgeops` deployments, and only if not already cached on state. Same best-effort try/catch semantics as before — an unreachable IDM instance still can't fail discovery.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full unit suite passes (106 suites / 1953 tests)
- [x] Rebuilt and linked into `frodo-cli`; e2e suite dropped from 377 failing suites to 0 systemic failures (remaining diffs were genuine, expected snapshot drift from unrelated merged features, plus 4 pre-existing local-only failures unrelated to this change)