### PR TITLE
Implement browser-based interactive login and session enhancements

### DIFF
--- a/src/api/BaseApi.ts
+++ b/src/api/BaseApi.ts
@@ -264,6 +264,46 @@ async function resolveAmRequestCredential(
 }
 
 /**
+ * Resolves the credential for an authentication/session/server-info-domain
+ * request (`generateAmAuthApi()`'s call sites) at send time — deliberately
+ * NOT `resolveAmRequestCredential()` above, despite the overlap. That
+ * function's staleness-check-and-refresh behavior is correct for ordinary
+ * post-login AM business-logic calls, but wrong here: this generator's own
+ * call sites (`AuthenticateApi.step()`, `SessionApi.ts`,
+ * `ServerInfoApi.ts`) include the login/tree-authentication flow itself,
+ * where a session cookie set moments ago by one step in a live-recorded
+ * fixture can appear "expired" purely because the fixture's own recorded
+ * timestamp is old relative to wall-clock replay time — confirmed as a real
+ * regression (a genuine, previously-passing classic login test started
+ * throwing "cannot be silently refreshed") when this generator briefly
+ * shared the other resolver. So: still check
+ * `state.getAmCredentialProvider()` first (the actual bug this generator
+ * needed fixed — a browser-login session's on-demand RFC 8693 exchange was
+ * never consulted here at all, so a plain `frodo info <host>` right after
+ * `frodo login --browser` sent no credential whatsoever and 403'd with "No
+ * session for request"), but otherwise fall back to the exact same
+ * unconditional, no-staleness-check cookie/bearer read this generator
+ * always had.
+ */
+async function resolveAmAuthRequestCredential(
+  state: State
+): Promise<AmCredentialOverride | null> {
+  const provider = state.getAmCredentialProvider();
+  if (provider) {
+    return provider([]);
+  }
+  if (state.getUseBearerTokenForAmApis()) {
+    const token = state.getBearerToken();
+    return token ? { header: 'Authorization', value: `Bearer ${token}` } : null;
+  }
+  const cookieName = state.getCookieName();
+  const cookieValue = state.getCookieValue();
+  return cookieName && cookieValue
+    ? { header: 'Cookie', value: `${cookieName}=${cookieValue}` }
+    : null;
+}
+
+/**
  * Resolves the `Authorization: Bearer` header for an IDM/environment/
  * governance-domain request, at actual send time — see
  * `resolveAmRequestCredential`'s remarks for why this matters. These domains
@@ -646,17 +686,6 @@ export function generateAmAuthApi({
     'Content-Type': 'application/json',
     // only add API version if we have it
     ...(resource.apiVersion && { 'Accept-API-Version': resource.apiVersion }),
-    // only send session cookie if we know its name and value and we are not instructed to use the bearer token for AM APIs
-    ...(!state.getUseBearerTokenForAmApis() &&
-      state.getCookieName() &&
-      state.getCookieValue() && {
-        Cookie: `${state.getCookieName()}=${state.getCookieValue()}`,
-      }),
-    // only add authorization header if we have a bearer token and are instructed to use it for AM APIs
-    ...(state.getUseBearerTokenForAmApis() &&
-      state.getBearerToken() && {
-        Authorization: `Bearer ${state.getBearerToken()}`,
-      }),
   };
 
   const requestConfig = mergeDeep(
@@ -678,6 +707,26 @@ export function generateAmAuthApi({
   );
 
   const request = createAxiosInstance(state, requestConfig);
+
+  // Resolve the actual credential (session cookie, bearer token, or — for
+  // cloud browser-login mode — a freshly RFC 8693-exchanged token) right
+  // before this request is sent. This generator used to build its headers
+  // once, synchronously, at construction time, checking only a plain
+  // session cookie or a bearer token gated by getUseBearerTokenForAmApis().
+  // It never knew about getAmCredentialProvider() at all, so a browser-login
+  // session (which deliberately never sets that flag — see
+  // applyCloudInteractiveToken's own remarks) got a request with no
+  // credential whatsoever: a real, live-repro'd bug (`frodo info <host>`
+  // 403 "No session for request" immediately after a successful `frodo
+  // login --browser`). Uses resolveAmAuthRequestCredential(), not
+  // resolveAmRequestCredential() — see that function's own remarks for why
+  // this generator specifically must not inherit the staleness-check/
+  // refresh/scope-gating behavior bundled into the other one.
+  attachCredentialInterceptor(
+    request,
+    () => resolveAmAuthRequestCredential(state),
+    state
+  );
 
   // enable curlirizer output in debug mode
   if (state.getCurlirize()) {

--- a/src/lib/Help.ts
+++ b/src/lib/Help.ts
@@ -927,7 +927,7 @@ export const helpMetadata: MethodHelpDoc[] = [
   {
     typeName: "Authenticate",
     methodName: "getTokens",
-    signature: "getTokens( forceLoginAsUser?: boolean, autoRefresh?: boolean, types?: string[], callbackHandler?: CallbackHandler, useDeviceFlow?: boolean, promptHandler?: BrowserLoginPromptHandler ): Promise<Tokens>",
+    signature: "getTokens( forceLoginAsUser?: boolean, autoRefresh?: boolean, types?: string[], callbackHandler?: CallbackHandler, useDeviceFlow?: boolean, promptHandler?: BrowserLoginPromptHandler, credentialOverride?: 'user' | 'svcacct' | 'amster' | 'browser' ): Promise<Tokens>",
     description: "Get tokens and store them in State",
     params: [
       { name: "forceLoginAsUser", type: "boolean", description: "true to force login as user even if a service account or Amster account is available (default: false)", required: false },

--- a/src/ops/AuthenticateOps.browserSessionReuse.unit.test.ts
+++ b/src/ops/AuthenticateOps.browserSessionReuse.unit.test.ts
@@ -403,4 +403,103 @@ describe('getTokens() reuses a cached browser-login session instead of a fresh i
       })
     ).rejects.toThrow();
   });
+
+  test("8: credentialOverride 'browser' reuses a merely-cached session on a later call with nothing else configured, same as the ambient default", async () => {
+    const cachePath = resolve(TMP_DIR, `${Math.random()}.TokenCache.json`);
+    runInteractiveAuthorizationCodeFlow.mockResolvedValueOnce({
+      access_token: fakeAccessTokenJwt('jdoe'),
+      token_type: 'Bearer',
+      scope: 'fr:idm:*',
+      expires_in: 1800,
+      expires: Date.now() + 1_800_000,
+    });
+    await getTokens({
+      state: freshState({ cachePath, deploymentType: 'cloud' }),
+      autoRefresh: false,
+      promptHandler,
+    });
+
+    const laterState = StateImpl({
+      host: 'https://openam-session-reuse.example.com/am',
+    });
+    laterState.setUseTokenCache(true);
+    laterState.setTokenCachePath(cachePath);
+    laterState.setMasterKeyPath(resolve(TMP_DIR, 'masterkey.key'));
+    laterState.setDeploymentType('cloud');
+
+    const later = await getTokens({
+      state: laterState,
+      autoRefresh: false,
+      credentialOverride: 'browser',
+      promptHandler,
+    });
+    expect(later.subject).toBe('jdoe');
+    expect(runInteractiveAuthorizationCodeFlow).toHaveBeenCalledTimes(1);
+  });
+
+  test("9: credentialOverride 'browser' with no cached session at all fails clearly instead of falling back to a fresh interactive login or a different credential", async () => {
+    const laterState = StateImpl({
+      host: 'https://openam-session-reuse.example.com/am',
+    });
+    laterState.setUseTokenCache(true);
+    laterState.setTokenCachePath(
+      resolve(TMP_DIR, `${Math.random()}.TokenCache.json`)
+    );
+    laterState.setMasterKeyPath(resolve(TMP_DIR, 'masterkey.key'));
+    laterState.setDeploymentType('cloud');
+
+    let caught: any;
+    try {
+      await getTokens({
+        state: laterState,
+        autoRefresh: false,
+        credentialOverride: 'browser',
+        promptHandler,
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.originalErrors?.[0]?.message).toMatch(
+      /No valid cached browser-login session/
+    );
+    expect(runInteractiveAuthorizationCodeFlow).not.toHaveBeenCalled();
+  });
+
+  test("10: credentialOverride 'browser' wins even over a saved defaultCredential that would otherwise skip the cached session entirely", async () => {
+    const cachePath = resolve(TMP_DIR, `${Math.random()}.TokenCache.json`);
+    runInteractiveAuthorizationCodeFlow.mockResolvedValueOnce({
+      access_token: fakeAccessTokenJwt('jdoe'),
+      token_type: 'Bearer',
+      scope: 'fr:idm:*',
+      expires_in: 1800,
+      expires: Date.now() + 1_800_000,
+    });
+    await getTokens({
+      state: freshState({ cachePath, deploymentType: 'cloud' }),
+      autoRefresh: false,
+      promptHandler,
+    });
+
+    const laterState = StateImpl({
+      host: 'https://openam-session-reuse.example.com/am',
+    });
+    laterState.setUseTokenCache(true);
+    laterState.setTokenCachePath(cachePath);
+    laterState.setMasterKeyPath(resolve(TMP_DIR, 'masterkey.key'));
+    laterState.setDeploymentType('cloud');
+    // Without credentialOverride, this alone would make tryBrowserLogin()
+    // skip the cached session entirely (per test 7's own mechanism) — and
+    // since nothing else is configured, getTokens() would reject.
+    laterState.setDefaultCredential('svcacct');
+
+    const later = await getTokens({
+      state: laterState,
+      autoRefresh: false,
+      credentialOverride: 'browser',
+      promptHandler,
+    });
+    expect(later.subject).toBe('jdoe');
+    expect(runInteractiveAuthorizationCodeFlow).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/ops/AuthenticateOps.defaultCredential.unit.test.ts
+++ b/src/ops/AuthenticateOps.defaultCredential.unit.test.ts
@@ -251,4 +251,60 @@ describe('AuthenticateOps defaultCredential resolution', () => {
 
     expect(readUser).not.toHaveBeenCalled();
   });
+
+  test("7: credentialOverride 'svcacct' wins even over an explicit defaultCredential 'user' — a stronger, per-invocation override", async () => {
+    const state = stateWithAllThreeCredentials();
+    state.setDefaultCredential('user');
+
+    const underlying = await getUnderlyingError(
+      getTokens({ state, credentialOverride: 'svcacct' })
+    );
+
+    expect(underlying).toBe(SVCACCT_SENTINEL);
+    expect(step).not.toHaveBeenCalled();
+  });
+
+  test("8: credentialOverride 'amster' skips service account and plain user, forcing the amster branch", async () => {
+    const state = stateWithAllThreeCredentials();
+
+    const underlying = await getUnderlyingError(
+      getTokens({ state, credentialOverride: 'amster' })
+    );
+
+    expect(accessToken).not.toHaveBeenCalled();
+    expect(underlying).toBe(TREE_LOGIN_SENTINEL);
+    expect(state.getAuthenticationService()).toBe(
+      Constants.DEFAULT_AMSTER_SERVICE
+    );
+  });
+
+  test("9: credentialOverride 'user' skips service account and amster, forcing the plain-user branch", async () => {
+    const state = stateWithAllThreeCredentials();
+
+    const underlying = await getUnderlyingError(
+      getTokens({ state, credentialOverride: 'user' })
+    );
+
+    expect(accessToken).not.toHaveBeenCalled();
+    expect(underlying).toBe(TREE_LOGIN_SENTINEL);
+    expect(state.getAuthenticationService()).not.toBe(
+      Constants.DEFAULT_AMSTER_SERVICE
+    );
+  });
+
+  test("10: credentialOverride 'svcacct' on a profile with no service account configured fails clearly instead of silently falling through to amster/user", async () => {
+    const state = StateImpl({ host: 'https://openam-example.forgeblocks.com/am' });
+    state.setAmsterPrivateKey('fake-amster-key');
+    state.setUsername('plain-user');
+    state.setPassword('plain-password');
+    state.setUseTokenCache(false);
+
+    const underlying = await getUnderlyingError(
+      getTokens({ state, credentialOverride: 'svcacct' })
+    );
+
+    expect(accessToken).not.toHaveBeenCalled();
+    expect(step).not.toHaveBeenCalled();
+    expect(underlying.message).toMatch(/Incomplete or no credentials/);
+  });
 });

--- a/src/ops/AuthenticateOps.getTokensInteractiveAliasResolution.unit.test.ts
+++ b/src/ops/AuthenticateOps.getTokensInteractiveAliasResolution.unit.test.ts
@@ -186,4 +186,85 @@ describe('getTokensInteractive() resolves a non-URL host before use', () => {
       /No connection profile found matching/
     );
   });
+
+  test('4: a saved profile\'s deploymentType is used when the invocation supplies none — no --type needed for a known alias', async () => {
+    const saveState = StateImpl({ host });
+    saveState.setConnectionProfilesPath(connectionProfilesPath);
+    saveState.setMasterKeyPath(resolve(TMP_DIR, 'masterkey.key'));
+    saveState.setDeploymentType('cloud');
+    await saveConnectionProfile({ host, state: saveState });
+
+    runInteractiveAuthorizationCodeFlow.mockResolvedValueOnce({
+      access_token: fakeAccessTokenJwt('volker.scheuber@pingidentity.com'),
+      token_type: 'Bearer',
+      scope: 'fr:am:* fr:idm:*',
+      expires_in: 1800,
+      expires: Date.now() + 1_800_000,
+    });
+
+    // Exactly the second reported repro: `frodo login volker-dev --browser`
+    // with no --type at all — deploymentType is deliberately left unset
+    // here to prove it comes from the saved profile, not a test fixture
+    // default.
+    const invocationState = StateImpl({ host: 'volker-dev' });
+    invocationState.setConnectionProfilesPath(connectionProfilesPath);
+    invocationState.setMasterKeyPath(resolve(TMP_DIR, 'masterkey.key'));
+
+    const tokens = await getTokensInteractive({
+      state: invocationState,
+      promptHandler,
+    });
+
+    expect(runInteractiveAuthorizationCodeFlow).toHaveBeenCalledTimes(1);
+    expect(tokens.host).toBe(host);
+    expect(invocationState.getDeploymentType()).toBe('cloud');
+  });
+
+  test('5: an explicit deploymentType always wins over a saved profile\'s own value', async () => {
+    // Saved profile says 'forgeops' (a materially different flow — session
+    // capture, not OAuth2 authorization-code); the invocation explicitly
+    // says 'cloud'. Only cloud's flow is mocked below, so this only passes
+    // if the explicit value actually won and the profile's was ignored.
+    const saveState = StateImpl({ host });
+    saveState.setConnectionProfilesPath(connectionProfilesPath);
+    saveState.setMasterKeyPath(resolve(TMP_DIR, 'masterkey.key'));
+    saveState.setDeploymentType('forgeops');
+    await saveConnectionProfile({ host, state: saveState });
+
+    runInteractiveAuthorizationCodeFlow.mockResolvedValueOnce({
+      access_token: fakeAccessTokenJwt('volker.scheuber@pingidentity.com'),
+      token_type: 'Bearer',
+      scope: 'fr:am:* fr:idm:*',
+      expires_in: 1800,
+      expires: Date.now() + 1_800_000,
+    });
+
+    const invocationState = StateImpl({ host: 'volker-dev' });
+    invocationState.setConnectionProfilesPath(connectionProfilesPath);
+    invocationState.setMasterKeyPath(resolve(TMP_DIR, 'masterkey.key'));
+    invocationState.setDeploymentType('cloud');
+
+    await getTokensInteractive({ state: invocationState, promptHandler });
+
+    expect(invocationState.getDeploymentType()).toBe('cloud');
+  });
+
+  test('6: an already-full URL with no saved profile and no explicit type still fails clearly', async () => {
+    const invocationState = StateImpl({
+      host: 'https://openam-no-profile-no-type.forgeblocks.com/am',
+    });
+    invocationState.setConnectionProfilesPath(connectionProfilesPath);
+    invocationState.setMasterKeyPath(resolve(TMP_DIR, 'masterkey.key'));
+
+    let caught: any;
+    try {
+      await getTokensInteractive({ state: invocationState, promptHandler });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.originalErrors?.[0]?.message).toMatch(
+      /Browser login requires a known deployment type/
+    );
+  });
 });

--- a/src/ops/AuthenticateOps.ts
+++ b/src/ops/AuthenticateOps.ts
@@ -97,7 +97,8 @@ export type Authenticate = {
     types?: string[],
     callbackHandler?: CallbackHandler,
     useDeviceFlow?: boolean,
-    promptHandler?: BrowserLoginPromptHandler
+    promptHandler?: BrowserLoginPromptHandler,
+    credentialOverride?: 'user' | 'svcacct' | 'amster' | 'browser'
   ): Promise<Tokens>;
   /**
    * Get tokens via a real interactive browser login (loopback-redirect or
@@ -117,10 +118,12 @@ export default (state: State): Authenticate => {
       types = Constants.DEPLOYMENT_TYPES,
       callbackHandler = null,
       useDeviceFlow = false,
-      promptHandler = undefined
+      promptHandler = undefined,
+      credentialOverride = undefined
     ) {
       return getTokens({
         forceLoginAsUser,
+        credentialOverride,
         autoRefresh,
         types,
         callbackHandler,
@@ -1449,6 +1452,7 @@ async function getLoggedInSubject(state: State): Promise<string> {
  */
 function scheduleAutoRefresh(
   forceLoginAsUser: boolean,
+  credentialOverride: 'user' | 'svcacct' | 'amster' | 'browser' | undefined,
   autoRefresh: boolean,
   state: State
 ) {
@@ -1492,6 +1496,7 @@ function scheduleAutoRefresh(
     });
     timer = setTimeout(getTokens, timeout, {
       forceLoginAsUser,
+      credentialOverride,
       autoRefresh,
       state,
       // Volker's Visual Studio Code doesn't want to have it any other way.
@@ -1709,6 +1714,7 @@ export type Tokens = {
  */
 export async function getTokens({
   forceLoginAsUser = process.env.FRODO_FORCE_LOGIN_AS_USER ? true : false,
+  credentialOverride,
   autoRefresh = true,
   types = Constants.DEPLOYMENT_TYPES,
   callbackHandler = null,
@@ -1717,6 +1723,20 @@ export async function getTokens({
   state,
 }: {
   forceLoginAsUser?: boolean;
+  /**
+   * Force this one invocation to use a specific configured credential type,
+   * overriding ambient browser-session cache reuse and any saved
+   * defaultCredential/forceLoginAsUser preference (the generalized,
+   * stateless successor to forceLoginAsUser — see `--credential` on the
+   * CLI). 'browser' means "use my cached browser-login session"; if none
+   * is valid, this throws rather than falling back to a different
+   * credential or popping a fresh interactive login. Every other value
+   * means "don't even consider a cached browser session"; if the requested
+   * type isn't actually configured, this falls through to the same
+   * "Incomplete or no credentials" error any other unconfigured credential
+   * hits today.
+   */
+  credentialOverride?: 'user' | 'svcacct' | 'amster' | 'browser';
   autoRefresh?: boolean;
   types?: string[];
   callbackHandler?: CallbackHandler;
@@ -1755,6 +1775,29 @@ export async function getTokens({
         })
       );
       return tokens;
+    }
+    // credentialOverride is an absolute override, checked before even the
+    // authMode branch below: 'browser' means the caller explicitly wants
+    // the cached browser session (reused regardless of authMode, a saved
+    // defaultCredential, or anything else) and fails clearly rather than
+    // silently trying something else if none is valid — still never pops a
+    // fresh interactive login, exactly like the ambient-reuse case this
+    // generalizes. Any other credentialOverride value means the caller
+    // explicitly does NOT want a browser session this time, so this
+    // returns undefined unconditionally, skipping both branches below
+    // (including a profile's own saved `authMode: 'interactive'`) and
+    // falling straight through to the non-interactive priority chain.
+    if (credentialOverride === 'browser') {
+      const reused = await tryReuseCachedBrowserSession({ state });
+      if (reused) {
+        return withEscalation(reused);
+      }
+      throw new FrodoError(
+        `No valid cached browser-login session exists for this host. Run 'frodo login --browser' first.`
+      );
+    }
+    if (credentialOverride) {
+      return undefined;
     }
     if (state.getAuthMode() !== 'interactive') {
       // Not explicitly interactive — but an ad hoc `frodo login --browser`
@@ -1908,20 +1951,34 @@ export async function getTokens({
     // now that we have the full tenant URL we can lookup the cookie name
     state.setCookieName(await determineCookieName(state));
 
-    // An explicit defaultCredential preference skips past whatever it
-    // isn't — 'amster' or 'user' both mean "don't use the service account
-    // even though it's configured"; 'user' additionally means "don't use
+    // credentialOverride, when set, is an absolute override: it alone
+    // decides every skip flag below, ignoring defaultCredential and
+    // forceLoginAsUser entirely (an explicit per-invocation request must
+    // win over standing profile/env configuration, not merely add to it).
+    // Only when it's unset does the older, narrower logic apply: an
+    // explicit defaultCredential preference skips past whatever it isn't
+    // — 'amster' or 'user' both mean "don't use the service account even
+    // though it's configured"; 'user' additionally means "don't use
     // Amster either." 'svcacct' (or unset) changes nothing: service
     // account already wins first in the fallback order below, same as
     // always. forceLoginAsUser (the --force-login-as-user flag/env var)
     // remains its own, simpler override, equivalent to defaultCredential:
     // 'user' but without needing to persist anything to the profile.
+    // skipUser only exists for credentialOverride's sake — defaultCredential
+    // alone never needed it, since 'user' is the final, unconditional
+    // fallback below regardless.
     const defaultCredential = state.getDefaultCredential();
-    const skipServiceAccount =
-      forceLoginAsUser ||
-      defaultCredential === 'user' ||
-      defaultCredential === 'amster';
-    const skipAmster = forceLoginAsUser || defaultCredential === 'user';
+    const skipServiceAccount = credentialOverride
+      ? credentialOverride !== 'svcacct'
+      : forceLoginAsUser ||
+        defaultCredential === 'user' ||
+        defaultCredential === 'amster';
+    const skipAmster = credentialOverride
+      ? credentialOverride !== 'amster'
+      : forceLoginAsUser || defaultCredential === 'user';
+    const skipUser = credentialOverride
+      ? credentialOverride !== 'user'
+      : false;
 
     // use service account to login?
     if (
@@ -2026,7 +2083,7 @@ export async function getTokens({
       state.setActiveCredentialSource('amster');
     }
     // use user account to login?
-    else if (state.getUsername() && state.getPassword()) {
+    else if (!skipUser && state.getUsername() && state.getPassword()) {
       debugMessage({
         message: `AuthenticateOps.getTokens: Authenticating with user account ${state.getUsername()}`,
         state,
@@ -2074,7 +2131,7 @@ export async function getTokens({
       ) {
         verboseMessage({ message: `Using cached session token.`, state });
       }
-      scheduleAutoRefresh(forceLoginAsUser, autoRefresh, state);
+      scheduleAutoRefresh(forceLoginAsUser, credentialOverride, autoRefresh, state);
       // On-demand counterpart to the timer above: api/BaseApi.ts's request
       // interceptors call this when a cached token is found stale at actual
       // send time, rather than relying solely on the timer (which never
@@ -2557,22 +2614,30 @@ export async function getTokensInteractive({
 
     // Resolve an alias/unique-substring host (e.g. `frodo login myhost
     // --browser`) to its full URL the same way getTokens()'s implicit path
-    // already does — but scoped to the host only. Unlike getTokens(),
-    // getTokensInteractive() is deliberately the "always do a real
-    // interactive login, ignore what's cached/configured" entry point, so
-    // this must not also adopt the profile's other saved fields (deployment
-    // type, credential type, etc.) the way getTokens() does.
+    // already does — but scoped to non-credential fields only. Unlike
+    // getTokens(), getTokensInteractive() is deliberately the "always do a
+    // real interactive login, ignore what's cached/configured" entry point,
+    // so this must not adopt the profile's saved *credential* fields
+    // (service account, username/password, etc.) the way getTokens() does.
+    // deploymentType is not a credential, though — it's structural metadata
+    // (which OAuth2 flow to run), so resolving it here doesn't compromise
+    // that contract, and it means a saved profile's deployment type covers
+    // `login --browser <alias>` the same way it already covers every other
+    // command instead of forcing a redundant --type on the command line.
+    let conn: Awaited<ReturnType<typeof getConnectionProfile>> | undefined;
     if (!isValidUrl(state.getHost())) {
-      const conn = await getConnectionProfile({ state });
+      conn = await getConnectionProfile({ state });
       state.setHost(conn.tenant);
     }
 
-    const resolvedDeploymentType = deploymentType || state.getDeploymentType();
+    const resolvedDeploymentType =
+      deploymentType || state.getDeploymentType() || conn?.deploymentType;
     if (!resolvedDeploymentType) {
       throw new FrodoError(
-        `Browser login requires a known deployment type. Call state.setDeploymentType() first.`
+        `Browser login requires a known deployment type: pass --type, or save a connection profile for this host with a deployment type set.`
       );
     }
+    state.setDeploymentType(resolvedDeploymentType);
 
     let token: AccessTokenMetaType;
     // The real username already resolved during token application, if any


### PR DESCRIPTION
Three fixes/additions, found via live testing against a real cloud tenant:

1. getTokensInteractive() now resolves deploymentType from a saved connection profile (alias/substring host only), same as every other command already does for the host itself. Fixes `frodo login --browser <alias>` requiring a redundant --type when the profile already has one saved. deploymentType is structural metadata, not a credential, so this doesn't compromise the "always do a real interactive login, ignore cached credentials" contract that applies to genuine credential fields.

2. generateAmAuthApi() (server-info/session/auth-endpoint calls) built its credential header once, synchronously, at construction time, checking only a plain session cookie or a bearer-token flag — it never knew about state.getAmCredentialProvider(), the on-demand RFC 8693 exchange mechanism cloud browser-login relies on exclusively. So `frodo info <host>` right after a successful `frodo login --browser` sent a request with no credential at all, 403ing with "No session for request". Fixed with a dedicated resolveAmAuthRequestCredential() resolver — deliberately not the sibling resolveAmRequestCredential() used by generateAmApi(), whose staleness-check/refresh behavior is correct for ordinary post-login calls but broke a real classic-login-flow test when first tried here (a session cookie set moments ago by a live-recorded fixture step looked "expired" purely from wall-clock replay drift, since this generator's call sites include the login flow itself).

3. New credentialOverride parameter on getTokens() ('user' | 'svcacct' | 'amster' | 'browser'): an absolute, per-invocation override that wins over both ambient browser-session cache reuse and any saved defaultCredential/forceLoginAsUser preference. 'browser' means "reuse my cached browser-login session, fail clearly if none is valid" — never triggers a fresh interactive login itself. Exposed on the CLI as `--credential <type>`/FRODO_CREDENTIAL, generalizing --force-login-as-user (which only ever forced 'user').

Verified live against a real cloud tenant for all three. Full suite: 149/149 suites, 2358 tests, no regressions.


Claude-Session: https://claude.ai/code/session_01LELpRLKxwcMLpQ1uMxWxc3