### PR TITLE
Fix privilege classification for single escalation candidate

### DIFF
--- a/src/ops/AuthenticateOps.defaultCredential.unit.test.ts
+++ b/src/ops/AuthenticateOps.defaultCredential.unit.test.ts
@@ -105,11 +105,14 @@ jest.unstable_mockModule('./BrowserAuthenticateOps', () => ({
   }),
 }));
 
-// lookupCallerPrivilegeGroups() (CallerTrustTierOps.ts) calls readUser() at
-// fresh-login time — not exercised by any non-interactive branch here, but
-// AuthenticateOps.ts imports it (transitively) at module load time.
+// lookupCallerPrivilegeGroups()/classifyCredentialTier() call readUser() —
+// tracked (not just stubbed) so tests can assert on whether escalation
+// actually needed the network call classifyCredentialTier() exists for, or
+// correctly skipped it (see test 6 below).
+const readUser = jest.fn(async (_args?: any): Promise<any> => ({}));
+
 jest.unstable_mockModule('./UserOps', () => ({
-  readUser: jest.fn(async () => ({})),
+  readUser,
 }));
 
 const { getTokens } = await import('./AuthenticateOps');
@@ -155,6 +158,7 @@ describe('AuthenticateOps defaultCredential resolution', () => {
     accessToken.mockClear();
     step.mockClear();
     getServerInfo.mockClear();
+    readUser.mockClear();
   });
 
   test('1: No defaultCredential set — service account still wins first, unchanged from today', async () => {
@@ -216,5 +220,35 @@ describe('AuthenticateOps defaultCredential resolution', () => {
     expect(state.getAuthenticationService()).not.toBe(
       Constants.DEFAULT_AMSTER_SERVICE
     );
+  });
+
+  test("6: escalating from the service account (the only other configured credential is 'user') never calls readUser() — nothing to rank against, so classifyCredentialTier() must be skipped", async () => {
+    // Regression test for a real bug caught via CI on the actual PR: the
+    // escalation handler used to call classifyCredentialTier() (a
+    // readUser() network call) unconditionally for the 'user' candidate,
+    // even when it was the *only* remaining one — needlessly, since there
+    // was nothing to compare its rank against. That extra, unanticipated
+    // call broke every Polly-replay e2e test whose command happened to
+    // trigger an escalation at all, since no pre-existing fixture
+    // recording could have anticipated it.
+    accessToken.mockResolvedValueOnce({
+      access_token: 'valid-sa-token',
+      token_type: 'Bearer',
+      scope: 'fr:am:*',
+      expires_in: 3600,
+      expires: Date.now() + 3_600_000,
+    });
+    const state = stateWithAllThreeCredentials();
+
+    const tokens = await getTokens({ state });
+
+    expect(tokens).toBeTruthy();
+    expect(state.getActiveCredentialSource()).toBe('svcacct');
+    const escalate = state.getPrivilegeEscalationHandler();
+    expect(escalate).toBeDefined();
+
+    await escalate();
+
+    expect(readUser).not.toHaveBeenCalled();
   });
 });

--- a/src/ops/AuthenticateOps.ts
+++ b/src/ops/AuthenticateOps.ts
@@ -1556,10 +1556,23 @@ async function authenticateUser(
  * target here (only ever available as the *already-active* credential,
  * tracked via `tried` below — escalating "to" a fresh interactive login
  * would mean popping a browser mid-command, exactly what an automation
- * tool must never do). Lazy by design: does not classify every possible
- * candidate up front — `classifyCredentialTier()` (a network call) only
- * runs for a candidate actually being considered, so the common case where
- * no escalation is ever needed costs nothing extra.
+ * tool must never do).
+ *
+ * @remarks
+ * Lazy in a second, more important sense than just "no classification
+ * up front": `classifyCredentialTier()` (a `frodo.user.readUser()` network
+ * call) only runs when there are genuinely *two or more* untried,
+ * configured sources to rank against each other — the overwhelmingly
+ * common case (escalating from a service account to a plain user, or vice
+ * versa, with nothing else configured) has exactly one remaining
+ * candidate, which needs no ranking at all and is used directly. Confirmed
+ * live (a real regression, caught via CI on the browser-login PR): calling
+ * `classifyCredentialTier()` unconditionally broke every Polly-replay e2e
+ * test whose command happens to trigger an escalation, since it's a new
+ * network call no pre-existing fixture recording anticipated — most
+ * escalations never actually need the rank comparison this call exists
+ * for, so paying for it unconditionally was both wasteful and a real
+ * regression, not just a missed optimization.
  */
 function buildPrivilegeEscalationHandler({
   usingConnectionProfile,
@@ -1582,22 +1595,47 @@ function buildPrivilegeEscalationHandler({
     tried.add(initial);
   }
   return async function escalatePrivilege(): Promise<boolean> {
-    const available: EscalationCandidate[] = [];
+    const untriedSources: CredentialSource[] = [];
     if (
       !tried.has('svcacct') &&
       state.getServiceAccountId() &&
       state.getServiceAccountJwk()
     ) {
-      available.push({ source: 'svcacct', tier: 'service-account' });
+      untriedSources.push('svcacct');
     }
     if (!tried.has('user') && state.getUsername() && state.getPassword()) {
-      const tier = await classifyCredentialTier({
-        username: state.getUsername(),
-        state,
-      });
-      available.push({ source: 'user', tier });
+      untriedSources.push('user');
     }
-    const next = pickNextEscalationCandidate({ available, tried });
+    let next: EscalationCandidate | undefined;
+    if (untriedSources.length === 1) {
+      // Nothing to rank against — classifying this one candidate's tier
+      // couldn't change which one gets picked, so skip the network call
+      // entirely.
+      const [source] = untriedSources;
+      next = {
+        source,
+        tier: source === 'svcacct' ? 'service-account' : 'unknown',
+      };
+    } else if (untriedSources.length > 1) {
+      // Only realistic way to reach here: escalating away from a browser
+      // session that also has both a service account and a plain user
+      // configured on the same profile — a genuine choice, so it's worth
+      // the one classifyCredentialTier() call needed to rank them.
+      const available: EscalationCandidate[] = untriedSources.map(
+        (source) => ({ source, tier: 'service-account' as const })
+      );
+      const userIndex = untriedSources.indexOf('user');
+      if (userIndex !== -1) {
+        available[userIndex] = {
+          source: 'user',
+          tier: await classifyCredentialTier({
+            username: state.getUsername(),
+            state,
+          }),
+        };
+      }
+      next = pickNextEscalationCandidate({ available, tried });
+    }
     if (!next) {
       return false;
     }


### PR DESCRIPTION
… remains

buildPrivilegeEscalationHandler() called classifyCredentialTier() (a readUser() network call) unconditionally for the 'user' candidate even when it was the only untried source left, with nothing to rank it against. This broke every Polly-replay e2e test whose command happened to trigger an escalation, since no fixture recording anticipated the new request — caught via CI on the browser-login PR (8 failing suites, all a missing recording for GET .../users/<email>).

Now only classifies when two or more untried sources are available to rank against each other; a lone remaining candidate is used directly.


Claude-Session: https://claude.ai/code/session_01LELpRLKxwcMLpQ1uMxWxc3