### PR TITLE
fix: skip null/malformed entries in sync mappings and realm themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+- `MappingOps.readSyncMappings` and `MappingOps.updateMapping` no longer throw `Cannot read properties of null (reading 'name')` when a tenant's legacy `sync.json` `mappings` array contains a null/malformed entry; such entries are now skipped instead of aborting the operation.
+- `ThemeOps.getRealmThemes` now filters out null/malformed entries from the `ui/themerealm` config entity's per-realm theme array, preventing `Cannot read properties of null (reading 'name'/'_id')` in `readTheme`, `readThemeByName`, `exportThemes`, `updateTheme`, and `updateThemes`.
+
 ## [v4.4.1] - 2026-08-19
 
 ### Added

--- a/src/ops/MappingOps.ts
+++ b/src/ops/MappingOps.ts
@@ -379,10 +379,23 @@ export async function readSyncMappings({
       entityId: 'sync',
       state,
     });
-    const mappings = (sync.mappings as MappingSkeleton[]).map((it) => {
-      it._id = `sync/${it.name}`;
-      return it;
-    });
+    const rawMappings = sync.mappings as MappingSkeleton[];
+    const mappings = rawMappings
+      .filter((it) => {
+        if (!it) {
+          debugMessage({
+            message:
+              'MappingOps.readLegacyMappings: skipping null/malformed entry in sync.json mappings array',
+            state,
+          });
+          return false;
+        }
+        return true;
+      })
+      .map((it) => {
+        it._id = `sync/${it.name}`;
+        return it;
+      });
     //Add syncAfter property to mappings, according to the ordering
     const syncAfter = [];
     for (const mapping of mappings) {
@@ -583,12 +596,12 @@ export async function updateMapping({
         entityData: { mappings },
         state,
       });
-      for (const mapping of (sync.mappings as MappingSkeleton[]).map(
-        (it: MappingSkeleton) => {
+      for (const mapping of (sync.mappings as MappingSkeleton[])
+        .filter((it) => !!it)
+        .map((it: MappingSkeleton) => {
           it._id = `sync/${it.name}`;
           return it;
-        }
-      )) {
+        })) {
         if (mapping._id === mappingId) return mapping;
       }
     } catch (error) {

--- a/src/ops/ThemeOps.ts
+++ b/src/ops/ThemeOps.ts
@@ -239,7 +239,8 @@ function getRealmThemes({
   realm: string;
 }): ThemeSkeleton[] {
   if (themes.realm && themes.realm[realm]) {
-    return themes.realm[realm];
+    // Skip null/malformed entries in the tenant's ui/themerealm config.
+    return themes.realm[realm].filter((theme) => !!theme);
   }
   return [];
 }


### PR DESCRIPTION
## Summary
- `MappingOps.readSyncMappings`/`updateMapping` now skip null/malformed entries in a tenant's legacy `sync.json` `mappings` array instead of throwing `Cannot read properties of null (reading 'name')`.
- `ThemeOps.getRealmThemes` now filters out null/malformed entries from the `ui/themerealm` config entity's per-realm theme array, preventing the same class of crash in `readTheme`, `readThemeByName`, `exportThemes`, `updateTheme`, and `updateThemes`.

## Test plan
- [ ] Verify `readSyncMappings`/`updateMapping` no longer throw against a tenant with a malformed `sync.json` mappings entry
- [ ] Verify theme read/export/update operations no longer throw against a tenant with a malformed `ui/themerealm` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vpf4gkcgWJzRJ98n3DK7GE