### PR TITLE
Prevent escalation on 403 errors for unavailable services

### DIFF
--- a/src/api/BaseApi.credentialInterceptor.unit.test.ts
+++ b/src/api/BaseApi.credentialInterceptor.unit.test.ts
@@ -526,6 +526,7 @@ describe('BaseApi credential interceptor — item 1+21 privilege escalation', ()
 describe('BaseApi credential interceptor — item 1+21 privilege escalation on a live 403', () => {
   test('15: a GET that 403s escalates and retries with the newly-escalated credential', async () => {
     const state = StateImpl({});
+    state.setActiveCredentialSource('browser');
     state.setBearerTokenMeta({
       access_token: 'limited-bearer',
       token_type: 'Bearer',
@@ -612,6 +613,7 @@ describe('BaseApi credential interceptor — item 1+21 privilege escalation on a
 
   test('18: a GET 403 where the escalation handler has nothing left to try propagates the original 403 unchanged', async () => {
     const state = StateImpl({});
+    state.setActiveCredentialSource('browser');
     state.setBearerTokenMeta({
       access_token: 'limited-bearer',
       token_type: 'Bearer',
@@ -662,6 +664,9 @@ describe('BaseApi credential interceptor — item 1+21 privilege escalation on a
 
   test('20: a GET 403 for a legacy service unavailable on this deployment type never triggers escalation, regardless of product-name wording — a real regression caught via CI', async () => {
     const state = StateImpl({});
+    // A browser-login session, so this exercises the message-based
+    // exclusion specifically, not the (also-true) starting-tier gate below.
+    state.setActiveCredentialSource('browser');
     state.setUseBearerTokenForAmApis(true);
     state.setBearerTokenMeta({
       access_token: 'sufficiently-privileged-bearer',
@@ -694,6 +699,7 @@ describe('BaseApi credential interceptor — item 1+21 privilege escalation on a
 
   test('21: the same exclusion matches the current "PingOne Advanced Identity Cloud" wording too', async () => {
     const state = StateImpl({});
+    state.setActiveCredentialSource('browser');
     state.setUseBearerTokenForAmApis(true);
     state.setBearerTokenMeta({
       access_token: 'sufficiently-privileged-bearer',
@@ -725,8 +731,9 @@ describe('BaseApi credential interceptor — item 1+21 privilege escalation on a
     expect(escalationCalls).toBe(0);
   });
 
-  test('22: an ordinary 403 with unrelated message text still escalates as before — the exclusion is narrow', async () => {
+  test('22: an ordinary 403 with unrelated message text still escalates as before, for a browser-started session — the exclusion is narrow', async () => {
     const state = StateImpl({});
+    state.setActiveCredentialSource('browser');
     state.setBearerTokenMeta({
       access_token: 'limited-bearer',
       token_type: 'Bearer',
@@ -761,5 +768,59 @@ describe('BaseApi credential interceptor — item 1+21 privilege escalation on a
 
     expect(response.status).toBe(200);
     expect(escalationCalls).toBe(1);
+  });
+
+  test('23: a GET 403 on a non-browser-started session (service account) never triggers escalation, even for an ordinary/unmatched 403 message — the real regression caught via CI (idm export hitting a routine, already-tolerated per-entity "Access denied" 403)', async () => {
+    const state = StateImpl({});
+    state.setActiveCredentialSource('svcacct');
+    state.setBearerTokenMeta({
+      access_token: 'sufficiently-privileged-bearer',
+      token_type: 'Bearer',
+      scope: 'fr:idm:*',
+      expires_in: 3600,
+      expires: Date.now() + 60 * 60 * 1000,
+    } as any);
+    let escalationCalls = 0;
+    state.setPrivilegeEscalationHandler(async () => {
+      escalationCalls++;
+      return true;
+    });
+    const adapter = scriptedAdapter(() => ({
+      status: 403,
+      data: { message: 'Access denied' },
+    }));
+    const request = generateIdmApi({
+      state,
+      requiredScopes: [],
+      requestOverride: { adapter },
+    });
+
+    await expect(request.get('/whatever')).rejects.toThrow(/403/);
+    expect(escalationCalls).toBe(0);
+  });
+
+  test('24: a GET 403 with no active credential source recorded at all never triggers escalation (fails closed, same as any other non-browser source)', async () => {
+    const state = StateImpl({});
+    state.setBearerTokenMeta({
+      access_token: 'sufficiently-privileged-bearer',
+      token_type: 'Bearer',
+      scope: 'fr:idm:*',
+      expires_in: 3600,
+      expires: Date.now() + 60 * 60 * 1000,
+    } as any);
+    let escalationCalls = 0;
+    state.setPrivilegeEscalationHandler(async () => {
+      escalationCalls++;
+      return true;
+    });
+    const adapter = scriptedAdapter(() => ({ status: 403 }));
+    const request = generateIdmApi({
+      state,
+      requiredScopes: [],
+      requestOverride: { adapter },
+    });
+
+    await expect(request.get('/whatever')).rejects.toThrow(/403/);
+    expect(escalationCalls).toBe(0);
   });
 });

--- a/src/api/BaseApi.ts
+++ b/src/api/BaseApi.ts
@@ -424,18 +424,35 @@ function isDeploymentTypeUnavailableError(error: AxiosError): boolean {
  * GET requests have no such risk at all: retrying a read with a different
  * credential can never cause an unwanted mutation.
  *
- * Also excludes `isDeploymentTypeUnavailableError()` matches: a real
- * regression, caught via CI on the browser-login PR, where a fully-
- * privileged service account's routine "list all services" sweep hit AM's
- * standard 403 for a legacy service with no cloud equivalent
- * (`id-repositories`, `DataStoreService`), and escalation dutifully — but
- * pointlessly — tried a real re-authentication with the profile's plain
- * user/password before giving up and surfacing the original error anyway.
- * No credential, however privileged, can make a structurally-absent
- * endpoint appear, so attempting one is never useful, and in production
- * would mean every ordinary "sweep every legacy service" export triggers
- * a real, unnecessary login round trip (and, more importantly, exercises
- * a real credential against a real IdP repeatedly for no reason).
+ * Also restricted to sessions whose *active* credential source is
+ * `'browser'` — i.e. only a scope-limited super/tenant-admin browser
+ * login, tenant-auditor, or theme-admin session (the tiers this mechanism
+ * exists for in the first place — see the class doc above) is ever
+ * eligible for a live-403-triggered escalation attempt. A service account
+ * or plain user is already tier 3 or higher on the documented privilege
+ * hierarchy; the only things they can't do that a more privileged
+ * credential could (managing other admin users, managing service
+ * accounts themselves) are already scope-gated and so already caught,
+ * more reliably, by `attachCredentialInterceptor`'s *pre-flight*
+ * `InsufficientScopeError` check above — which this restriction does not
+ * touch. Everything else a fully-privileged svcacct/user 403s on during
+ * an ordinary bulk sweep (`config export --all`, `idm export -a`, etc.)
+ * has turned out, twice now via real CI failures on the browser-login PR,
+ * to be a condition the calling ops code already tolerates as normal and
+ * expected — a legacy AM service with no cloud equivalent
+ * (`id-repositories`, `DataStoreService`), or one specific IDM config
+ * entity a tenant genuinely can't read (`fidc/federation-EntraID`,
+ * "Access denied") — not a privilege gap escalating could ever fix.
+ * Message-matching each newly-discovered "already tolerated" 403 pattern
+ * one at a time (see `isDeploymentTypeUnavailableError()` below, kept as
+ * a second, narrower layer of defense) doesn't scale: this class of
+ * lenient-per-item error handling exists throughout the ops layer, in
+ * more files than can be enumerated up front, so relying on message text
+ * alone would keep resurfacing the same failure with a new shape. Gating
+ * on the *starting* credential's tier instead fixes the whole class at
+ * once, for the overwhelmingly common case (an automation run using a
+ * service account or plain user, not a browser login) — without weakening
+ * the signal for the tiers it actually exists to help.
  *
  * No separate retry-count guard is needed: `state
  * .getPrivilegeEscalationHandler()`'s own `tried` bookkeeping (see
@@ -457,6 +474,7 @@ function attachEscalationResponseInterceptor(
         status === 403 &&
         method === 'get' &&
         config &&
+        state.getActiveCredentialSource() === 'browser' &&
         !isDeploymentTypeUnavailableError(error)
       ) {
         const escalate = state.getPrivilegeEscalationHandler();


### PR DESCRIPTION
attachEscalationResponseInterceptor() treated any GET 403 as a privilege-insufficiency signal, escalating for a service account or plain-user session too. But those are already tier 3+ on the documented privilege hierarchy — the only things they can't do that a more privileged credential could (managing other admins, managing service accounts) are already scope-gated and caught more reliably by the pre-flight InsufficientScopeError path, which this change doesn't touch.

Caught via CI on the browser-login PR, a second time: an already-fixed AM "not available in Identity Cloud" 403 was one instance of a broader problem — a fully-scoped service account's routine `idm export -a` hit a *different*, unrelated, already-tolerated 403 (a single IDM config entity, "Access denied") that IdmConfigOps.ts already prints and moves past. Escalation still tried a real re-authentication with the profile's plain user/password first, breaking the same class of Polly-replay e2e test again, just via a different, previously unseen 403 message. Message-matching each newly discovered "already tolerated" 403 doesn't scale: this lenient per-item error handling exists throughout the ops layer. Gating live-403 escalation on the *starting* credential's tier (only 'browser' — auditor/theme-admin/scope-limited admin sessions, the actual tiers this mechanism exists for) fixes the whole class at once.

Reproduced locally for the first time this session after discovering e2e tests shell out to frodo-cli's built dist/app.cjs binary, not the source — a stale, unrebuilt binary was silently masking the failure in every earlier local verification attempt (see the frodo-cli-e2e-tests-shell-out-to-built-binary memory).


Claude-Session: https://claude.ai/code/session_01LELpRLKxwcMLpQ1uMxWxc3